### PR TITLE
Use Latest Testing Code/Config

### DIFF
--- a/.github/workflows/detection-testing.yml
+++ b/.github/workflows/detection-testing.yml
@@ -50,6 +50,8 @@ jobs:
 
         - name: Checkout Repo
           uses: actions/checkout@v2
+          with:
+            ref: develop
         
       
 
@@ -137,6 +139,8 @@ jobs:
 
         - name: Checkout Repo
           uses: actions/checkout@v2
+          with:
+            ref: develop
         
         - name: Download artifacts
           uses: actions/download-artifact@v2
@@ -194,6 +198,8 @@ jobs:
 
         - name: Checkout Repo
           uses: actions/checkout@v2
+          with:
+            ref: develop
         
         - name: Download artifacts
           uses: actions/download-artifact@v2


### PR DESCRIPTION
Ensuring that testing code from develop
branch is always used for CI/CD.  This is
done by explicitly checking out the develop
branch to get the testing code.  We make
this change to avoid doing CI/CD tests 
using out-of-data Splunkbase Apps.
For one-off testing, a develop can
always modify this workflow file to 
NOT check out the develop branch
and include a custom test JSON.

# PR Template for new Detections

For Authors:
- [ ] Make sure that CI/CD [detection-testing and build-and-validate](https://github.com/splunk/security_content/actions) jobs passed ✔️. 

For Reviewers:
- [ ] Verify CI/CD jobs have passed without errors.
- [ ] Validate SPL logic.
- [ ] Validate tags, description, and how to implement.
- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>`
- [ ] Verify references match analytic.
- [ ] Is there an Atomic Test?