### PR TITLE
Selecting only necessary fields to avoid serialization problem on DSP

### DIFF
--- a/detections/endpoint/first_time_seen_cmd_line___ssa.yml
+++ b/detections/endpoint/first_time_seen_cmd_line___ssa.yml
@@ -16,6 +16,7 @@ search: '| from read_ssa_enriched_events()
        cmd_line=lower(ucast(map_get(input_event, "process"), "string", null))
 | where process_name="cmd.exe" AND
         match_regex(ucast(cmd_line, "string", ""), /.* \/[cC] .*/)=true
+| select cmd_line, timestamp, dest_device_id, dest_user_id
 | first_time_event cache_partitions=5 input_columns="cmd_line"
 | where first_time_cmd_line
 | eval start_time = timestamp,


### PR DESCRIPTION
Our detection is hitting this null pointer exception caused by kryoserializer issues with guava.

https://jira.splunk.com/browse/MLR-335

the workaround is to only select the fields used by the detection.