### PR TITLE
Increased the width of research.splunk.com posts

### DIFF
--- a/docs/_layouts/single.html
+++ b/docs/_layouts/single.html
@@ -14,10 +14,10 @@ layout: default
   {% endunless %}
 {% endif %}
 
-<div id="main" role="main">
+<div id="main" role="main" style="max-width:95%">
   {% include sidebar.html %}
 
-  <article class="page h-entry" itemscope itemtype="https://schema.org/CreativeWork">
+  <article style="width:95%" class="page h-entry" itemscope itemtype="https://schema.org/CreativeWork">
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}


### PR DESCRIPTION
for all of the content.  This reduces
the extremely large whitespace
columns on the sides of all the
content and is a more efficient
use of space.

Side-by-side comparison pictures included.
Note that this does not increase the width
of the Nav Bar at the top or bottom of the
screen by design (so that it remains consistent
with the rest of the site).

Fullscreen
Before:
<img width="2554" alt="image" src="https://user-images.githubusercontent.com/87383215/161629386-992d7611-48de-4619-935f-a4a401d8d114.png">

After:
<img width="2554" alt="image" src="https://user-images.githubusercontent.com/87383215/161629257-538d7a91-dc06-409e-b13d-44fed6c1208d.png">

Half Screen Before (left) and after (right)
<img width="2554" alt="image" src="https://user-images.githubusercontent.com/87383215/161629841-72bf48b3-cc09-4d15-832c-67348723104f.png">
