### PR TITLE
This version can executes job with run_smoketest script.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,9 +3,11 @@ variables:
   K8S_PLAYGROUND_ROLE: k8s:v1/app-play1/namespace/threat-research/role/deployer
   DOCKER_ROLE: docker:v1/registry/prefix/threat-research
   K8_DEPLOYER_CONTAINER: docker.repo.splunkdev.net/threat-research/k8-deployer
+  SMOKETEST_RUNNER: docker.repo.splunkdev.net/threat-research/smoketest-runner
   SRCBRANCH: $CI_COMMIT_REF_NAME
 
 stages:
+  - publish_smoketest_runner
   - publish_deployer
   - smoketest_play
   - ssa-validate
@@ -32,9 +34,20 @@ publish_deployer:
     - docker build . -t ${K8_DEPLOYER_CONTAINER}:${CI_COMMIT_SHORT_SHA}
     - docker push ${K8_DEPLOYER_CONTAINER}:${CI_COMMIT_SHORT_SHA}
 
+publish_smoketest_runner:
+  stage: publish_smoketest_runner
+  image: docker.repo.splunkdev.net/ci-cd/ci-container:alpine-3.11
+  before_script:
+    - apk add --update docker
+  script:
+    - eval $(go-go vault -a ${DOCKER_ROLE})
+    - docker build bin/ssa-end-to-end-testing/smoke-test-runner -t ${SMOKETEST_RUNNER}:${CI_COMMIT_SHORT_SHA}
+    - docker push ${SMOKETEST_RUNNER}:${CI_COMMIT_SHORT_SHA}
+
 smoketest_play:
   stage: smoketest_play
   dependencies:
+    - publish_smoketest_runner
     - publish_deployer
   image: ${K8_DEPLOYER_CONTAINER}:${CI_COMMIT_SHORT_SHA}
   script:
@@ -44,3 +57,4 @@ smoketest_play:
     - ./deployer.sh
   variables:
     SCSENV: app_play1
+    SMOKETEST_RUNNER_IMAGE: ${SMOKETEST_RUNNER}:${CI_COMMIT_SHORT_SHA}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ publish_smoketest_runner:
     - apk add --update docker
   script:
     - eval $(go-go vault -a ${DOCKER_ROLE})
-    - docker build bin/ssa-end-to-end-testing/smoke-test-runner -t ${SMOKETEST_RUNNER}:${CI_COMMIT_SHORT_SHA}
+    - docker build bin/ssa-end-to-end-testing/smoke-test-runner -t ${SMOKETEST_RUNNER}:${CI_COMMIT_SHORT_SHA} --build-arg SRCBRANCH=$CI_COMMIT_REF_NAME
     - docker push ${SMOKETEST_RUNNER}:${CI_COMMIT_SHORT_SHA}
 
 smoketest_play:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,4 +44,3 @@ smoketest_play:
     - ./deployer.sh
   variables:
     SCSENV: app_play1
-#    SRCBRANCH: $CI_COMMIT_REF_NAME

--- a/bin/ssa-end-to-end-testing/k8s-deployer/Dockerfile
+++ b/bin/ssa-end-to-end-testing/k8s-deployer/Dockerfile
@@ -27,17 +27,3 @@ COPY k8s /deployer/k8s
 RUN chmod +x /deployer/k8s/deployer.sh
 
 WORKDIR /deployer/k8s
-
-#FROM docker.repo.splunkdev.net/kub/debug-tools:latest
-#
-#ARG SRCBRANCH=develop
-#ARG SCSENV=app_play1
-#ENV SRCBRANCH=${SRCBRANCH}
-#ENV SCSENV=${SCSENV}
-#
-##RUN mkdir /aws/deployer
-#
-#COPY k8s /tmp/deployer/k8s
-#
-##RUN chmod +x /tmp/deployer/k8s/deployer.sh
-#WORKDIR /tmp/deployer/k8s

--- a/bin/ssa-end-to-end-testing/k8s-deployer/k8s/components/smoketest.jsonnet
+++ b/bin/ssa-end-to-end-testing/k8s-deployer/k8s/components/smoketest.jsonnet
@@ -26,7 +26,7 @@ local job = {
               containers: [
                 {
                   name: 'ssa-smoke-test',
-                  image: params.components.smokeTestImage,
+                  image: std.extVar('SMOKETEST_RUNNER_IMAGE'),
                   imagePullPolicy: 'Always',
                   env: [
                     {
@@ -61,7 +61,7 @@ local job = {
                     },
                   },
                   command: ['/bin/bash', '-c'],
-                  args: ['cd /smoketest && ./entrypoint.sh'],
+                  args: ['./run_ssa_smoketest_helper.sh'],
                 },
               ],
             },

--- a/bin/ssa-end-to-end-testing/k8s-deployer/k8s/components/smoketest.jsonnet
+++ b/bin/ssa-end-to-end-testing/k8s-deployer/k8s/components/smoketest.jsonnet
@@ -30,8 +30,20 @@ local job = {
                   imagePullPolicy: 'Always',
                   env: [
                     {
-                        "name": 'SCBRANCH',
-                        "value": std.extVar('SCBRANCH')
+                        "name": 'SRCBRANCH',
+                        "value": std.extVar('SRCBRANCH')
+                    },
+                    {
+                        "name": 'SMOKETEST_VAULT_READ_PATH',
+                        "value": params.components.vaultReadPath
+                    },
+                    {
+                        "name": 'DSP_ENV',
+                        "value": params.components.dspEnv
+                    },
+                    {
+                        "name": 'TENANT',
+                        "value": params.components.tenant
                     },
                     {
                         "name": 'ENV',
@@ -47,9 +59,9 @@ local job = {
                         cpu: '800m',
                         memory: '750Mi'
                     },
-                    command: ['/bin/bash', '-c'],
-                    args: ['cd /smoketest && ./smoketest.sh']
                   },
+                  command: ['/bin/bash', '-c'],
+                  args: ['cd /smoketest && ./entrypoint.sh'],
                 },
               ],
             },

--- a/bin/ssa-end-to-end-testing/k8s-deployer/k8s/deployer.sh
+++ b/bin/ssa-end-to-end-testing/k8s-deployer/k8s/deployer.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-qbec --yes apply $SCSENV --vm:ext-str SCBRANCH=$SRCBRANCH --vm:ext-str CI_COMMIT_SHORT_SHA -c service-account -c smoketest --wait-timeout "1m"
+qbec --yes apply $SCSENV --vm:ext-str SRCBRANCH --vm:ext-str CI_COMMIT_SHORT_SHA -c service-account -c smoketest --wait-timeout "1m"

--- a/bin/ssa-end-to-end-testing/k8s-deployer/k8s/deployer.sh
+++ b/bin/ssa-end-to-end-testing/k8s-deployer/k8s/deployer.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-qbec --yes apply $SCSENV --vm:ext-str SRCBRANCH --vm:ext-str CI_COMMIT_SHORT_SHA -c service-account -c smoketest --wait-timeout "1m"
+qbec --yes apply $SCSENV --vm:ext-str SRCBRANCH --vm:ext-str CI_COMMIT_SHORT_SHA --vm:ext-str SMOKETEST_RUNNER_IMAGE -c service-account -c smoketest --wait-timeout "1m"

--- a/bin/ssa-end-to-end-testing/k8s-deployer/k8s/environments/smoke-test-playground.libsonnet
+++ b/bin/ssa-end-to-end-testing/k8s-deployer/k8s/environments/smoke-test-playground.libsonnet
@@ -6,6 +6,7 @@ base {
   components +: {
     smokeTestImage: 'docker-test.repo.splunkdev.net/user-icorrales/security-content-test',
     serviceAccountName: "sa-tr-playground",
+    vaultReadPath: 'scpauth-app-play1/token/threat-research-test.app-play1',
     tenant: 'research2',
     dspEnv: 'playground',
   }

--- a/bin/ssa-end-to-end-testing/k8s-deployer/k8s/environments/smoke-test-playground.libsonnet
+++ b/bin/ssa-end-to-end-testing/k8s-deployer/k8s/environments/smoke-test-playground.libsonnet
@@ -4,7 +4,6 @@ local base = import './base.libsonnet';
 
 base {
   components +: {
-    smokeTestImage: 'docker-test.repo.splunkdev.net/user-icorrales/security-content-test',
     serviceAccountName: "sa-tr-playground",
     vaultReadPath: 'scpauth-app-play1/token/threat-research-test.app-play1',
     tenant: 'research2',

--- a/bin/ssa-end-to-end-testing/k8s-deployer/k8s/environments/smoke-test-staging.libsonnet
+++ b/bin/ssa-end-to-end-testing/k8s-deployer/k8s/environments/smoke-test-staging.libsonnet
@@ -6,6 +6,7 @@ base {
   components +: {
     smokeTestImage: 'docker-test.repo.splunkdev.net/user-icorrales/security-content-test',
     serviceAccountName: "sa-tr-staging",
+    vaultReadPath: 'scpauth-stage1/token/threat-research-test.app-stage1',
     tenant: 'research',
     dspEnv: 'staging',
   }

--- a/bin/ssa-end-to-end-testing/run_ssa_smoketest_helper.sh
+++ b/bin/ssa-end-to-end-testing/run_ssa_smoketest_helper.sh
@@ -4,10 +4,6 @@ export VAULT_TOKEN=`cat /vault/.vault-token`
 
 SCLOUD_TOKEN=$(vault read  -format json $SMOKETEST_VAULT_READ_PATH tenant=$TENANT | jq -r '.data.token')
 
-git clone https://github.com/splunk/security_content.git && cd security_content && git checkout $SRCBRANCH
-
-cd bin/ssa-end-to-end-testing
-
 virtualenv -p python3 smoketest && source smoketest/bin/activate && pip3 install -r requirements.txt
 
 python run_ssa_smoketest.py -t $SCLOUD_TOKEN -e $DSP_ENV -s $TENANT -b $SRCBRANCH

--- a/bin/ssa-end-to-end-testing/smoke-test-runner/Dockerfile
+++ b/bin/ssa-end-to-end-testing/smoke-test-runner/Dockerfile
@@ -1,25 +1,18 @@
 # Base image that support pod to communicate with SCS Vault to fetch IAC token as well to support python3 pytest framework
 FROM docker.repo.splunkdev.net/ci-cd/ci-container:python-3.7-buster
 
+ARG SRCBRANCH=develop
+
 RUN mkdir smoketest && \
     /usr/local/bin/python -m pip install --upgrade pip && \
     pip install pytest && pip install requests && pip install virtualenv
 
-#RUN mkdir smoketest && \
-#    /usr/local/bin/python -m pip install --upgrade pip && \
-#    pip install pytest && pip install requests && pip install virtualenv \
-#    # Docker Engine Install
-#    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-#    apt-key fingerprint 0EBFCD88 && \
-#    add-apt-repository \
-#    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-#    $(lsb_release -cs) \
-#    stable" && \
-#    apt-get install -y docker-ce docker-ce-cli containerd.io
+RUN git clone https://github.com/splunk/security_content.git -b ${SRCBRANCH}
 
-COPY entrypoint.sh /smoketest/entrypoint.sh
-RUN chmod +x /smoketest/*
+RUN chmod +x security_content/bin/ssa-end-to-end-testing/run_ssa_smoketest_helper.sh
 
 RUN curl -L https://github.com/splunk/splunk-cloud-sdk-go/releases/download/v1.11.1/scloud_v7.1.0_linux_amd64.tar.gz | tar -xz -C /usr/bin 
 
 COPY --from=docker.repo.splunkdev.net/kub/debug-tools:latest /usr/local/bin/vault /usr/local/bin/vault
+
+WORKDIR /security_content/bin/ssa-end-to-end-testing

--- a/bin/ssa-end-to-end-testing/smoke-test-runner/Dockerfile
+++ b/bin/ssa-end-to-end-testing/smoke-test-runner/Dockerfile
@@ -1,15 +1,21 @@
 # Base image that support pod to communicate with SCS Vault to fetch IAC token as well to support python3 pytest framework
 FROM docker.repo.splunkdev.net/ci-cd/ci-container:python-3.7-buster
 
-RUN mkdir smoketest && pip install pytest && pip install requests && \
-    # Docker Engine Install
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    apt-key fingerprint 0EBFCD88 && \
-    add-apt-repository \
-    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) \
-    stable" && \
-    apt-get install -y docker-ce docker-ce-cli containerd.io
+RUN mkdir smoketest && \
+    /usr/local/bin/python -m pip install --upgrade pip && \
+    pip install pytest && pip install requests && pip install virtualenv
+
+#RUN mkdir smoketest && \
+#    /usr/local/bin/python -m pip install --upgrade pip && \
+#    pip install pytest && pip install requests && pip install virtualenv \
+#    # Docker Engine Install
+#    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+#    apt-key fingerprint 0EBFCD88 && \
+#    add-apt-repository \
+#    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+#    $(lsb_release -cs) \
+#    stable" && \
+#    apt-get install -y docker-ce docker-ce-cli containerd.io
 
 COPY entrypoint.sh /smoketest/entrypoint.sh
 RUN chmod +x /smoketest/*

--- a/bin/ssa-end-to-end-testing/smoke-test-runner/entrypoint.sh
+++ b/bin/ssa-end-to-end-testing/smoke-test-runner/entrypoint.sh
@@ -2,7 +2,7 @@
 
 export VAULT_TOKEN=`cat /vault/.vault-token`
 
-SCLOUD_TOKEN=$(vault read  -format json $SMOKETEST_VAULT_READ_PATH --tenant=$TENANT | jq -r '.data.token')
+SCLOUD_TOKEN=$(vault read  -format json $SMOKETEST_VAULT_READ_PATH tenant=$TENANT | jq -r '.data.token')
 
 git clone https://github.com/splunk/security_content.git && cd security_content && git checkout $SRCBRANCH
 
@@ -10,4 +10,4 @@ cd bin/ssa-end-to-end-testing
 
 virtualenv -p python3 smoketest && source smoketest/bin/activate && pip3 install -r requirements.txt
 
-python run_ssa_smoketest.py -t $SCLOUD_TOKEN -e $DSP_ENV -s $TENANT
+python run_ssa_smoketest.py -t $SCLOUD_TOKEN -e $DSP_ENV -s $TENANT -b $SRCBRANCH

--- a/bin/ssa-end-to-end-testing/smoke-test-runner/entrypoint.sh
+++ b/bin/ssa-end-to-end-testing/smoke-test-runner/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export VAULT_TOKEN=`cat /vault/.vault-token`
+
+SCLOUD_TOKEN=$(vault read  -format json $SMOKETEST_VAULT_READ_PATH --tenant=$TENANT | jq -r '.data.token')
+
+git clone https://github.com/splunk/security_content.git && cd security_content && git checkout $SRCBRANCH
+
+cd bin/ssa-end-to-end-testing
+
+virtualenv -p python3 smoketest && source smoketest/bin/activate && pip3 install -r requirements.txt
+
+python run_ssa_smoketest.py -t $SCLOUD_TOKEN -e $DSP_ENV -s $TENANT


### PR DESCRIPTION
- should grab the scs token
- clones and checkout the tested branch
- executes the script

vault changes

typo in smoke-test env

errors in smoke test jsonnet

fixing missing quote

change in deployer.sh

change in deployer.sh

testing a different image for the smoketest

reverting to our testing image

calling wrong entrypoint

fixing vault path

smoketest runner image working