### PR TITLE
Fixing lowercasing of entitiy ids, which must not be done for SSA.

### DIFF
--- a/detections/endpoint/ssa___ptt_pth_kerb_ntlm_dest_device.yml
+++ b/detections/endpoint/ssa___ptt_pth_kerb_ntlm_dest_device.yml
@@ -11,9 +11,9 @@ description: This detection identifies potential Pass the Token or Pass the Hash
   by a detination device.
 search: '| from read_ssa_enriched_events() | eval timestamp=      parse_long(ucast(map_get(input_event,
   "_time"), "string", null)), dest_user=      lower(ucast(map_get(input_event, "dest_user_primary_artifact"),
-  "string", null)), dest_user_id=   lower(ucast(map_get(input_event, "dest_user_id"),
-  "string", null)), dest_device_id=       lower(ucast(map_get(input_event, "dest_device_id"),
-  "string", null)), signature_id=   lower(ucast(map_get(input_event, "signature_id"),
+  "string", null)), dest_user_id=   ucast(map_get(input_event, "dest_user_id"),
+  "string", null), dest_device_id=       ucast(map_get(input_event, "dest_device_id"),
+  "string", null), signature_id=   lower(ucast(map_get(input_event, "signature_id"),
   "string", null)), authentication_method=  lower(ucast(map_get(input_event, "authentication_method"),
   "string", null))
 

--- a/detections/endpoint/ssa___ptt_pth_kerb_ntlm_origin_device.yml
+++ b/detections/endpoint/ssa___ptt_pth_kerb_ntlm_origin_device.yml
@@ -11,8 +11,8 @@ description: This detection identifies potential Pass the Token or Pass the Hash
   by an event-collecting device (i.e., a specific domain controller or an endpoint
   destination).
 search: '| from read_ssa_enriched_events() | eval timestamp=      parse_long(ucast(map_get(input_event,
-  "_time"), "string", null)), dest_user=      ucast(map_get(input_event, "dest_user_primary_artifact"),
-  "string", null), dest_user_id=   ucast(map_get(input_event, "dest_user_id"),
+  "_time"), "string", null)), dest_user=      lower(ucast(map_get(input_event, "dest_user_primary_artifact"),
+  "string", null)), dest_user_id=   ucast(map_get(input_event, "dest_user_id"),
   "string", null), origin_device_id=       ucast(map_get(input_event, "origin_device_id"),
   "string", null), signature_id=   lower(ucast(map_get(input_event, "signature_id"),
   "string", null)), authentication_method=  lower(ucast(map_get(input_event, "authentication_method"),

--- a/detections/endpoint/ssa___ptt_pth_kerb_ntlm_origin_device.yml
+++ b/detections/endpoint/ssa___ptt_pth_kerb_ntlm_origin_device.yml
@@ -11,10 +11,10 @@ description: This detection identifies potential Pass the Token or Pass the Hash
   by an event-collecting device (i.e., a specific domain controller or an endpoint
   destination).
 search: '| from read_ssa_enriched_events() | eval timestamp=      parse_long(ucast(map_get(input_event,
-  "_time"), "string", null)), dest_user=      lower(ucast(map_get(input_event, "dest_user_primary_artifact"),
-  "string", null)), dest_user_id=   lower(ucast(map_get(input_event, "dest_user_id"),
-  "string", null)), origin_device_id=       lower(ucast(map_get(input_event, "origin_device_id"),
-  "string", null)), signature_id=   lower(ucast(map_get(input_event, "signature_id"),
+  "_time"), "string", null)), dest_user=      ucast(map_get(input_event, "dest_user_primary_artifact"),
+  "string", null), dest_user_id=   ucast(map_get(input_event, "dest_user_id"),
+  "string", null), origin_device_id=       ucast(map_get(input_event, "origin_device_id"),
+  "string", null), signature_id=   lower(ucast(map_get(input_event, "signature_id"),
   "string", null)), authentication_method=  lower(ucast(map_get(input_event, "authentication_method"),
   "string", null))
 


### PR DESCRIPTION
Fix for lowercasing of entity IDs which should not be done in SSA