### PR TITLE
[TR-213] basic risk tagging check in validate_ssa.py

### DIFF
--- a/bin/validate.py
+++ b/bin/validate.py
@@ -88,6 +88,7 @@ def validate_objects(REPO_PATH, objects):
     return errors
 
 
+# todo refactor this so that logic can be independent of uuids for use in validate_ssa.py
 def validate_standard_fields(object, uuids):
 
     errors = []

--- a/bin/validate_ssa.py
+++ b/bin/validate_ssa.py
@@ -94,6 +94,28 @@ def activate_detection(detection, data, pass_condition):
         parsed_detection = yaml.safe_load(fh)
         # Returns pipeline only for SSA detections
         if parsed_detection['type'] == "SSA":
+
+            # validate tags before we run any tests
+            # todo add full tag validation via validate_standard_fields from validate.py and move this code block
+            # todo into a common file used by both validate.py and validate_ssa.py
+            if 'tags' in parsed_detection:
+                for k, v in parsed_detection['tags'].items():
+
+                    if k == 'risk_score':
+                        if not isinstance(v, int):
+                            log(logging.ERROR, "ERROR: risk_score not integer value for object: %s" % v)
+                    risk_object_type = ["user", "system", "other"]
+
+                    if k == 'risk_object_type':
+                        if v not in risk_object_type:
+                            log(logging.ERROR, "ERROR: risk_object_type can only contain user, system, other: %s" % v)
+
+                    if k == 'risk_object':
+                        try:
+                            v.encode('ascii')
+                        except UnicodeEncodeError:
+                            log(logging.ERROR, "ERROR: risk_object not ascii for object: %s" % v)
+
             pipeline = extract_pipeline(parsed_detection['search'], data, pass_condition)
             return pipeline
         else:

--- a/detections/endpoint/attempted_credential_dump_from_registry_via_reg_exe.yml
+++ b/detections/endpoint/attempted_credential_dump_from_registry_via_reg_exe.yml
@@ -34,3 +34,7 @@ tags:
   - DE.CM
   security_domain: endpoint
   asset_type: Endpoint
+  risk_score: 50
+  risk_object_type: user
+  risk_object: Processes.user
+


### PR DESCRIPTION
(WIP) add basic check for risk tagging in validate_ssa.py.  There is an error being thrown on my local without the tag checking logic enabled and after updating to the latest jdk. 

`(venv) ➜  security-content git:(TR-213-ssa_risk_tags) ✗ python3 bin/validate_ssa.py tests/endpoint/attempted_credential_dump_from_registry_via_reg_exe___ssa.test.yml
2020-10-28 02:57:07 - INFO - Testing Attempted Credential Dump From Registry via Reg exe - SSA Unit test
2020-10-28 02:57:08 - INFO - Humvee test Attempted Credential Dump From Registry via Reg exe
2020-10-28 02:57:16 - INFO - Attempted Credential Dump From Registry via Reg exe executed without issues
2020-10-28 02:57:16 - INFO - Passed tests
tests/endpoint/attempted_credential_dump_from_registry_via_reg_exe___ssa.test.yml
2020-10-28 02:57:16 - INFO - Failed tests`

