### PR TITLE
Filter PTR requests to optimize deviation calculation and remove them from result.

### DIFF
--- a/detections/network/dns_query_length_with_high_standard_deviation.yml
+++ b/detections/network/dns_query_length_with_high_standard_deviation.yml
@@ -10,7 +10,7 @@ description: This search allows you to identify DNS requests and compute the sta
   deviation on the length of the names being resolved, then filter on two times the
   standard deviation to show you those queries that are unusually large for your environment.
 search: '| tstats `security_content_summariesonly` count from datamodel=Network_Resolution
-  by DNS.query |  `drop_dm_object_name("DNS")` | eval query_length = len(query) |
+  where NOT DNS.message_type IN("Pointer","PTR") by DNS.query | `drop_dm_object_name("DNS")` | eval query_length = len(query) |
   table query query_length record_type count | eventstats stdev(query_length) AS stdev
   avg(query_length) AS avg p50(query_length) AS p50| where query_length>(avg+stdev*2)
   | eval z_score=(query_length-avg)/stdev | `dns_query_length_with_high_standard_deviation_filter` '


### PR DESCRIPTION
As I know PTR requests can not be used for data exfiltration so having them in search result is just a false positive. 
Also they have effect on deviation calculation and lead to a lot of false positive in result, specially when PTR requests in the environment is about 20% or more. So I add this filter to the search 'where NOT DNS.message_type IN("Pointer","PTR")'