### PR TITLE
moved mitre_attack_id from single line to two lines

### DIFF
--- a/detections/endpoint/create_service_in_suspicious_file_path.yml
+++ b/detections/endpoint/create_service_in_suspicious_file_path.yml
@@ -29,7 +29,8 @@ tags:
   kill_chain_phases:
   - Privilege Escalation
   mitre_attack_id:
-  - T1569.001, T1569.002
+  - T1569.001
+  - T1569.002
   product:
   - Splunk Enterprise
   - Splunk Enterprise Security


### PR DESCRIPTION
Fixing SSE pulls for this content.