### PR TITLE
Support custom indices in test files

### DIFF
--- a/bin/docker_detection_tester/modules/splunk_sdk.py
+++ b/bin/docker_detection_tester/modules/splunk_sdk.py
@@ -74,7 +74,7 @@ def get_number_of_indexed_events(splunk_host, splunk_port, splunk_password, inde
         raise(Exception("Unable to connect to Splunk instance: " + str(e)))
 
     if sourcetype is not None:
-        search = f'''search index="{index}" sourcetype="{sourcetype}" host="{event_host} | stats count'''
+        search = f'''search index="{index}" sourcetype="{sourcetype}" host="{event_host}" | stats count'''
     else:
         search = f'''search index="{index}" host="{event_host}" | stats count'''
     kwargs = {"exec_mode":"blocking"}

--- a/bin/docker_detection_tester/modules/splunk_sdk.py
+++ b/bin/docker_detection_tester/modules/splunk_sdk.py
@@ -302,7 +302,7 @@ def test_detection_search(splunk_host:str, splunk_port:int, splunk_password:str,
         return test_results
 
 
-def delete_attack_data(splunk_host:str, splunk_password:str, splunk_port:int, wait_on_delete:Union[dict,None], search_string:str, detection_filename:str, index:str=DEFAULT_DATA_INDEX, host:str=DEFAULT_EVENT_HOST)->bool:
+def delete_attack_data(splunk_host:str, splunk_password:str, splunk_port:int, wait_on_delete:Union[dict,None], search_string:str, detection_filename:str, indices:list[str]=[DEFAULT_DATA_INDEX], host:str=DEFAULT_EVENT_HOST)->bool:
     
     try:
         service = client.connect(
@@ -326,47 +326,48 @@ def delete_attack_data(splunk_host:str, splunk_password:str, splunk_port:int, wa
     data_exists = True
 
 
+    #print(f"Deleting data for {detection_filename}: {indices}")
+    for index in indices:
+        while (get_number_of_indexed_events(splunk_host, splunk_port, splunk_password, index=index, event_host=host) != 0) :
+            splunk_search = f'search index="{index}" host="{host}" | delete'
 
-    while (get_number_of_indexed_events(splunk_host, splunk_port, splunk_password, index=index, event_host=host) != 0) :
-        splunk_search = f'search index="{index}" host="{host}" | delete'
+            kwargs = {
+                    "exec_mode": "blocking",
+                    "dispatch.earliest_time": "-1d",
+                    "dispatch.latest_time": "now"}
+            try:
+                
+                job = service.jobs.create(splunk_search, **kwargs)
+                reader = results.ResultsReader(job)
 
-        kwargs = {
-                "exec_mode": "blocking",
-                "dispatch.earliest_time": "-1d",
-                "dispatch.latest_time": "now"}
-        try:
-            
-            job = service.jobs.create(splunk_search, **kwargs)
-            reader = results.ResultsReader(job)
+                
+                '''
+                error_in_results = False
+                for result in reader:
+                    if hasattr(result,"message") and hasattr(result,"type") and ("You have insufficient privileges to delete events" in result.message or result.type == "FATAL"):
+                        print("Delete is not enabled for admin: [%s] - enabling delete and trying to delete again..."%(result.message), file=sys.stderr)
+                        if already_enabled_delete is True:
+                            print("We already enabled delete, but the setting did not take effect.")
+                            raise(Exception("Enabling delete command failed to take effect"))
+                        if enable_delete_for_admin(splunk_host, splunk_port,splunk_password) != True:
+                            raise(Exception("Failure enabling delete for admin. We cannot continue"))
+                        # We enabled delete, so now we will try to delete again
+                        already_enabled_delete = True
+                        break
+                    else:
+                        #This is not one of the error messages, do nothing
+                        pass
+                '''
+                #No need to issue Delete command again, we will now break out of the loop
+                #if error_in_results is False:
+                #    data_exists = False
 
-            
-            '''
-            error_in_results = False
-            for result in reader:
-                if hasattr(result,"message") and hasattr(result,"type") and ("You have insufficient privileges to delete events" in result.message or result.type == "FATAL"):
-                    print("Delete is not enabled for admin: [%s] - enabling delete and trying to delete again..."%(result.message), file=sys.stderr)
-                    if already_enabled_delete is True:
-                        print("We already enabled delete, but the setting did not take effect.")
-                        raise(Exception("Enabling delete command failed to take effect"))
-                    if enable_delete_for_admin(splunk_host, splunk_port,splunk_password) != True:
-                        raise(Exception("Failure enabling delete for admin. We cannot continue"))
-                    # We enabled delete, so now we will try to delete again
-                    already_enabled_delete = True
-                    break
-                else:
-                    #This is not one of the error messages, do nothing
-                    pass
-            '''
-            #No need to issue Delete command again, we will now break out of the loop
-            #if error_in_results is False:
-            #    data_exists = False
+                #Otherwise, we will loop again
 
-            #Otherwise, we will loop again
-
-        except Exception as e:
-            print(f"Trouble deleting data from a run.... we will try again: {str(e)}")
-            time.sleep(5)
-            #raise(Exception("Unable to delete data from a run: " + str(e)))
+            except Exception as e:
+                print(f"Trouble deleting data from a run.... we will try again: {str(e)}")
+                time.sleep(5)
+                #raise(Exception("Unable to delete data from a run: " + str(e)))
         
     
     return True

--- a/bin/docker_detection_tester/modules/splunk_sdk.py
+++ b/bin/docker_detection_tester/modules/splunk_sdk.py
@@ -94,11 +94,13 @@ def get_number_of_indexed_events(splunk_host, splunk_port, splunk_password, inde
 
 
 def wait_for_indexing_to_complete(splunk_host, splunk_port, splunk_password, sourcetype:str, index:str, check_interval_seconds:int=10)->bool:
-    
+    MAX_WAIT_TIME = 60
     startTime = timeit.default_timer()
     previous_count = -1
     time.sleep(check_interval_seconds)
     while True:
+        if (timeit.default_timer() - startTime) > 60:
+            print("force timeout! assume we are done indexing")
         new_count = get_number_of_indexed_events(splunk_host, splunk_port, splunk_password, index=index, sourcetype=sourcetype)
         #print(f"Previous Count [{previous_count}] New Count [{new_count}]")
         if previous_count == -1:

--- a/bin/docker_detection_tester/modules/splunk_sdk.py
+++ b/bin/docker_detection_tester/modules/splunk_sdk.py
@@ -101,6 +101,7 @@ def wait_for_indexing_to_complete(splunk_host, splunk_port, splunk_password, sou
     while True:
         if (timeit.default_timer() - startTime) > 60:
             print("force timeout! assume we are done indexing")
+            break
         new_count = get_number_of_indexed_events(splunk_host, splunk_port, splunk_password, index=index, sourcetype=sourcetype)
         #print(f"Previous Count [{previous_count}] New Count [{new_count}]")
         if previous_count == -1:

--- a/bin/docker_detection_tester/modules/splunk_sdk.py
+++ b/bin/docker_detection_tester/modules/splunk_sdk.py
@@ -101,7 +101,7 @@ def wait_for_indexing_to_complete(splunk_host, splunk_port, splunk_password, sou
     while True:
         if (timeit.default_timer() - startTime) > 60:
             print("force timeout! assume we are done indexing")
-            break
+            return True
         new_count = get_number_of_indexed_events(splunk_host, splunk_port, splunk_password, index=index, sourcetype=sourcetype)
         #print(f"Previous Count [{previous_count}] New Count [{new_count}]")
         if previous_count == -1:

--- a/bin/docker_detection_tester/modules/testing_service.py
+++ b/bin/docker_detection_tester/modules/testing_service.py
@@ -48,9 +48,8 @@ def test_detection_wrapper(container_name:str, splunk_ip:str, splunk_password:st
     else:
         wait_on_delete = None
 
-    for index_to_delete in indices_to_delete:
-        print(f"Deleting index data for {test_file}: {index_to_delete}")
-        splunk_sdk.delete_attack_data(splunk_ip, splunk_password, splunk_port, wait_on_delete, search_string, test_file, index = index_to_delete)
+
+    splunk_sdk.delete_attack_data(splunk_ip, splunk_password, splunk_port, wait_on_delete, search_string, test_file, indices = indices_to_delete
    
 
     return result_test    

--- a/bin/docker_detection_tester/modules/testing_service.py
+++ b/bin/docker_detection_tester/modules/testing_service.py
@@ -18,7 +18,7 @@ import datetime
 import http.client
 
 
-DEFAULT_DATA_INDEX = "main"
+
 
 def test_detection_wrapper(container_name:str, splunk_ip:str, splunk_password:str, splunk_port:int, 
                            test_file:str, attack_data_root_folder, wait_on_failure:bool=False, wait_on_completion:bool=False)->dict:
@@ -101,7 +101,7 @@ def test_detection(splunk_ip:str, splunk_port:int, container_name:str, splunk_pa
             print(f"Found a custom index for {test_file}: {attack_data['custom_index']}")
             data_upload_index = attack_data['custom_index']
         else:
-            data_upload_index = DEFAULT_DATA_INDEX
+            data_upload_index = splunk_sdk.DEFAULT_DATA_INDEX
 
         indices_to_delete.add(data_upload_index)
 

--- a/bin/docker_detection_tester/modules/testing_service.py
+++ b/bin/docker_detection_tester/modules/testing_service.py
@@ -11,19 +11,21 @@ import requests
 from modules.DataManipulation import DataManipulation
 from modules import splunk_sdk
 import timeit
-from typing import Union
+from typing import Union, Tuple
 from os.path import relpath
 from tempfile import mkdtemp
 import datetime
 import http.client
 
 
+DEFAULT_DATA_INDEX = "main"
+
 def test_detection_wrapper(container_name:str, splunk_ip:str, splunk_password:str, splunk_port:int, 
                            test_file:str, attack_data_root_folder, wait_on_failure:bool=False, wait_on_completion:bool=False)->dict:
     
     one_test_start = timeit.default_timer()
     uuid_var = str(uuid.uuid4())
-    result_test = test_detection(splunk_ip, splunk_port, container_name, splunk_password, test_file, uuid_var, attack_data_root_folder)
+    result_test, indices_to_delete = test_detection(splunk_ip, splunk_port, container_name, splunk_password, test_file, uuid_var, attack_data_root_folder)
     one_test_stop = timeit.default_timer()
     
     if result_test is None:
@@ -45,8 +47,10 @@ def test_detection_wrapper(container_name:str, splunk_ip:str, splunk_password:st
         wait_on_delete = {'message':"\n\n\n****SEARCH SUCCESS : Allowing time to examine search/data****"}
     else:
         wait_on_delete = None
-    
-    splunk_sdk.delete_attack_data(splunk_ip, splunk_password, splunk_port, wait_on_delete, search_string, test_file)
+
+    for index_to_delete in indices_to_delete:
+        print(f"Deleting index data for {test_file}: {index_to_delete}")
+        splunk_sdk.delete_attack_data(splunk_ip, splunk_password, splunk_port, wait_on_delete, search_string, test_file, index = index_to_delete)
    
 
     return result_test    
@@ -66,7 +70,7 @@ def get_service(splunk_ip:str, splunk_port:int, splunk_password:str):
         raise(Exception("Unable to connect to Splunk instance: " + str(e)))
     return service
 
-def test_detection(splunk_ip:str, splunk_port:int, container_name:str, splunk_password:str, test_file:str, uuid_var, attack_data_root_folder)->Union[dict,None]:
+def test_detection(splunk_ip:str, splunk_port:int, container_name:str, splunk_password:str, test_file:str, uuid_var, attack_data_root_folder)->Tuple[Union[dict,None], set[str]]:
     
     test_file_obj = load_file(os.path.join("security_content/", test_file))
     
@@ -89,9 +93,18 @@ def test_detection(splunk_ip:str, splunk_port:int, container_name:str, splunk_pa
 
     
 
-
+    indices_to_delete = set()
     for attack_data in test_file_obj['tests'][0]['attack_data']:
         url = attack_data['data']
+        
+        if 'custom_index' in attack_data:
+            print(f"Found a custom index for {test_file}: {attack_data['custom_index']}")
+            data_upload_index = attack_data['custom_index']
+        else:
+            data_upload_index = DEFAULT_DATA_INDEX
+
+        indices_to_delete.add(data_upload_index)
+
         r = requests.get(url, allow_redirects=True)
         target_file = os.path.join(folder_name, attack_data['file_name'])
         with open(target_file, 'wb') as target:
@@ -108,7 +121,7 @@ def test_detection(splunk_ip:str, splunk_port:int, container_name:str, splunk_pa
         
         try:
             service = get_service(splunk_ip, splunk_port, splunk_password)
-            test_index = service.indexes["main"]
+            test_index = service.indexes[data_upload_index]
             
             with open(target_file, 'rb') as target:
                 test_index.submit(target.read(), sourcetype=attack_data['sourcetype'], source=attack_data['source'])
@@ -122,7 +135,7 @@ def test_detection(splunk_ip:str, splunk_port:int, container_name:str, splunk_pa
             
 
 
-        if not splunk_sdk.wait_for_indexing_to_complete(splunk_ip, splunk_port, splunk_password, attack_data['sourcetype'], "main"):
+        if not splunk_sdk.wait_for_indexing_to_complete(splunk_ip, splunk_port, splunk_password, attack_data['sourcetype'], data_upload_index):
             raise Exception("There was an error waiting for indexing to complete.")
         
     #Allow some time for the data to be ingested and processed
@@ -169,7 +182,7 @@ def test_detection(splunk_ip:str, splunk_port:int, container_name:str, splunk_pa
     result_test['attack_data_directory'] = abs_folder_path
 
 
-    return result_test
+    return result_test, indices_to_delete
 
 
 def load_file(file_path):

--- a/bin/docker_detection_tester/modules/testing_service.py
+++ b/bin/docker_detection_tester/modules/testing_service.py
@@ -49,7 +49,7 @@ def test_detection_wrapper(container_name:str, splunk_ip:str, splunk_password:st
         wait_on_delete = None
 
 
-    splunk_sdk.delete_attack_data(splunk_ip, splunk_password, splunk_port, wait_on_delete, search_string, test_file, indices = indices_to_delete
+    splunk_sdk.delete_attack_data(splunk_ip, splunk_password, splunk_port, wait_on_delete, search_string, test_file, indices = indices_to_delete)
    
 
     return result_test    


### PR DESCRIPTION
There are a number of detections whose
attack_data MUST be uploaded into specific
indices.  This is required due to macros that
are used to search for that data or for 
Datamodel Acceleration searches that require
data to be resident in specific indexes.
This PR adds the ability to specify a field
called "custom_index" in the test.yml files.
This field can be specified for each individual file
(just like source and sourcetype).  If this field is
not present, then a default index 
(at this time "main") will be used for replaying
data.