### PR TITLE
Added Palo Alto TA in support of CRITICAL CVE 2022-1388 Detection

### DIFF
--- a/bin/docker_detection_tester/modules/validate_args.py
+++ b/bin/docker_detection_tester/modules/validate_args.py
@@ -77,7 +77,15 @@ setup_schema = {
                     "app_version": None,
                     "local_path": None
                 },
+
+
                 #The default apps below were taken from the attack_range loadout: https://github.com/splunk/attack_range/blob/develop/attack_range.conf.template
+
+                "PALO_ALTO_NETWORKS_ADD_ON_FOR_SPLUNK": {
+                    "app_number": 2757,
+                    "app_version": "7.1.0",
+                    "http_path": "https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/palo-alto-networks-add-on-for-splunk_710.tgz"
+                },
                 "SPLUNK_ADD_ON_FOR_MICROSOFT_WINDOWS": {
                     "app_number": 742,
                     "app_version": "8.4.0",

--- a/bin/docker_detection_tester/test_config_github_actions.json
+++ b/bin/docker_detection_tester/test_config_github_actions.json
@@ -1,5 +1,10 @@
 {
   "apps": {
+      "PALO_ALTO_NETWORKS_ADD_ON_FOR_SPLUNK": {
+          "app_number": 2757,
+          "app_version": "7.1.0",
+          "http_path": "https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/palo-alto-networks-add-on-for-splunk_710.tgz"
+      },
       "ADD_ON_FOR_LINUX_SYSMON": {
           "app_number": 6176,
           "app_version": "1.0.4",


### PR DESCRIPTION
Detection in question, which resides in the F5 branch:
[CVE 2022-1388 Detection Draft (unmerged)](https://github.com/splunk/security_content/blob/77abe7703585447de7ae9b578b3968947fd8cd0a/detections/network/f5_big_ip_icontrol_rest_vulnerability_cve_2022_1388.yml)

Has already passed detection testing locally.