### PR TITLE
Excessive number of sc.exe start as disabled calls

### DIFF
--- a/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
+++ b/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
@@ -15,7 +15,8 @@ description: This detection targets behaviors observed when threat actors have u
 search: '| tstats `security_content_summariesonly` distinct_count(Processes.process)
   as distinct_cmdlines min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Processes
   WHERE Processes.process_name = "sc.exe" AND Processes.process="*start= disabled*"
-  BY Processes.dest, Processes.user, _time span=30m | where distinct_cmdlines >= 8
+  by Processes.dest Processes.user Processes.parent_process Processes.process_name Processes.process
+  Processes.process_id Processes.parent_process_id, _time span=30m | where distinct_cmdlines >= 8
   | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
   | `excessive_number_of_service_control_start_as_disabled_filter`'
 how_to_implement: You must be ingesting data that records process activity from your
@@ -45,8 +46,12 @@ tags:
   - Splunk Cloud
   required_fields:
   - _time
-  - Processes.process_name
-  - Processes.user
+  - Processes.dest 
+  - Processes.user 
+  - Processes.parent_process 
+  - Processes.process_name 
   - Processes.process
+  - Processes.process_id 
+  - Processes.parent_process_id
   security_domain: endpoint
   automated_detection_testing: passed

--- a/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
+++ b/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
@@ -6,32 +6,30 @@ author: Michael Hart, Splunk
 type: batch
 datamodel:
 - Endpoint
-description: This detection targets behaviors observed when threat actors have used sc.exe to modify services.
-  We observed malware in a honey pot spawning numerous sc.exe processes in a short period of time, presumably to
-  impair defenses, possibly to block others from compromising the same machine.  This detection will alert when we
-  see both an excessive number of sc.exe processes launched with specific commandline arguments to disable the start
-  of certain services.
-search: '| tstats `security_content_summariesonly` distinct_count(Processes.process) as distinct_cmdlines
-                           min(_time) as firstTime max(_time) as lastTime
-            FROM datamodel=Endpoint.Processes
-            WHERE Processes.process_name = "sc.exe" AND Processes.process="*start= disabled*"
-            BY Processes.dest, Processes.user, _time span=30m
-          | where distinct_cmdlines >= 8
-          | `drop_dm_object_name(Processes)`
-          | `security_content_ctime(firstTime)`
-          | `security_content_ctime(lastTime)`
-          | `excessive_number_of_service_control_start_as_disabled_filter`'
+description: This detection targets behaviors observed when threat actors have used
+  sc.exe to modify services. We observed malware in a honey pot spawning numerous
+  sc.exe processes in a short period of time, presumably to impair defenses, possibly
+  to block others from compromising the same machine.  This detection will alert when
+  we see both an excessive number of sc.exe processes launched with specific commandline
+  arguments to disable the start of certain services.
+search: '| tstats `security_content_summariesonly` distinct_count(Processes.process)
+  as distinct_cmdlines min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Processes
+  WHERE Processes.process_name = "sc.exe" AND Processes.process="*start= disabled*"
+  BY Processes.dest, Processes.user, _time span=30m | where distinct_cmdlines >= 8
+  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  | `excessive_number_of_service_control_start_as_disabled_filter`'
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must be ingesting
   logs with both the process name and command line from your endpoints. The complete
   process name with command-line arguments are mapped to the "process" field in the
   Endpoint data model.
-known_false_positives: Legitimate programs and administrators will execute sc.exe with the start disabled flag.  It is
-  possible, but unlikely from the telemetry of normal Windows operation we observed, that sc.exe will be called more than
-  seven times in a short period of time.
+known_false_positives: Legitimate programs and administrators will execute sc.exe
+  with the start disabled flag.  It is possible, but unlikely from the telemetry of
+  normal Windows operation we observed, that sc.exe will be called more than seven
+  times in a short period of time.
 references:
-  - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create
-  - https://attack.mitre.org/techniques/T1562/001/
+- https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create
+- https://attack.mitre.org/techniques/T1562/001/
 tags:
   analytic_story:
   - Windows Defense Evasion Tactics
@@ -48,3 +46,4 @@ tags:
   required_fields:
   - _time
   security_domain: endpoint
+  automated_detection_testing: passed

--- a/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
+++ b/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
@@ -30,6 +30,8 @@ known_false_positives: Legitimate programs and administrators will execute sc.ex
   possible, but unlikely from the telemetry of normal Windows operation we observed, that sc.exe will be called more than
   seven times in a short period of time.
 references:
+  - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create
+  - https://attack.mitre.org/techniques/T1562/001/
 tags:
   analytic_story:
   - Windows Defense Evasion Tactics

--- a/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
+++ b/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
@@ -13,10 +13,10 @@ description: This detection targets behaviors observed when threat actors have u
   we see both an excessive number of sc.exe processes launched with specific commandline
   arguments to disable the start of certain services.
 search: '| tstats `security_content_summariesonly` distinct_count(Processes.process)
-  as distinct_cmdlines min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Processes
+  as distinct_cmdlines values(Processes.process_id) as process_ids min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Processes
   WHERE Processes.process_name = "sc.exe" AND Processes.process="*start= disabled*"
-  by Processes.dest Processes.user Processes.parent_process Processes.process_name Processes.process
-  Processes.process_id Processes.parent_process_id, _time span=30m | where distinct_cmdlines >= 8
+  by Processes.dest Processes.user Processes.parent_process Processes.process_name Processes.parent_process_id,
+  _time span=30m | where distinct_cmdlines >= 8
   | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
   | `excessive_number_of_service_control_start_as_disabled_filter`'
 how_to_implement: You must be ingesting data that records process activity from your

--- a/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
+++ b/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
@@ -1,0 +1,48 @@
+name: Excessive number of service control start as disabled
+id: 77592bec-d5cc-11eb-9e60-acde48001122
+version: 1
+date: '2021-06-25'
+author: Michael Hart, Splunk
+type: batch
+datamodel:
+- Endpoint
+description: This detection targets behaviors observed when threat actors have used sc.exe to modify services.
+  We observed malware in a honey pot spawning numerous sc.exe processes in a short period of time, presumably to
+  impair defenses, possibly to block others from compromising the same machine.  This detection will alert when we
+  see both an excessive number of sc.exe processes launched with specific commandline arguments to disable the start
+  of certain services.
+search: '| tstats `security_content_summariesonly` distinct_count(Processes.process) as distinct_cmdlines
+                           min(_time) as firstTime max(_time) as lastTime
+            FROM datamodel=Endpoint.Processes
+            WHERE Processes.process_name = "sc.exe" AND Processes.process="*start= disabled*"
+            BY Processes.dest, Processes.user, _time span=30m
+          | where distinct_cmdlines >= 8
+          | `drop_dm_object_name(Processes)`
+          | `security_content_ctime(firstTime)`
+          | `security_content_ctime(lastTime)`
+          | `excessive_number_of_service_control_start_as_disabled_filter`'
+how_to_implement: You must be ingesting data that records process activity from your
+  hosts to populate the Endpoint data model in the Processes node. You must be ingesting
+  logs with both the process name and command line from your endpoints. The complete
+  process name with command-line arguments are mapped to the "process" field in the
+  Endpoint data model.
+known_false_positives: Legitimate programs and administrators will execute sc.exe with the start disabled flag.  It is
+  possible, but unlikely from the telemetry of normal Windows operation we observed, that sc.exe will be called more than
+  seven times in a short period of time.
+references:
+tags:
+  analytic_story:
+  - Windows Defense Evasion Tactics
+  dataset:
+  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1562.001/sc_service_start_disabled/windows-sysmon.log
+  kill_chain_phases:
+  - Exploitation
+  mitre_attack_id:
+  - T1562.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  security_domain: endpoint

--- a/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
+++ b/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
@@ -47,5 +47,6 @@ tags:
   - _time
   - Processes.process_name
   - Processes.user
+  - Processes.process
   security_domain: endpoint
   automated_detection_testing: passed

--- a/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
+++ b/detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
@@ -45,5 +45,7 @@ tags:
   - Splunk Cloud
   required_fields:
   - _time
+  - Processes.process_name
+  - Processes.user
   security_domain: endpoint
   automated_detection_testing: passed

--- a/tests/endpoint/excessive_number_of_service_control_start_as_disabled.test.yml
+++ b/tests/endpoint/excessive_number_of_service_control_start_as_disabled.test.yml
@@ -1,7 +1,7 @@
 name: Excessive number of service control start as disabled Unit Test
 tests:
 - name: Excessive number of service control start as disabled
-  file: detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
+  file: endpoint/excessive_number_of_service_control_start_as_disabled.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: '-24h'
   latest_time: 'now'

--- a/tests/endpoint/excessive_number_of_service_control_start_as_disabled.test.yml
+++ b/tests/endpoint/excessive_number_of_service_control_start_as_disabled.test.yml
@@ -1,0 +1,13 @@
+name: Excessive number of service control start as disabled Unit Test
+tests:
+- name: Excessive number of service control start as disabled
+  file: detections/endpoint/excessive_number_of_service_control_start_as_disabled.yml
+  pass_condition: '| stats count | where count > 0'
+  earliest_time: '-24h'
+  latest_time: 'now'
+  attack_data:
+  - file_name: windows-sysmon.log
+    data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1562.001/sc_service_start_disabled/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: xmlwineventlog
+    update_timestamp: True


### PR DESCRIPTION
This detection is based on observations from honey pot activity where a malware spawned an excessive number of sc.exe processes in a short time that disabled services using the start= disabled command line flags.