### PR TITLE
Filter PTR requests to optimize deviation calculation and remove them from result.

### DIFF
--- a/detections/network/dns_query_length_with_high_standard_deviation.yml
+++ b/detections/network/dns_query_length_with_high_standard_deviation.yml
@@ -10,10 +10,11 @@ description: This search allows you to identify DNS requests and compute the sta
   deviation on the length of the names being resolved, then filter on two times the
   standard deviation to show you those queries that are unusually large for your environment.
 search: '| tstats `security_content_summariesonly` count from datamodel=Network_Resolution
-  where NOT DNS.message_type IN("Pointer","PTR") by DNS.query | `drop_dm_object_name("DNS")` | eval query_length = len(query) |
-  table query query_length record_type count | eventstats stdev(query_length) AS stdev
-  avg(query_length) AS avg p50(query_length) AS p50| where query_length>(avg+stdev*2)
-  | eval z_score=(query_length-avg)/stdev | `dns_query_length_with_high_standard_deviation_filter` '
+  where NOT DNS.message_type IN("Pointer","PTR") by DNS.query | `drop_dm_object_name("DNS")`
+  | eval query_length = len(query) | table query query_length record_type count |
+  eventstats stdev(query_length) AS stdev avg(query_length) AS avg p50(query_length)
+  AS p50| where query_length>(avg+stdev*2) | eval z_score=(query_length-avg)/stdev
+  | `dns_query_length_with_high_standard_deviation_filter` '
 how_to_implement: To successfully implement this search, you will need to ensure that
   DNS data is populating the Network_Resolution data model.
 known_false_positives: It's possible there can be long domain names that are legitimate.
@@ -63,4 +64,3 @@ tags:
   - DNS.query
   risk_score: 56
   security_domain: network
-  

--- a/detections/network/dns_query_length_with_high_standard_deviation.yml
+++ b/detections/network/dns_query_length_with_high_standard_deviation.yml
@@ -1,7 +1,7 @@
 name: DNS Query Length With High Standard Deviation
 id: 1a67f15a-f4ff-4170-84e9-08cf6f75d6f5
 version: 3
-date: '2021-01-18'
+date: '2021-07-21'
 author: Bhavin Patel, Splunk
 type: batch
 datamodel:
@@ -10,7 +10,7 @@ description: This search allows you to identify DNS requests and compute the sta
   deviation on the length of the names being resolved, then filter on two times the
   standard deviation to show you those queries that are unusually large for your environment.
 search: '| tstats `security_content_summariesonly` count from datamodel=Network_Resolution
-  by DNS.query |  `drop_dm_object_name("DNS")` | eval query_length = len(query) |
+  where NOT DNS.message_type IN("Pointer","PTR") by DNS.query | `drop_dm_object_name("DNS")` | eval query_length = len(query) |
   table query query_length record_type count | eventstats stdev(query_length) AS stdev
   avg(query_length) AS avg p50(query_length) AS p50| where query_length>(avg+stdev*2)
   | eval z_score=(query_length-avg)/stdev | `dns_query_length_with_high_standard_deviation_filter` '
@@ -63,3 +63,4 @@ tags:
   - DNS.query
   risk_score: 56
   security_domain: network
+  


### PR DESCRIPTION
As I know PTR requests can not be used for data exfiltration so having them in search result is just a false positive.
Also they have effect on deviation calculation and lead to a lot of false positive in result, specially when PTR requests in the environment is about 20% or more. So I add this filter to the search 'where NOT DNS.message_type IN("Pointer","PTR")'