### PR TITLE
Validate.py - Risk Score error fix

### DIFF
--- a/bin/validate.py
+++ b/bin/validate.py
@@ -176,7 +176,7 @@ def validate_standard_fields(object, uuids):
         if 'impact' in object['tags'] and 'confidence' in object['tags']:
             calculated_risk_score = int(((object['tags']['impact'])*(object['tags']['confidence']))/100)
             if calculated_risk_score != object['tags']['risk_score']:
-                errors.append("ERROR: risk_score not calulated correctly and it should be set as: %s" % calculated_risk_score)
+                errors.append("ERROR: risk_score not calulated correctly and it should be set to %s for " % calculated_risk_score + object['name'])
 
     return errors, uuids
 


### PR DESCRIPTION
Modified validate to share a bit more info on the score that was incorrect.

Changed:
![image](https://user-images.githubusercontent.com/5632822/125793320-2eca6241-f53c-4bd0-a9c0-8fca6dc4e645.png)

to:
![image](https://user-images.githubusercontent.com/5632822/125793361-b2bf74aa-2221-4235-94b2-941cf20cfa35.png)

Provides further context of what analytic is failing.