### PR TITLE
The Haag Is Not Enough

### DIFF
--- a/detections/endpoint/services_escalate_exe.yml
+++ b/detections/endpoint/services_escalate_exe.yml
@@ -1,0 +1,49 @@
+name: Services Escalate Exe
+id: c448488c-b7ec-11eb-8253-acde48001122
+version: 1
+date: '2021-05-18'
+author: Michael Haag, Splunk
+type: batch
+datamodel:
+- Endpoint
+description: The following analytic identifies the use of `svc-exe` with Cobalt Strike. The behavior typically follows after an adversary has already gained initial access and is escalating privileges. Using `svc-exe`, a randomly named binary will be downloaded from the remote Teamserver and placed on disk within `C:\Windows\400619a.exe`. Following, the binary will be added to the registry under key `HKLM\System\CurrentControlSet\Services\400619a\` with multiple keys and values added to look like a legitimate service.
+  Upon loading, `services.exe` will spawn the randomly named binary from `\\127.0.0.1\ADMIN$\400619a.exe`. The process lineage is completed with `400619a.exe` spawning rundll32.exe, which is the default `spawnto_` value for Cobalt Strike. The `spawnto_` value is arbitrary and may be any process on disk (typically system32/syswow64 binary). The `spawnto_` process will also contain a network connection.
+  During triage, review parallel procesess and identify any additional file modifications. 
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name=services.exe
+  Processes.process_path=*admin$* by Processes.dest Processes.user Processes.parent_process Processes.process_name
+  Processes.process Processes.process_id Processes.parent_process_id
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` 
+  | `services_escalate_exe_filter`'
+how_to_implement: To successfully implement this search, you will need to ensure that
+  DNS data is populating the Network_Resolution data model.
+known_false_positives: False positives should be limited as `services.exe` should never spawn a process from `ADMIN$`. Filter as needed.
+references:
+  - https://thedfirreport.com/2021/03/29/sodinokibi-aka-revil-ransomware/
+  - https://attack.mitre.org/techniques/T1548/
+  - https://www.cobaltstrike.com/help-beacon
+tags:
+  analytic_story:
+  - Cobalt Strike
+  dataset: []
+  kill_chain_phases:
+  - Exploitation
+  - Privilege Escalation
+  mitre_attack_id:
+  - T1548
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - Processes.dest
+  - Processes.user
+  - Processes.parent_process
+  - Processes.process_name
+  - Processes.process
+  - Processes.process_id
+  - Processes.parent_process_id
+  security_domain: endpoint

--- a/detections/endpoint/services_escalate_exe.yml
+++ b/detections/endpoint/services_escalate_exe.yml
@@ -6,28 +6,37 @@ author: Michael Haag, Splunk
 type: batch
 datamodel:
 - Endpoint
-description: The following analytic identifies the use of `svc-exe` with Cobalt Strike. The behavior typically follows after an adversary has already gained initial access and is escalating privileges. Using `svc-exe`, a randomly named binary will be downloaded from the remote Teamserver and placed on disk within `C:\Windows\400619a.exe`. Following, the binary will be added to the registry under key `HKLM\System\CurrentControlSet\Services\400619a\` with multiple keys and values added to look like a legitimate service.
-  Upon loading, `services.exe` will spawn the randomly named binary from `\\127.0.0.1\ADMIN$\400619a.exe`. The process lineage is completed with `400619a.exe` spawning rundll32.exe, which is the default `spawnto_` value for Cobalt Strike. The `spawnto_` value is arbitrary and may be any process on disk (typically system32/syswow64 binary). The `spawnto_` process will also contain a network connection.
-  During triage, review parallel procesess and identify any additional file modifications. 
+description: The following analytic identifies the use of `svc-exe` with Cobalt Strike.
+  The behavior typically follows after an adversary has already gained initial access
+  and is escalating privileges. Using `svc-exe`, a randomly named binary will be downloaded
+  from the remote Teamserver and placed on disk within `C:\Windows\400619a.exe`. Following,
+  the binary will be added to the registry under key `HKLM\System\CurrentControlSet\Services\400619a\`
+  with multiple keys and values added to look like a legitimate service. Upon loading,
+  `services.exe` will spawn the randomly named binary from `\\127.0.0.1\ADMIN$\400619a.exe`.
+  The process lineage is completed with `400619a.exe` spawning rundll32.exe, which
+  is the default `spawnto_` value for Cobalt Strike. The `spawnto_` value is arbitrary
+  and may be any process on disk (typically system32/syswow64 binary). The `spawnto_`
+  process will also contain a network connection. During triage, review parallel procesess
+  and identify any additional file modifications.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name=services.exe
-  Processes.process_path=*admin$* by Processes.dest Processes.user Processes.parent_process Processes.process_name
-  Processes.process Processes.process_id Processes.parent_process_id
-  | `drop_dm_object_name(Processes)` 
-  | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` 
+  Processes.process_path=*admin$* by Processes.dest Processes.user Processes.parent_process
+  Processes.process_name Processes.process Processes.process_id Processes.parent_process_id
+  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
   | `services_escalate_exe_filter`'
 how_to_implement: To successfully implement this search, you will need to ensure that
   DNS data is populating the Network_Resolution data model.
-known_false_positives: False positives should be limited as `services.exe` should never spawn a process from `ADMIN$`. Filter as needed.
+known_false_positives: False positives should be limited as `services.exe` should
+  never spawn a process from `ADMIN$`. Filter as needed.
 references:
-  - https://thedfirreport.com/2021/03/29/sodinokibi-aka-revil-ransomware/
-  - https://attack.mitre.org/techniques/T1548/
-  - https://www.cobaltstrike.com/help-beacon
+- https://thedfirreport.com/2021/03/29/sodinokibi-aka-revil-ransomware/
+- https://attack.mitre.org/techniques/T1548/
+- https://www.cobaltstrike.com/help-beacon
 tags:
   analytic_story:
   - Cobalt Strike
-  dataset: []
+  dataset:
+  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1055/cobalt_strike/windows-sysmon.log
   kill_chain_phases:
   - Exploitation
   - Privilege Escalation
@@ -47,3 +56,4 @@ tags:
   - Processes.process_id
   - Processes.parent_process_id
   security_domain: endpoint
+  automated_detection_testing: passed

--- a/detections/experimental/endpoint/winrm_spawning_a_process.yml
+++ b/detections/experimental/endpoint/winrm_spawning_a_process.yml
@@ -1,0 +1,49 @@
+name: WinRM Spawning a Process
+id: a081836a-ba4d-11eb-8593-acde48001122
+version: 1
+date: '2021-05-21'
+author: Drew Church, Michael Haag, Splunk
+type: batch
+datamodel:
+- Endpoint
+description: The following analytic identifies suspicious processes spawning from WinRM (wsmprovhost.exe). This analytic is related to potential exploitation of CVE-2021-31166. which is a kernel-mode device driver http.sys vulnerability. Current proof of concept code will blue-screen the operating system. However, http.sys used by many different Windows processes, including WinRM. In this case, identifying suspicious process create (child processes) from `wsmprovhost.exe` is what this analytic is identifying.
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name=wsmprovhost.exe
+  Processes.process_name IN ("cmd.exe","sh.exe","bash.exe","powershell.exe","pwsh.exe","schtasks.exe","certutil.exe","whoami.exe","bitsadmin.exe","scp.exe") by Processes.dest Processes.user Processes.parent_process Processes.process_name
+  Processes.process Processes.process_id Processes.parent_process_id
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `winrm_spawning_a_process_filter`'
+how_to_implement: To successfully implement this search you need to be ingesting information
+  on process that include the name of the process responsible for the changes from
+  your endpoints into the `Endpoint` datamodel in the `Processes` node.
+known_false_positives: Unknown. Add new processes or filter as needed. It is possible system management software may spawn processes from `wsmprovhost.exe`.
+references:
+  - https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_access/win_susp_shell_spawn_from_winrm.yml
+  - https://www.zerodayinitiative.com/blog/2021/5/17/cve-2021-31166-a-wormable-code-execution-bug-in-httpsys
+  - https://github.com/0vercl0k/CVE-2021-31166/blob/main/cve-2021-31166.py
+tags:
+  analytic_story:
+  - Unusual Processes
+  dataset: []
+  kill_chain_phases:
+  - Exploitation
+  - Privilege Escalation
+  - Denial of Service
+  mitre_attack_id:
+  - T1190
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - Processes.dest
+  - Processes.user
+  - Processes.parent_process
+  - Processes.process_name
+  - Processes.process
+  - Processes.process_id
+  - Processes.parent_process_id
+  security_domain: endpoint

--- a/tests/endpoint/services_escalate_exe.test.yml
+++ b/tests/endpoint/services_escalate_exe.test.yml
@@ -1,0 +1,12 @@
+name: Services Escalate Exe Unit Test
+tests:
+- name: Services Escalate Exe
+  file: endpoint/services_escalate_exe.yml
+  pass_condition: '| stats count | where count > 0'
+  earliest_time: '-24h'
+  latest_time: 'now'
+  attack_data:
+  - file_name: windows-sysmon.log
+    data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1055/cobalt_strike/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: xmlwineventlog


### PR DESCRIPTION
## New Analytics

- Services Escalate Exe
- WinRM Spawning a Process


The following analytic (WinRM Spawning a Process) assists with identifying suspicious processes spawning from `wsmprovhost.exe` related to CVE-2021-31166. 

references:
  - https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_access/win_susp_shell_spawn_from_winrm.yml
  - https://www.zerodayinitiative.com/blog/2021/5/17/cve-2021-31166-a-wormable-code-execution-bug-in-httpsys
  - https://github.com/0vercl0k/CVE-2021-31166/blob/main/cve-2021-31166.py