### PR TITLE
[TR-240] add analytics_story as additional annotation in savedsearche…

### DIFF
--- a/bin/generate.py
+++ b/bin/generate.py
@@ -106,7 +106,7 @@ def generate_savedsearches_conf(detections, response_tasks, baselines, deploymen
         # we are duplicating the code block above for now and just changing variable names to make future
         # changes to this data structure separate from the mappings generation
         # @todo expose the JSON data structure for newer risk type
-        annotation_keys = ['mitre_attack', 'kill_chain_phases', 'cis20', 'nist']
+        annotation_keys = ['mitre_attack', 'kill_chain_phases', 'cis20', 'nist', 'analytics_story']
         savedsearch_annotations = {}
         for key in annotation_keys:
             if key == 'mitre_attack':


### PR DESCRIPTION
After adding the 'analytics_story' tag in tags processing logic within generate.py it looks like the annotation is being picked up correctly:

action.correlationsearch.annotations = {"analytics_story": ["AWS Suspicious Provisioning Activities"], "cis20": ["CIS 1"], "mitre_attack": ["T1535"], "nist": ["ID.AM"]}
