### PR TITLE
List failed detections in cicd summary

### DIFF
--- a/bin/automated_detection_testing/ci/detection_testing_batch/summarize_json.py
+++ b/bin/automated_detection_testing/ci/detection_testing_batch/summarize_json.py
@@ -63,7 +63,7 @@ def outputResultsJSON(output_filename:str, data:list[dict], baseline:OrderedDict
         if len(fail_list) > 0:
             print("FAILURES:")
             for failed_test in fail_list:
-                print(f"\tfailed_test")
+                print(f"\t{failed_test}")
             failures_test_override = copy.deepcopy(summarization_reproduce_failure_config)
             #Force all tests to be interactive, even if they don't fail (because they failed on this test)
             failures_test_override.update({"detections_list": fail_list, "no_interactive_failure":False, "interactive": True,

--- a/bin/automated_detection_testing/ci/detection_testing_batch/summarize_json.py
+++ b/bin/automated_detection_testing/ci/detection_testing_batch/summarize_json.py
@@ -61,9 +61,12 @@ def outputResultsJSON(output_filename:str, data:list[dict], baseline:OrderedDict
         fail_list = [os.path.join("security_content/detections",x['detection_file'] ) for x in data_sorted if x['success'] == False]
 
         if len(fail_list) > 0:
-                                    
+            print("FAILURES:")
+            for failed_test in fail_list:
+                print(f"\tfailed_test")
             failures_test_override = copy.deepcopy(summarization_reproduce_failure_config)
-            failures_test_override.update({"detections_list": fail_list, "no_interactive_failure":False, 
+            #Force all tests to be interactive, even if they don't fail (because they failed on this test)
+            failures_test_override.update({"detections_list": fail_list, "no_interactive_failure":False, "interactive": True,
                                     "num_containers":1, "branch": baseline["branch"], "commit_hash":baseline["commit_hash"], 
                                     "mode":"selected", "show_splunk_app_password": True})
             with open(os.path.join(output_folder,failure_manifest_filename),"w") as failures:


### PR DESCRIPTION
Small update to CI/CD Code:
Now, in the last step of CI/CD for detection
testing, the names of failed tests are printed
before the summary is printed.  This helps
maintainers see the list of failed tests without
needing to download the summary.json
files and read through it.
This functionality is not exercised on this
branch, because no detections were changed.
However, here is a local run showing this 
behavior on a branch with failed detections.
<img width="549" alt="image" src="https://user-images.githubusercontent.com/87383215/158882251-623bb430-2832-46b4-9137-0301d94559c5.png">
