### PR TITLE
T1490 BCDedit

### DIFF
--- a/detections/endpoint/bcdedit_failure_recovery_modification.yml
+++ b/detections/endpoint/bcdedit_failure_recovery_modification.yml
@@ -29,6 +29,5 @@ tags:
   - PR.IP
   security_domain: endpoint
   asset_type: Endpoint
-  automated_detection_testing: passed
   dataset:
-  - 
+  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1490/atomic_red_team/windows-sysmon.log

--- a/detections/endpoint/bcdedit_failure_recovery_modification.yml
+++ b/detections/endpoint/bcdedit_failure_recovery_modification.yml
@@ -1,8 +1,10 @@
 name: BCDEdit Failure Recovery Modification
-id: 
+id: null
 version: 1
 date: '2020-12-21'
-description: This search looks for flags passed to bcdedit.exe modifications to the built-in Windows error recovery boot configurations. This is typically used by ransomware to prevent recovery.
+description: This search looks for flags passed to bcdedit.exe modifications to the
+  built-in Windows error recovery boot configurations. This is typically used by ransomware
+  to prevent recovery.
 how_to_implement: You must be ingesting endpoint data that tracks process activity,
   including parent-child relationships from your endpoints to populate the Endpoint
   data model in the Processes node. Tune based on parent process names.
@@ -12,9 +14,11 @@ references:
 author: Michael Haag, Splunk
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.process_name = bcdedit.exe
-  Processes.process="*recoveryenabled*" (Processes.process="* no*") by Processes.process_name Processes.process Processes.parent_process_name
-  Processes.dest Processes.user | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `bcdedit_failure_recovery_modification_filter`'
-known_false_positives: Administrators may modify the boot configuration. 
+  Processes.process="*recoveryenabled*" (Processes.process="* no*") by Processes.process_name
+  Processes.process Processes.parent_process_name Processes.dest Processes.user |
+  `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  | `bcdedit_failure_recovery_modification_filter`'
+known_false_positives: Administrators may modify the boot configuration.
 tags:
   analytics_story:
   - Ryuk Ransomware
@@ -31,3 +35,4 @@ tags:
   asset_type: Endpoint
   dataset:
   - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1490/atomic_red_team/windows-sysmon.log
+  automated_detection_testing: passed

--- a/detections/endpoint/bcdedit_failure_recovery_modification.yml
+++ b/detections/endpoint/bcdedit_failure_recovery_modification.yml
@@ -13,7 +13,7 @@ author: Michael Haag, Splunk
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.process_name = bcdedit.exe
   Processes.process="*recoveryenabled*" (Processes.process="* no*") by Processes.process_name Processes.process Processes.parent_process_name
-  Processes.dest Processes.user | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime) | `security_content_ctime(lastTime)` | `bcdedit_failure_recovery_modification_filter`'
+  Processes.dest Processes.user | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `bcdedit_failure_recovery_modification_filter`'
 known_false_positives: Administrators may modify the boot configuration. 
 tags:
   analytics_story:

--- a/detections/endpoint/bcdedit_failure_recovery_modification.yml
+++ b/detections/endpoint/bcdedit_failure_recovery_modification.yml
@@ -1,0 +1,34 @@
+name: BCDEdit Failure Recovery Modification
+id: 
+version: 1
+date: '2020-12-21'
+description: This search looks for flags passed to bcdedit.exe modifications to the built-in Windows error recovery boot configurations. This is typically used by ransomware to prevent recovery.
+how_to_implement: You must be ingesting endpoint data that tracks process activity,
+  including parent-child relationships from your endpoints to populate the Endpoint
+  data model in the Processes node. Tune based on parent process names.
+type: ESCU
+references:
+- https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1490/T1490.md#atomic-test-4---windows---disable-windows-recovery-console-repair
+author: Michael Haag, Splunk
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where Processes.process_name = bcdedit.exe
+  Processes.process="*recoveryenabled*" (Processes.process="* no*") by Processes.process_name Processes.process Processes.parent_process_name
+  Processes.dest Processes.user | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime) | `security_content_ctime(lastTime)` | `bcdedit_failure_recovery_modification_filter`'
+known_false_positives: Administrators may modify the boot configuration. 
+tags:
+  analytics_story:
+  - Ryuk Ransomware
+  - Ransomware
+  mitre_attack_id:
+  - T1490
+  kill_chain_phases:
+  - Actions on Objectives
+  cis20:
+  - CIS 8
+  nist:
+  - PR.IP
+  security_domain: endpoint
+  asset_type: Endpoint
+  automated_detection_testing: passed
+  dataset:
+  - 

--- a/detections/endpoint/bcdedit_failure_recovery_modification.yml
+++ b/detections/endpoint/bcdedit_failure_recovery_modification.yml
@@ -1,5 +1,5 @@
 name: BCDEdit Failure Recovery Modification
-id: null
+id: 809b31d2-5462-11eb-ae93-0242ac130002
 version: 1
 date: '2020-12-21'
 description: This search looks for flags passed to bcdedit.exe modifications to the

--- a/tests/endpoint/bcdedit_failure_recovery_modification.test.yml
+++ b/tests/endpoint/bcdedit_failure_recovery_modification.test.yml
@@ -1,0 +1,12 @@
+name: BCDEdit Failure Recovery Modification
+tests:
+- name: BCDEdit Failure Recovery Modification
+  file: endpoint/bcdedit_failure_recovery_modification.yml
+  pass_condition: '| stats count | where count > 0'
+  earliest_time: '-24h'
+  latest_time: 'now'
+  attack_data:
+  - file_name: windows-sysmon.log
+    data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1018/atomic_red_team/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: xmlwineventlog

--- a/tests/endpoint/bcdedit_failure_recovery_modification.test.yml
+++ b/tests/endpoint/bcdedit_failure_recovery_modification.test.yml
@@ -7,6 +7,7 @@ tests:
   latest_time: 'now'
   attack_data:
   - file_name: windows-sysmon.log
-    data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1018/atomic_red_team/windows-sysmon.log
+    data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1490/atomic_red_team/windows-sysmon.log
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
     sourcetype: xmlwineventlog
+    update_timestamp: True


### PR DESCRIPTION
The following detection analytic identifies the use of bcdedit.exe disabling automatic Windows recovery features by modifying boot configuration data - `bcdedit.exe /set {default} bootstatuspolicy ignoreallfailures` & `bcdedit /set {default} recoveryenabled no`
This was tested with Atomic Red Team [T1490-4](https://github.com/redcanaryco/atomic-red-team/blob/8eb52117b748d378325f7719554a896e37bccec7/atomics/T1490/T1490.md#atomic-test-4---windows---disable-windows-recovery-console-repair).
