### PR TITLE
Excessive taskhost process detection

### DIFF
--- a/detections/endpoint/excessive_number_of_taskhost_processes.yml
+++ b/detections/endpoint/excessive_number_of_taskhost_processes.yml
@@ -11,17 +11,17 @@ description: This detection targets behaviors observed in post exploit kits like
   to complete various actions (discovery, lateral movement, etc.).  It is extremely uncommon in the course of normal operations
   to see so many distinct taskhost and taskhostex processes running concurrently in a short time frame.
 search: '| tstats `security_content_summariesonly` values(Processes.process_id) as process_ids  min(_time) as firstTime max(_time) as lastTime
-             FROM datamodel=Endpoint.Processes
-             WHERE Processes.process_name = "taskhost.exe" OR Processes.process_name = "taskhostex.exe"
-             BY Processes.dest Processes.user Processes.process_name _time span=1h
-         | `drop_dm_object_name(Processes)`
-         | eval pid_count=mvcount(process_ids)
-         | eval taskhost_count_=if(process_name == "taskhost.exe", pid_count, 0)
-         | eval taskhostex_count_=if(process_name == "taskhostex.exe", pid_count, 0)
-         | stats sum(taskhost_count_) as taskhost_count, sum(taskhostex_count_) as taskhostex_count by _time, dest, user
-         | where taskhost_count > 10 and taskhostex_count > 10
-         | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-         | `excessive_number_of_taskhost_processes_filter`'
+  FROM datamodel=Endpoint.Processes
+  WHERE Processes.process_name = "taskhost.exe" OR Processes.process_name = "taskhostex.exe"
+  BY Processes.dest Processes.process_name _time span=1h
+| `drop_dm_object_name(Processes)`
+| eval pid_count=mvcount(process_ids)
+| eval taskhost_count_=if(process_name == "taskhost.exe", pid_count, 0)
+| eval taskhostex_count_=if(process_name == "taskhostex.exe", pid_count, 0)
+| stats sum(taskhost_count_) as taskhost_count, sum(taskhostex_count_) as taskhostex_count by _time, dest, firstTime, lastTime
+| where taskhost_count > 10 and taskhostex_count > 10
+| `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+| `excessive_number_of_taskhost_processes_filter`'
 how_to_implement: To successfully implement this search you need to be ingesting events related to
   processes on the endpoints that include the name of the process and process id into the `Endpoint` datamodel in the
   `Processes` node.

--- a/detections/endpoint/excessive_number_of_taskhost_processes.yml
+++ b/detections/endpoint/excessive_number_of_taskhost_processes.yml
@@ -6,34 +6,34 @@ author: Michael Hart
 type: batch
 datamodel:
 - Endpoint
-description: This detection targets behaviors observed in post exploit kits like Meterpreter and Koadic that are run
-  in memory.  We have observed that these tools must invoke an excessive number of taskhost.exe and taskhostex.exe processes
-  to complete various actions (discovery, lateral movement, etc.).  It is extremely uncommon in the course of normal operations
-  to see so many distinct taskhost and taskhostex processes running concurrently in a short time frame.
-search: '| tstats `security_content_summariesonly` values(Processes.process_id) as process_ids  min(_time) as firstTime max(_time) as lastTime
-  FROM datamodel=Endpoint.Processes
+description: This detection targets behaviors observed in post exploit kits like Meterpreter
+  and Koadic that are run in memory.  We have observed that these tools must invoke
+  an excessive number of taskhost.exe and taskhostex.exe processes to complete various
+  actions (discovery, lateral movement, etc.).  It is extremely uncommon in the course
+  of normal operations to see so many distinct taskhost and taskhostex processes running
+  concurrently in a short time frame.
+search: '| tstats `security_content_summariesonly` values(Processes.process_id) as
+  process_ids  min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Processes
   WHERE Processes.process_name = "taskhost.exe" OR Processes.process_name = "taskhostex.exe"
-  BY Processes.dest Processes.process_name _time span=1h
-| `drop_dm_object_name(Processes)`
-| eval pid_count=mvcount(process_ids)
-| eval taskhost_count_=if(process_name == "taskhost.exe", pid_count, 0)
-| eval taskhostex_count_=if(process_name == "taskhostex.exe", pid_count, 0)
-| stats sum(taskhost_count_) as taskhost_count, sum(taskhostex_count_) as taskhostex_count by _time, dest, firstTime, lastTime
-| where taskhost_count > 10 and taskhostex_count > 10
-| `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-| `excessive_number_of_taskhost_processes_filter`'
-how_to_implement: To successfully implement this search you need to be ingesting events related to
-  processes on the endpoints that include the name of the process and process id into the `Endpoint` datamodel in the
-  `Processes` node.
-known_false_positives: Administrators, administrative actions or certain applications may run many instances of taskhost and
-  taskhostex concurrently.  Filter as needed.
+  BY Processes.dest Processes.process_name _time span=1h | `drop_dm_object_name(Processes)`
+  | eval pid_count=mvcount(process_ids) | eval taskhost_count_=if(process_name ==
+  "taskhost.exe", pid_count, 0) | eval taskhostex_count_=if(process_name == "taskhostex.exe",
+  pid_count, 0) | stats sum(taskhost_count_) as taskhost_count, sum(taskhostex_count_)
+  as taskhostex_count by _time, dest, firstTime, lastTime | where taskhost_count >
+  10 and taskhostex_count > 10 | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  | `excessive_number_of_taskhost_processes_filter`'
+how_to_implement: To successfully implement this search you need to be ingesting events
+  related to processes on the endpoints that include the name of the process and process
+  id into the `Endpoint` datamodel in the `Processes` node.
+known_false_positives: Administrators, administrative actions or certain applications
+  may run many instances of taskhost and taskhostex concurrently.  Filter as needed.
 references:
-  - https://attack.mitre.org/software/S0250/
+- https://attack.mitre.org/software/S0250/
 tags:
   analytic_story:
   - Meterpreter
   dataset:
-  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_tools/meterpreter/taskhost_processes/excessive.taskhost.taskhostex.processes.json
+  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1059/meterpreter/taskhost_processes/logExcessiveTaskHost.log
   kill_chain_phases:
   - Exploitation
   mitre_attack_id:
@@ -49,3 +49,4 @@ tags:
   - Processes.dest
   - Processes.user
   security_domain: endpoint
+  automated_detection_testing: passed

--- a/detections/endpoint/excessive_number_of_taskhost_processes.yml
+++ b/detections/endpoint/excessive_number_of_taskhost_processes.yml
@@ -1,0 +1,51 @@
+name: Excessive number of taskhost processes
+id: f443dac2-c7cf-11eb-ab51-acde48001122
+version: 1
+date: '2021-06-07'
+author: Michael Hart
+type: batch
+datamodel:
+- Endpoint
+description: This detection targets behaviors observed in post exploit kits like Meterpreter and Koadic that are run
+  in memory.  We have observed that these tools must invoke an excessive number of taskhost.exe and taskhostex.exe processes
+  to complete various actions (discovery, lateral movement, etc.).  It is extremely uncommon in the course of normal operations
+  to see so many distinct taskhost and taskhostex processes running concurrently in a short time frame.
+search: '| tstats `security_content_summariesonly` values(Processes.process_id) as process_ids  min(_time) as firstTime max(_time) as lastTime
+             FROM datamodel=Endpoint.Processes
+             WHERE Processes.process_name = "taskhost.exe" OR Processes.process_name = "taskhostex.exe"
+             BY Processes.dest Processes.user Processes.process_name _time span=1h
+         | `drop_dm_object_name(Processes)`
+         | eval pid_count=mvcount(process_ids)
+         | eval taskhost_count_=if(process_name == "taskhost.exe", pid_count, 0)
+         | eval taskhostex_count_=if(process_name == "taskhostex.exe", pid_count, 0)
+         | stats sum(taskhost_count_) as taskhost_count, sum(taskhostex_count_) as taskhostex_count by _time, dest, user
+         | where taskhost_count > 10 and taskhostex_count > 10
+         | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+         | `excessive_number_of_taskhost_processes_filter`'
+how_to_implement: To successfully implement this search you need to be ingesting events related to
+  processes on the endpoints that include the name of the process and process id into the `Endpoint` datamodel in the
+  `Processes` node.
+known_false_positives: Administrators, administrative actions or certain applications may run many instances of taskhost and
+  taskhostex concurrently.  Filter as needed.
+references:
+  - https://attack.mitre.org/software/S0250/
+tags:
+  analytic_story:
+  - Meterpreter
+  dataset:
+  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_tools/meterpreter/taskhost_processes/excessive.taskhost.taskhostex.processes.json
+  kill_chain_phases:
+  - Exploitation
+  mitre_attack_id:
+  - T1033
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - Processes.process_id
+  - Processes.process_name
+  - Processes.dest
+  - Processes.user
+  security_domain: endpoint

--- a/stories/meterpreter.yml
+++ b/stories/meterpreter.yml
@@ -6,17 +6,17 @@ author: Michael Hart
 type: batch
 description: Meterpreter provides red teams, pen testers and threat actors interactive access to a compromised host to run commands, upload payloads, download files, and other actions.
 narrative: 'This Analytic Story supports you to detect Tactics, Techniques and Procedures (TTPs) from Meterpreter.
-Meterpreter is a Metasploit payload for remote execution that leverages DLL injection to make it extremely difficult to detect.  Since the software
-runs in memory, no new processes are created upon injection.  It also leverages encrypted communication channels.
+  Meterpreter is a Metasploit payload for remote execution that leverages DLL injection to make it extremely difficult to detect.  Since the software
+  runs in memory, no new processes are created upon injection.  It also leverages encrypted communication channels.\
 
-Meterpreter enables the operator to remotely run commands on the target machine, upload payloads, download files, dump password hashes,
-and much more.  It is difficult to determine from the forensic evidence what actions the operator performed.  Splunk Research, however, has observed
-anomalous behaviors on the compromised hosts that seem to only appear when Meterpreter is executing various commands.  With that, we have written new
-detections targeted to these detections.
+  Meterpreter enables the operator to remotely run commands on the target machine, upload payloads, download files, dump password hashes,
+  and much more.  It is difficult to determine from the forensic evidence what actions the operator performed.  Splunk Research, however, has observed
+  anomalous behaviors on the compromised hosts that seem to only appear when Meterpreter is executing various commands.  With that, we have written new
+  detections targeted to these detections.\
 
-While investigating a detection related to this analytic story, please bear in mind that the detections look for anomalies in system behavior.  It will be
-imperative to look for other signs in the endpoint and network logs for lateral movement, discovery and other actions to confirm that the host was compromised
-and a remote actor used it to progress on their objectives.'
+  While investigating a detection related to this analytic story, please bear in mind that the detections look for anomalies in system behavior.  It will be
+  imperative to look for other signs in the endpoint and network logs for lateral movement, discovery and other actions to confirm that the host was compromised
+  and a remote actor used it to progress on their objectives.'
 references:
 - https://www.offensive-security.com/metasploit-unleashed/about-meterpreter/
 - https://doubleoctopus.com/security-wiki/threats-and-tools/meterpreter/

--- a/stories/meterpreter.yml
+++ b/stories/meterpreter.yml
@@ -1,0 +1,33 @@
+name: Meterpreter
+id: d5f8e298-c85a-11eb-9fea-acde48001122
+version: 1
+date: '2021-06-08'
+author: Michael Hart
+type: batch
+description: Meterpreter provides red teams, pen testers and threat actors interactive access to a compromised host to run commands, upload payloads, download files, and other actions.
+narrative: 'This Analytic Story supports you to detect Tactics, Techniques and Procedures (TTPs) from Meterpreter.
+Meterpreter is a Metasploit payload for remote execution that leverages DLL injection to make it extremely difficult to detect.  Since the software
+runs in memory, no new processes are created upon injection.  It also leverages encrypted communication channels.
+
+Meterpreter enables the operator to remotely run commands on the target machine, upload payloads, download files, dump password hashes,
+and much more.  It is difficult to determine from the forensic evidence what actions the operator performed.  Splunk Research, however, has observed
+anomalous behaviors on the compromised hosts that seem to only appear when Meterpreter is executing various commands.  With that, we have written new
+detections targeted to these detections.
+
+While investigating a detection related to this analytic story, please bear in mind that the detections look for anomalies in system behavior.  It will be
+imperative to look for other signs in the endpoint and network logs for lateral movement, discovery and other actions to confirm that the host was compromised
+and a remote actor used it to progress on their objectives.'
+references:
+- https://www.offensive-security.com/metasploit-unleashed/about-meterpreter/
+- https://doubleoctopus.com/security-wiki/threats-and-tools/meterpreter/
+- https://www.rapid7.com/products/metasploit/
+tags:
+  analytic_story:
+  - Meterpreter
+  category:
+  - Adversary Tactics
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  usecase: Advanced Threat Detection

--- a/tests/endpoint/excessive_number_of_taskhost_processes.test.yml
+++ b/tests/endpoint/excessive_number_of_taskhost_processes.test.yml
@@ -1,0 +1,13 @@
+name: Excessive number of taskhost processes Unit Test
+tests:
+- name: Excessive number of taskhost processes
+  file: detections/endpoint/excessive_number_of_taskhost_processes.yml
+  pass_condition: '| stats count | where count > 0'
+  earliest_time: '-24h'
+  latest_time: 'now'
+  attack_data:
+    - file_name: windows-security.log
+      data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1059/meterpreter/taskhost_processes/logExcessiveTaskHost.log
+      source: WinEventLog:Security
+      sourcetype: WinEventLog
+      update_timestamp: True

--- a/tests/endpoint/excessive_number_of_taskhost_processes.test.yml
+++ b/tests/endpoint/excessive_number_of_taskhost_processes.test.yml
@@ -1,7 +1,7 @@
 name: Excessive number of taskhost processes Unit Test
 tests:
 - name: Excessive number of taskhost processes
-  file: detections/endpoint/excessive_number_of_taskhost_processes.yml
+  file: endpoint/excessive_number_of_taskhost_processes.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: '-24h'
   latest_time: 'now'


### PR DESCRIPTION
Generates an alert if there are an excessive number of taskhost processes running on a machine in an hour window.  This behavior was seen with Meterpreter.