### PR TITLE
Fixed to use the PROTECTED_BRANCH_PUSH_TOKEN to push to repo.  Added …

### DIFF
--- a/.github/workflows/build-and-validate.yml
+++ b/.github/workflows/build-and-validate.yml
@@ -393,6 +393,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.PROTECTED_BRANCH_PUSH_TOKEN }}
           ref: 'develop'
       
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Fixed to use the PROTECTED_BRANCH_PUSH_TOKEN to push to repo.  Added token to repo.
This will allow us to push to develop from within an action. However, we still need to have the tag pointing at the correct thing.