### PR TITLE
CRL-1598 removed incorrect stanza

### DIFF
--- a/package/metadata/default.meta
+++ b/package/metadata/default.meta
@@ -21,7 +21,3 @@ access = read : [ * ], write : [ * ]
 [postprocess]
 access = read : [ * ], write : [ * ]
 
-
-## Exclude export of custom alert actions
-[alert_actions/email]
-export = none%


### PR DESCRIPTION
seems like this was there incorrectly, in the above stanza we make everything available to the system. Under 
```
## shared Application-level permissions
[]
access = read : [ * ], write : [ admin ]
export = system
```