### PR TITLE
MSHTA Child Process fix

### DIFF
--- a/detections/endpoint/ssa___windows_mshta_child_process.yml
+++ b/detections/endpoint/ssa___windows_mshta_child_process.yml
@@ -17,7 +17,7 @@ search: '| from read_ssa_enriched_events() | eval timestamp=parse_long(ucast(map
   null), parent_process_name=lower(ucast(map_get(input_event, "parent_process_name"), "string",
   null)), event_id=ucast(map_get(input_event, "event_id"), "string", null) | where
   cmd_line IS NOT NULL AND process_name IS NOT NULL AND parent_process_name IS NOT
-  NULL | where like(parent_process_name, "%\\\\mshta.exe") AND ( process_name="powershell.exe" OR
+  NULL | where like(parent_process_name, "%\\\\mshta.exe") AND (process_name="powershell.exe" OR
   process_name="cmd.exe" OR process_name="scrcons.exe" OR process_name="colorcpl.exe"
   OR process_name="msbuild.exe" OR process_name="microsoft.workflow.compiler.exe"
   OR process_name="searchprotocolhost.exe" OR process_name="cscript.exe"  OR process_name="wscript.exe")

--- a/detections/endpoint/ssa___windows_mshta_child_process.yml
+++ b/detections/endpoint/ssa___windows_mshta_child_process.yml
@@ -1,6 +1,6 @@
 name: Windows MSHTA Child Process
 id: f63f7e9c-9526-11ec-9fc7-acde48001122
-version: 1
+version: 2
 date: '2022-02-23'
 author: Michael Haag, Splunk
 type: TTP
@@ -14,10 +14,10 @@ search: '| from read_ssa_enriched_events() | eval timestamp=parse_long(ucast(map
   "_time"), "string", null)), cmd_line=lower(ucast(map_get(input_event, "process"),
   "string", null)), process_name=lower(ucast(map_get(input_event, "process_name"),
   "string", null)), process_path=ucast(map_get(input_event, "process_path"), "string",
-  null), parent_process_name=ucast(map_get(input_event, "parent_process_name"), "string",
-  null), event_id=ucast(map_get(input_event, "event_id"), "string", null) | where
+  null), parent_process_name=lower(ucast(map_get(input_event, "parent_process_name"), "string",
+  null)), event_id=ucast(map_get(input_event, "event_id"), "string", null) | where
   cmd_line IS NOT NULL AND process_name IS NOT NULL AND parent_process_name IS NOT
-  NULL | where parent_process_name="mshta.exe" AND ( process_name="powershell.exe" OR
+  NULL | where like(parent_process_name, "%\\\\mshta.exe") AND ( process_name="powershell.exe" OR
   process_name="cmd.exe" OR process_name="scrcons.exe" OR process_name="colorcpl.exe"
   OR process_name="msbuild.exe" OR process_name="microsoft.workflow.compiler.exe"
   OR process_name="searchprotocolhost.exe" OR process_name="cscript.exe"  OR process_name="wscript.exe")

--- a/detections/endpoint/ssa___windows_mshta_child_process.yml
+++ b/detections/endpoint/ssa___windows_mshta_child_process.yml
@@ -17,10 +17,10 @@ search: '| from read_ssa_enriched_events() | eval timestamp=parse_long(ucast(map
   null), parent_process_name=ucast(map_get(input_event, "parent_process_name"), "string",
   null), event_id=ucast(map_get(input_event, "event_id"), "string", null) | where
   cmd_line IS NOT NULL AND process_name IS NOT NULL AND parent_process_name IS NOT
-  NULL | where parent_process_name="mshta.exe" AND process_name="powershell.exe" OR
+  NULL | where parent_process_name="mshta.exe" AND ( process_name="powershell.exe" OR
   process_name="cmd.exe" OR process_name="scrcons.exe" OR process_name="colorcpl.exe"
   OR process_name="msbuild.exe" OR process_name="microsoft.workflow.compiler.exe"
-  OR process_name="searchprotocolhost.exe" OR process_name="cscript.exe"  OR process_name="wscript.exe"
+  OR process_name="searchprotocolhost.exe" OR process_name="cscript.exe"  OR process_name="wscript.exe")
   | eval start_time=timestamp, end_time=timestamp, entities=mvappend(ucast(map_get(input_event,
   "dest_user_id"), "string", null), ucast(map_get(input_event, "dest_device_id"),
   "string", null)), body=create_map(["event_id", event_id, "cmd_line", cmd_line, "process_name",


### PR DESCRIPTION
# PR Template for new Detections

For Authors:
- [ ] Make sure that CI/CD [detection-testing and build-and-validate](https://github.com/splunk/security_content/actions) jobs passed ✔️. 

For Reviewers:
- [ ] Verify CI/CD jobs have passed without errors.
- [ ] Validate SPL logic.
- [ ] Validate tags, description, and how to implement.
- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>`
- [ ] Verify references match analytic.
- [ ] Is there an Atomic Test?

# Summary:
`parent_process_name` includes a full path, using like() to match on executable from `parent_process_name`. Additionally, added parentheses to separate logic between parent process and child process matching.