### PR TITLE
doc_gen.py issues with pyattck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,11 @@ jobs:
             source venv/bin/activate
             python contentctl.py --path . --verbose  validate
       - run:
+          name: get cti repo for mitre context
+          command: |
+            cd security-content
+            git clone https://github.com/mitre/cti.git
+      - run:
           name: generate documentation
           command: |
             cd security-content
@@ -244,7 +249,7 @@ jobs:
           name: submit saaws package to appinspect API
           command: |
             cd security-content/bin
-            ./appinspect.sh ~/ DA-ESS_AmazonWebServices_Content-latest.tar.gz $APPINSPECT_USERNAME $APPINSPECT_PASSWORD            
+            ./appinspect.sh ~/ DA-ESS_AmazonWebServices_Content-latest.tar.gz $APPINSPECT_USERNAME $APPINSPECT_PASSWORD
       - store_artifacts:
           path: ~/report
           destination: report/
@@ -292,7 +297,7 @@ jobs:
             source venv/bin/activate
             python bin/pretty_yaml.py --path . -v
       - run:
-          name: get cti repo for mitre-maps
+          name: get cti repo for mitre context
           command: |
             cd security-content
             git clone https://github.com/mitre/cti.git

--- a/bin/doc_gen.py
+++ b/bin/doc_gen.py
@@ -6,35 +6,39 @@ import re
 from os import path, walk
 import json
 from jinja2 import Environment, FileSystemLoader
-from pyattck import Attck
 import datetime
+from stix2 import FileSystemSource
+from stix2 import Filter
 
+def get_all_techniques(projects_path):
+    path_cti = path.join(projects_path,'cti/enterprise-attack')
+    fs = FileSystemSource(path_cti)
+    all_techniques = get_techniques(fs)
+    return all_techniques
 
-
+def get_techniques(src):
+    filt = [Filter('type', '=', 'attack-pattern')]
+    return src.query(filt)
 
 def mitre_attack_object(technique, attack):
     mitre_attack = dict()
-    mitre_attack['technique_id'] = technique.id
-    mitre_attack['technique'] = technique.name
+    mitre_attack['technique_id'] = technique["external_references"][0]["external_id"]
+    mitre_attack['technique'] = technique["name"]
 
     # process tactics
     tactics = []
-    for tactic in technique.tactics:
-        tactics.append(tactic.name)
+    if 'kill_chain_phases' in technique:
+        for tactic in technique['kill_chain_phases']:
+            if tactic['kill_chain_name'] == 'mitre-attack':
+                tactic = tactic['phase_name'].replace('-', ' ')
+                tactics.append(tactic.title())
+                
     mitre_attack['tactic'] = tactics
-
     return mitre_attack
 
 def get_mitre_enrichment_new(attack, mitre_attack_id):
-    for technique in attack.enterprise.techniques:
-        apt_groups = []
-        if '.' in mitre_attack_id:
-            for subtechnique in technique.subtechniques:
-                if mitre_attack_id == subtechnique.id:
-                    mitre_attack = mitre_attack_object(subtechnique, attack)
-                    return mitre_attack
-
-        elif mitre_attack_id == technique.id:
+    for technique in attack:
+        if mitre_attack_id == technique["external_references"][0]["external_id"]:
             mitre_attack = mitre_attack_object(technique, attack)
             return mitre_attack
     return []
@@ -260,11 +264,11 @@ if __name__ == "__main__":
 
     if VERBOSE:
         print("getting mitre enrichment data from cti")
-    attack = Attck()
+    techniques = get_all_techniques(REPO_PATH)
 
     messages = []
-    sorted_detections, messages = generate_doc_detections(REPO_PATH, OUTPUT_DIR, TEMPLATE_PATH, attack, messages, VERBOSE)
-    sorted_stories, messages = generate_doc_stories(REPO_PATH, OUTPUT_DIR, TEMPLATE_PATH, attack, sorted_detections, messages, VERBOSE)
+    sorted_detections, messages = generate_doc_detections(REPO_PATH, OUTPUT_DIR, TEMPLATE_PATH, techniques, messages, VERBOSE)
+    sorted_stories, messages = generate_doc_stories(REPO_PATH, OUTPUT_DIR, TEMPLATE_PATH, techniques, sorted_detections, messages, VERBOSE)
 
     # print all the messages from generation
     for m in messages:

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ Pillow==8.2.0
 pre-commit==2.12.1
 progress==1.5
 prompt-toolkit==1.0.14
-pyattck==3.0.1
 pyfiglet==0.8.post1
 Pygments==2.9.0
 PyInquirer==1.0.3


### PR DESCRIPTION
removing pyattck and changing `doc_gen.py` to instead use the STIX CTI library like we do with generate-actor-map.py and `generate-coverage-map.py`. This should resolve CI failing issues.