### PR TITLE
vscode files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,67 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "contentctl new_detection",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/contentctl.py",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": ["-p", ".", "new_content", "-t", "detection"]
+        },
+        {
+            "name": "contentctl validate",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/contentctl.py",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": ["-p", ".", "validate", "-pr", "ESCU"]
+        },
+        {
+            "name": "contentctl generate",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/contentctl.py",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": ["-p", ".", "generate", "-o", "dist/escu", "-pr", "detection"]
+        },
+        {
+            "name": "contentctl docgen",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/contentctl.py",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": ["-p", ".", "docgen", "-o", "docs"]
+        },
+        {
+            "name": "contentctl content_changer",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/contentctl.py",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": ["-p", "detections", "content_changer", "-cf", "fix_kill_chain", "-pr", "detection"]
+        },
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "args": [
+                "--path",
+                ".",
+                "--output",
+                "docs",
+                "-v"
+            ]
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,7 @@
             "program": "${workspaceFolder}/contentctl.py",
             "console": "integratedTerminal",
             "justMyCode": true,
-            "args": ["-p", ".", "generate", "-o", "dist/escu", "-pr", "detection"]
+            "args": ["-p", ".", "generate", "-o", "dist/escu", "-pr", "ESCU"]
         },
         {
             "name": "contentctl docgen",
@@ -47,7 +47,7 @@
             "program": "${workspaceFolder}/contentctl.py",
             "console": "integratedTerminal",
             "justMyCode": true,
-            "args": ["-p", "detections", "content_changer", "-cf", "fix_kill_chain", "-pr", "detection"]
+            "args": ["-p", "detections", "content_changer", "-cf", "fix_kill_chain"]
         },
         {
             "name": "Python: Current File",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "python.testing.pytestArgs": [
+        "bin/contentctl_project"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.terminal.activateEnvironment": true,
+    "python.envFile": "${workspaceFolder}/.env",
+    "python.testing.cwd": "${workspaceFolder}"
+}


### PR DESCRIPTION
# PR Template for new Detections

For Authors:
- [x] Make sure that CI/CD [detection-testing and build-and-validate](https://github.com/splunk/security_content/actions) jobs passed ✔️. 

For Reviewers:
- [ ] Verify CI/CD jobs have passed without errors.
- [ ] Validate SPL logic.
- [ ] Validate tags, description, and how to implement.
- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>`
- [ ] Verify references match analytic.
- [ ] Is there an Atomic Test?

# Summary
Two additions: launch.json & settings.json
launch.json contains several different configurations that can be used to "launch" contentctl.py during debugging. These include sample arguments that will allow you to set your breakpoint anywhere in the code base and launch the program with the arguments for "new_detection", "generate", etc.

settings.json - this includes a couple of small configurations that allows for using the built in Testing extension for VScode. Tests can easily be run & the status checked, in the IDE. It does require the use of an environment file as detailed in python.envFile and outlined [here in Microsoft's Docs](https://code.visualstudio.com/docs/python/environments#_use-of-the-pythonpath-variable). This allows for the proper setting of the PYTHONPATH environment variable. A sample of that file could be simply 

```PYTHONPATH=.``` 

but should reflect the path to the security_content repo.