### PR TITLE
Detect Rare Executables bug with lookup

### DIFF
--- a/lookups/rare_process_allow_list_default.csv
+++ b/lookups/rare_process_allow_list_default.csv
@@ -1,4 +1,4 @@
-process,whitelist
+process,allow_list
 splunk-regmon.exe,true
 winword.exe,true
 excel.exe,true

--- a/lookups/rare_process_allow_list_local.csv
+++ b/lookups/rare_process_allow_list_local.csv
@@ -1,1 +1,1 @@
-process,whitelist
+process,allow_list


### PR DESCRIPTION
Reported via email by Fransson Pär. When we renmoved whitelist it broke the search due the lookup table headers not being updated.


