### PR TITLE
Search name check- contentctl

### DIFF
--- a/bin/contentctl_project/contentctl_core/domain/entities/baseline.py
+++ b/bin/contentctl_project/contentctl_core/domain/entities/baseline.py
@@ -34,8 +34,8 @@ class Baseline(BaseModel, SecurityContentObject):
 
     @validator('name')
     def name_max_length(cls, v):
-        if len(v) > 75:
-            raise ValueError('name is longer then 75 chars: ' + v)
+        if len(v) > 67:
+            raise ValueError('name is longer then 67 chars: ' + v)
         return v
 
     @validator('name')

--- a/bin/contentctl_project/contentctl_core/domain/entities/detection.py
+++ b/bin/contentctl_project/contentctl_core/domain/entities/detection.py
@@ -52,11 +52,11 @@ class Detection(BaseModel, SecurityContentObject):
     source: str = None
 
 
-    @validator('name')
-    def name_max_length(cls, v):
-        if len(v) > 67:
-            raise ValueError('name is longer then 67 chars: ' + v)
-        return v
+    # @validator('name')
+    # def name_max_length(cls, v, values):      
+    #     if len(v) > 67:
+    #         raise ValueError('name is longer then 67 chars: ' + v)
+    #     return v
 
     @validator('name')
     def name_invalid_chars(cls, v):
@@ -110,6 +110,14 @@ class Detection(BaseModel, SecurityContentObject):
             if any(x in values['search'] for x in ['eventtype=', 'sourcetype=', ' source=', 'index=']):
                 if not 'index=_internal' in values['search']:
                     raise ValueError('Use source macro instead of eventtype, sourcetype, source or index in detection: ' + values["name"])
+        return values
+
+    @root_validator
+    def name_max_length(cls, values):
+        # Check max length only for ESCU searches, SSA does not have that constraint
+        if 'ssa_' not in values['file_path']:
+            if len(values["name"]) > 67:
+                raise ValueError('name is longer then 67 chars: ' + values["name"])
         return values
 
 

--- a/bin/contentctl_project/contentctl_core/domain/entities/detection.py
+++ b/bin/contentctl_project/contentctl_core/domain/entities/detection.py
@@ -54,8 +54,8 @@ class Detection(BaseModel, SecurityContentObject):
 
     @validator('name')
     def name_max_length(cls, v):
-        if len(v) > 75:
-            raise ValueError('name is longer then 75 chars: ' + v)
+        if len(v) > 67:
+            raise ValueError('name is longer then 67 chars: ' + v)
         return v
 
     @validator('name')

--- a/detections/deprecated/kubernetes_azure_active_service_accounts_by_pod_namespace.yml
+++ b/detections/deprecated/kubernetes_azure_active_service_accounts_by_pod_namespace.yml
@@ -1,4 +1,4 @@
-name: Kubernetes Azure detect most active service accounts by pod namespace
+name: Kubernetes Azure active service accounts by pod namespace
 id: 55a2264a-b7f0-45e5-addd-1e5ab3415c72
 version: 1
 date: '2020-05-26'
@@ -11,7 +11,7 @@ search: '`kubernetes_azure` category=kube-audit | spath input=properties.log | s
   user.groups{}=system:serviceaccounts* OR user.username=system.anonymous OR annotations.authorization.k8s.io/decision=allow  |
   table  sourceIPs{} user.username userAgent verb responseStatus.reason responseStatus.status
   properties.pod objectRef.namespace | top sourceIPs{} user.username verb responseStatus.status
-  properties.pod objectRef.namespace |`kubernetes_azure_detect_most_active_service_accounts_by_pod_namespace_filter`'
+  properties.pod objectRef.namespace |`kubernetes_azure_active_service_accounts_by_pod_namespace_filter`'
 how_to_implement: You must install the Add-on for Microsoft Cloud Services and Configure
   Kube-Audit data diagnostics
 known_false_positives: Not all service accounts interactions are malicious. Analyst

--- a/detections/deprecated/suspicious_powershell_command_line_arguments.yml
+++ b/detections/deprecated/suspicious_powershell_command_line_arguments.yml
@@ -1,4 +1,4 @@
-name: Malicious PowerShell Process - Multiple Suspicious Command-Line Arguments
+name: Suspicious Powershell Command-Line Arguments
 id: 2cdb91d2-542c-497f-b252-be495e71f38c
 version: 6
 date: '2021-01-19'
@@ -18,7 +18,7 @@ search: '| tstats `security_content_summariesonly` count values(Processes.proces
   max(_time) as lastTime from datamodel=Endpoint.Processes where Processes.process_name=powershell.exe
   by Processes.user Processes.process_name Processes.parent_process_name Processes.dest  |
   `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)`|
-  search (process=*-EncodedCommand* OR process=*-enc*) process=*-Exec* | `malicious_powershell_process___multiple_suspicious_command_line_arguments_filter`'
+  search (process=*-EncodedCommand* OR process=*-enc*) process=*-Exec* | `suspicious_powershell_command_line_arguments_filter`'
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be
   ingesting logs with both the process name and command line from your endpoints.

--- a/detections/endpoint/excessive_distinct_processes_from_windows_temp.yml
+++ b/detections/endpoint/excessive_distinct_processes_from_windows_temp.yml
@@ -1,4 +1,4 @@
-name: Excessive number of distinct processes created in Windows Temp folder
+name: Excessive distinct processes from Windows Temp
 id: 23587b6a-c479-11eb-b671-acde48001122
 version: 2
 date: '2022-02-28'
@@ -16,7 +16,7 @@ search: '| tstats `security_content_summariesonly` values(Processes.process) as 
   max(_time) as lastTime from datamodel=Endpoint.Processes where Processes.process_path
   = "*\\Windows\\Temp\\*" by Processes.dest Processes.user  _time span=20m | where
   distinct_process_count > 37 | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` | `excessive_number_of_distinct_processes_created_in_windows_temp_folder_filter`'
+  | `security_content_ctime(lastTime)` | `excessive_distinct_processes_from_windows_temp_filter`'
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the full process path in the process field of CIM's Process data model.
   If you are using Sysmon, you must have at least version 6.0.4 of the Sysmon TA.

--- a/detections/endpoint/powershell_loading_dotnet_into_memory_via_reflection_filter.yml
+++ b/detections/endpoint/powershell_loading_dotnet_into_memory_via_reflection_filter.yml
@@ -1,4 +1,4 @@
-name: PowerShell Loading DotNET into Memory via System Reflection Assembly
+name: PowerShell Loading DotNET into Memory via Reflection
 id: 85bc3f30-ca28-11eb-bd21-acde48001122
 version: 1
 date: '2021-06-10'
@@ -22,7 +22,7 @@ description: 'The following analytic utilizes PowerShell Script Block Logging (E
 search: '`powershell` EventCode=4104 Message IN ("*[system.reflection.assembly]::load(*","*[reflection.assembly]*")
   | stats count min(_time) as firstTime max(_time) as lastTime by OpCode ComputerName
   User EventCode Message | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `powershell_loading_dotnet_into_memory_via_system_reflection_assembly_filter`'
+  | `powershell_loading_dotnet_into_memory_via_reflection_filter`'
 how_to_implement: To successfully implement this analytic, you will need to enable
   PowerShell Script Block Logging on some or all endpoints. Additional setup here
   https://docs.splunk.com/Documentation/UBA/5.0.4.1/GetDataIn/AddPowerShell#Configure_module_logging_for_PowerShell.

--- a/detections/endpoint/windows_disabled_users_failing_to_authenticate_kerberos.yml
+++ b/detections/endpoint/windows_disabled_users_failing_to_authenticate_kerberos.yml
@@ -1,19 +1,19 @@
-name: Multiple Invalid Users Failing To Authenticate From Host Using Kerberos
-id: 001266a6-9d5b-11eb-829b-acde48001122
+name: Windows Disabled Users Failing To Authenticate Kerberos
+id: 98f22d82-9d62-11eb-9fcf-acde48001122
 version: 1
 date: '2021-04-14'
 author: Mauricio Velazco, Splunk
 type: Anomaly
 datamodel: []
 description: 'The following analytic identifies one source endpoint failing to authenticate
-  with multiple invalid domain users using the Kerberos protocol. This behavior could
+  with multiple disabled domain users using the Kerberos protocol. This behavior could
   represent an adversary performing a Password Spraying attack against an Active Directory
   environment using Kerberos to obtain initial access or elevate privileges. As attackers
   progress in a breach, mistakes will be made. In certain scenarios, adversaries may
-  execute a password spraying attack using an invalid list of users. Event 4768 is
-  generated every time the Key Distribution Center issues a Kerberos Ticket Granting
-  Ticket (TGT). Failure code 0x6 stands for `client not found in Kerberos database`
-  (the attempted user is not a valid domain user).\
+  execute a password spraying attack against disabled users. Event 4768 is generated
+  every time the Key Distribution Center issues a Kerberos Ticket Granting Ticket
+  (TGT). Failure code `0x12` stands for `clients credentials have been revoked` (account
+  disabled, expired or locked out).\
 
   The detection calculates the standard deviation for each host and leverages the
   3-sigma statistical rule to identify an unusual number of users. To customize this
@@ -26,18 +26,18 @@ description: 'The following analytic identifies one source endpoint failing to a
 
   The analytics returned fields allow analysts to investigate the event further by
   providing fields like source ip and attempted user accounts.'
-search: '`wineventlog_security` EventCode=4768 Result_Code=0x6 Account_Name!="*$"
+search: '`wineventlog_security` EventCode=4768 Account_Name!="*$" Result_Code=0x12
   | bucket span=2m _time | stats dc(Account_Name) AS unique_accounts values(Account_Name)
   as tried_accounts by _time, Client_Address | eventstats avg(unique_accounts) as
   comp_avg , stdev(unique_accounts) as comp_std by Client_Address | eval upperBound=(comp_avg+comp_std*3)
   | eval isOutlier=if(unique_accounts > 10 and unique_accounts >= upperBound, 1, 0)
-  | search isOutlier=1 | `multiple_invalid_users_failing_to_authenticate_from_host_using_kerberos_filter` '
+  | search isOutlier=1 | `windows_disabled_users_failing_to_authenticate_kerberos_filter` '
 how_to_implement: To successfully implement this search, you need to be ingesting
   Domain Controller and Kerberos events. The Advanced Security Audit policy setting
   `Audit Kerberos Authentication Service` within `Account Logon` needs to be enabled.
-known_false_positives: A host failing to authenticate with multiple invalid domain
+known_false_positives: A host failing to authenticate with multiple disabled domain
   users is not a common behavior for legitimate systems. Possible false positive scenarios
-  include but are not limited to vulnerability scanners, multi-user systems and missconfigured
+  include but are not limited to vulnerability scanners, multi-user systems missconfigured
   systems.
 references:
 - https://attack.mitre.org/techniques/T1110/003/
@@ -52,7 +52,7 @@ tags:
   - Stage:Initial Access
   - Stage:Privilege Escalation
   dataset:
-  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1110.003/purplesharp_invalid_users_kerberos/windows-security.log
+  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1110.003/purplesharp_disabled_users_kerberos/windows-security.log
   impact: 70
   kill_chain_phases:
   - Exploitation

--- a/detections/endpoint/windows_invalid_users_failed_authentication_via_kerberos.yml
+++ b/detections/endpoint/windows_invalid_users_failed_authentication_via_kerberos.yml
@@ -1,19 +1,19 @@
-name: Multiple Disabled Users Failing To Authenticate From Host Using Kerberos
-id: 98f22d82-9d62-11eb-9fcf-acde48001122
+name: Windows Invalid Users Failed Authentication via Kerberos
+id: 001266a6-9d5b-11eb-829b-acde48001122
 version: 1
 date: '2021-04-14'
 author: Mauricio Velazco, Splunk
 type: Anomaly
 datamodel: []
 description: 'The following analytic identifies one source endpoint failing to authenticate
-  with multiple disabled domain users using the Kerberos protocol. This behavior could
+  with multiple invalid domain users using the Kerberos protocol. This behavior could
   represent an adversary performing a Password Spraying attack against an Active Directory
   environment using Kerberos to obtain initial access or elevate privileges. As attackers
   progress in a breach, mistakes will be made. In certain scenarios, adversaries may
-  execute a password spraying attack against disabled users. Event 4768 is generated
-  every time the Key Distribution Center issues a Kerberos Ticket Granting Ticket
-  (TGT). Failure code `0x12` stands for `clients credentials have been revoked` (account
-  disabled, expired or locked out).\
+  execute a password spraying attack using an invalid list of users. Event 4768 is
+  generated every time the Key Distribution Center issues a Kerberos Ticket Granting
+  Ticket (TGT). Failure code 0x6 stands for `client not found in Kerberos database`
+  (the attempted user is not a valid domain user).\
 
   The detection calculates the standard deviation for each host and leverages the
   3-sigma statistical rule to identify an unusual number of users. To customize this
@@ -26,18 +26,18 @@ description: 'The following analytic identifies one source endpoint failing to a
 
   The analytics returned fields allow analysts to investigate the event further by
   providing fields like source ip and attempted user accounts.'
-search: '`wineventlog_security` EventCode=4768 Account_Name!="*$" Result_Code=0x12
+search: '`wineventlog_security` EventCode=4768 Result_Code=0x6 Account_Name!="*$"
   | bucket span=2m _time | stats dc(Account_Name) AS unique_accounts values(Account_Name)
   as tried_accounts by _time, Client_Address | eventstats avg(unique_accounts) as
   comp_avg , stdev(unique_accounts) as comp_std by Client_Address | eval upperBound=(comp_avg+comp_std*3)
   | eval isOutlier=if(unique_accounts > 10 and unique_accounts >= upperBound, 1, 0)
-  | search isOutlier=1 | `multiple_disabled_users_failing_to_authenticate_from_host_using_kerberos_filter` '
+  | search isOutlier=1 | `windows_invalid_users_failed_authentication_via_kerberos_filter` '
 how_to_implement: To successfully implement this search, you need to be ingesting
   Domain Controller and Kerberos events. The Advanced Security Audit policy setting
   `Audit Kerberos Authentication Service` within `Account Logon` needs to be enabled.
-known_false_positives: A host failing to authenticate with multiple disabled domain
+known_false_positives: A host failing to authenticate with multiple invalid domain
   users is not a common behavior for legitimate systems. Possible false positive scenarios
-  include but are not limited to vulnerability scanners, multi-user systems missconfigured
+  include but are not limited to vulnerability scanners, multi-user systems and missconfigured
   systems.
 references:
 - https://attack.mitre.org/techniques/T1110/003/
@@ -52,7 +52,7 @@ tags:
   - Stage:Initial Access
   - Stage:Privilege Escalation
   dataset:
-  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1110.003/purplesharp_disabled_users_kerberos/windows-security.log
+  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1110.003/purplesharp_invalid_users_kerberos/windows-security.log
   impact: 70
   kill_chain_phases:
   - Exploitation

--- a/detections/endpoint/windows_users_authenticate_using_explicit_credentials.yml
+++ b/detections/endpoint/windows_users_authenticate_using_explicit_credentials.yml
@@ -1,4 +1,4 @@
-name: Multiple Users Attempting To Authenticate Using Explicit Credentials
+name: Windows Users Authenticate Using Explicit Credentials
 id: e61918fa-9ca4-11eb-836c-acde48001122
 version: 1
 date: '2021-04-13'
@@ -32,7 +32,7 @@ search: ' `wineventlog_security` EventCode=4648 | bucket span=2m _time | eval So
   tried_account by _time, ComputerName, Source_Account | eventstats avg(unique_accounts)
   as comp_avg , stdev(unique_accounts) as comp_std by ComputerName | eval upperBound=(comp_avg+comp_std*3)
   | eval isOutlier=if(unique_accounts > 10 and unique_accounts >= upperBound, 1, 0)
-  | search isOutlier=1 | `multiple_users_attempting_to_authenticate_using_explicit_credentials_filter` '
+  | search isOutlier=1 | `windows_users_authenticate_using_explicit_credentials_filter` '
 how_to_implement: To successfully implement this search, you need to be ingesting
   Windows Event Logs from domain controllers as well as member servers and workstations.
   The Advanced Security Audit policy setting `Audit Logon` within `Logon/Logoff` needs

--- a/detections/experimental/endpoint/ms_exchange_mailbox_replication_service_writing_active_server_pages.yml
+++ b/detections/experimental/endpoint/ms_exchange_mailbox_replication_service_writing_active_server_pages.yml
@@ -1,4 +1,4 @@
-name: Microsoft Exchange Mailbox Replication service writing Active Server Pages
+name: MS Exchange Mailbox Replication service writing Active Server Pages
 id: 985f322c-57a5-11ec-b9ac-acde48001122
 version: 1
 date: '2021-12-07'
@@ -37,7 +37,7 @@ search: '| tstats `security_content_summariesonly` count FROM datamodel=Endpoint
   Filesystem.file_create_time Filesystem.file_name Filesystem.file_path | `drop_dm_object_name(Filesystem)`
   | fields _time dest file_create_time file_name file_path process_name process_path
   process process_guid] | dedup file_create_time | table dest file_create_time, file_name,
-  file_path, process_name | `microsoft_exchange_mailbox_replication_service_writing_active_server_pages_filter`'
+  file_path, process_name | `ms_exchange_mailbox_replication_service_writing_active_server_pages_filter`'
 how_to_implement: To successfully implement this search you need to be ingesting information
   on process that include the name of the process responsible for the changes from
   your endpoints into the `Endpoint` datamodel in the `Processes` node and `Filesystem`

--- a/tests/endpoint/excessive_distinct_processes_from_windows_temp.test.yml
+++ b/tests/endpoint/excessive_distinct_processes_from_windows_temp.test.yml
@@ -1,7 +1,7 @@
-name: Excessive number of distinct processes created in Windows Temp folder Unit Test
+name: Excessive distinct processes from Windows Temp Unit Test
 tests:
-- name: Excessive number of distinct processes created in Windows Temp folder
-  file: endpoint/excessive_number_of_distinct_processes_created_in_windows_temp_folder.yml
+- name: Excessive distinct processes from Windows Temp
+  file: endpoint/excessive_distinct_processes_from_windows_temp.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: -24h
   latest_time: now

--- a/tests/endpoint/powershell_loading_dotnet_into_memory_via_reflection.test.yml
+++ b/tests/endpoint/powershell_loading_dotnet_into_memory_via_reflection.test.yml
@@ -1,7 +1,7 @@
-name: PowerShell Loading DotNET into Memory via System Reflection Assembly Unit Test
+name: PowerShell Loading DotNET into Memory via Reflection Unit Test
 tests:
-- name: PowerShell Loading DotNET into Memory via System Reflection Assembly
-  file: endpoint/powershell_loading_dotnet_into_memory_via_system_reflection_assembly.yml
+- name: PowerShell Loading DotNET into Memory via Reflection
+  file: endpoint/powershell_loading_dotnet_into_memory_via_reflection.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: -24h
   latest_time: now

--- a/tests/endpoint/windows_disabled_users_failing_to_authenticate_kerberos.test.yml
+++ b/tests/endpoint/windows_disabled_users_failing_to_authenticate_kerberos.test.yml
@@ -1,8 +1,7 @@
-name: Multiple Disabled Users Failing To Authenticate From Host Using Kerberos Unit
-  Test
+name: Windows Disabled Users Failing To Authenticate Using Kerberos Unit Test
 tests:
-- name: Multiple Disabled Users Failing To Authenticate From Host Using Kerberos
-  file: endpoint/multiple_disabled_users_failing_to_authenticate_from_host_using_kerberos.yml
+- name: Windows Disabled Users Failing To Authenticate Using Kerberos
+  file: endpoint/windows_disabled_users_failing_to_authenticate_kerberos.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: -24h
   latest_time: now

--- a/tests/endpoint/windows_invalid_users_failed_authentication_via_kerberos.test.yml
+++ b/tests/endpoint/windows_invalid_users_failed_authentication_via_kerberos.test.yml
@@ -1,8 +1,7 @@
-name: Multiple Invalid Users Failing To Authenticate From Host Using Kerberos Unit
-  Test
+name: Windows Invalid Users Failed Authentication via Kerberos Unit Test
 tests:
-- name: Multiple Invalid Users Failing To Authenticate From Host Using Kerberos
-  file: endpoint/multiple_invalid_users_failing_to_authenticate_from_host_using_kerberos.yml
+- name: Windows Invalid Users Failed Authentication via Kerberos
+  file: endpoint/windows_invalid_users_failed_authentication_via_kerberos.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: -24h
   latest_time: now

--- a/tests/endpoint/windows_users_authenticate_using_explicit_credentials.test.yml
+++ b/tests/endpoint/windows_users_authenticate_using_explicit_credentials.test.yml
@@ -1,7 +1,7 @@
-name: Multiple Users Attempting To Authenticate Using Explicit Credentials Unit Test
+name: Windows Users Authenticate Using Explicit Credentials Unit Test
 tests:
-- name: Multiple Users Attempting To Authenticate Using Explicit Credentials
-  file: endpoint/multiple_users_attempting_to_authenticate_using_explicit_credentials.yml
+- name: Windows Users Authenticate Using Explicit Credentials
+  file: endpoint/windows_users_authenticate_using_explicit_credentials.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: -24h
   latest_time: now


### PR DESCRIPTION
updated contentctl validate code for detection and baselines to check for character length for ESCU searches
Truncated all searches to have names less that 67 chars for ESCU detections only