### PR TITLE
Update aws_iam_accessdenied_discovery_events.yml

### DIFF
--- a/detections/cloud/aws_iam_accessdenied_discovery_events.yml
+++ b/detections/cloud/aws_iam_accessdenied_discovery_events.yml
@@ -11,7 +11,7 @@ description: The following detection identifies excessive AccessDenied events wi
   is not available with the key stolen therefore these events will be generated.
 search: '`cloudtrail` (errorCode = "AccessDenied") user_type=IAMUser (userAgent!=*.amazonaws.com)
   | bucket _time span=1h | stats count as failures min(_time) as firstTime max(_time)
-  as lastTime, dc(eventName) as methods, dc(eventSource) as sources values(userIdentity.arn)
+  as lastTime, dc(eventName) as methods, dc(eventSource) as sources
   by src_ip, userIdentity.arn, _time | where failures >= 5 and methods >= 1 and sources
   >= 1 | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
   | `aws_iam_accessdenied_discovery_events_filter`'


### PR DESCRIPTION
Remove redundant "values(userIdentity.arn)" from stats command. The field is included in "by" section of stats command.