### PR TITLE
Enhance specificity of cybersecurity terminology and references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 Welcome to the Splunk Security Content
 
-This project gives you access to our repository of Analytic Stories, security guides that provide background on TTPs, mapped to the MITRE framework, the Lockheed Martin Kill Chain, and CIS controls. They include Splunk searches, machine-learning algorithms, and Splunk Phantom playbooks (where available)—all designed to work together to detect, investigate, and respond to threats.
+This project gives you access to our repository of Analytic Stories, security guides that provide background on tactics, techniques and procedures (TTPs), mapped to the MITRE ATT&CK Framework, the Lockheed Martin Cyber Kill Chain, and CIS Controls. They include Splunk searches, machine learning algorithms and Splunk Phantom playbooks (where available)—all designed to work together to detect, investigate, and respond to threats.
 
 # Get Content🛡
 The latest Splunk Security Content can be obtained via:


### PR DESCRIPTION
- Wrote out the full term for TTPs
- Specified that "MITRE framework" refers to the MITRE ATT&CK Framework (since this Splunk security content is more on TTPs than CAPEC)
- Specified that "Lockheed Martin Kill Chain" refers to the Lockheed Martin Cyber Kill Chain

NOTE:  It might also be useful to provide the links to the following cybersecurity references mentioned in this README file:

- MITRE ATT&CK Framework:   https://attack.mitre.org/ 
- Lockheed Martin Cyber Kill Chain:  https://www.lockheedmartin.com/en-us/capabilities/cyber/cyber-kill-chain.html 
- CIS Controls:  https://www.cisecurity.org/controls/ 