### PR TITLE
Fixed 'credential' typo in name of detection & missing filter macro

### DIFF
--- a/detections/application/multiple_okta_users_with_invalid_credentails_from_the_same_ip.yml
+++ b/detections/application/multiple_okta_users_with_invalid_credentails_from_the_same_ip.yml
@@ -1,6 +1,6 @@
-name: Multiple Okta Users With Invalid Credentails From The Same IP
+name: Multiple Okta Users With Invalid Credentials From The Same IP
 id: 19cba45f-cad3-4032-8911-0c09e0444552
-version: 2
+version: 3
 date: '2020-07-21'
 author: Rico Valdez, Splunk
 type: batch
@@ -17,7 +17,7 @@ how_to_implement: This search is specific to Okta and requires Okta logs are bei
   ingested in your Splunk deployment.
 known_false_positives: A single public IP address servicing multiple legitmate users
   may trigger this search. In addition, the threshold of 5 distinct users may be too
-  low for your needs. You may modify the included filter macro XXXXXXXXXXXXX to raise
+  low for your needs. You may modify the included filter macro `multiple_okta_users_with_invalid_credentails_from_the_same_ip_filter` to raise
   the threshold or except specific IP adresses from triggering this search.
 references: []
 tags:


### PR DESCRIPTION
Fixed a typo in the name & updated the Known False Positives.