### PR TITLE
Exlude windows DNS query for finding AD services

### DIFF
--- a/detections/network/dns_query_length_with_high_standard_deviation.yml
+++ b/detections/network/dns_query_length_with_high_standard_deviation.yml
@@ -11,6 +11,7 @@ description: This search allows you to identify DNS requests and compute the sta
   standard deviation to show you those queries that are unusually large for your environment.
 search: '| tstats `security_content_summariesonly` count from datamodel=Network_Resolution
   where NOT DNS.message_type IN("Pointer","PTR") by DNS.query | `drop_dm_object_name("DNS")`
+  | eval tlds=split(query,".") | eval tld=mvindex(tlds,-1) | eval tld_len=len(tld) | search tld_len<=24
   | eval query_length = len(query) | table query query_length record_type count |
   eventstats stdev(query_length) AS stdev avg(query_length) AS avg p50(query_length)
   AS p50| where query_length>(avg+stdev*2) | eval z_score=(query_length-avg)/stdev


### PR DESCRIPTION
Windows generate a lot of DNS query for finding AD services these queries have a long TLD and made a lot of false positives, but on the Internet currently the longest TLD has 24 chars’ length, so by adding this line queries with TLD longer than 24 chars will be excluded.