### PR TITLE
Detection fixes

### DIFF
--- a/detections/cloud/aws_ecr_container_scanning_findings_high.yml
+++ b/detections/cloud/aws_ecr_container_scanning_findings_high.yml
@@ -1,7 +1,7 @@
 name: AWS ECR Container Scanning Findings High
 id: 62721bd2-1d82-4623-b6e6-aac170014423
 version: 1
-date: '2021-08-17'
+date: '2022-06-21'
 author: Patrick Bareiss, Splunk
 type: TTP
 datamodel: []
@@ -14,7 +14,7 @@ search: '`cloudtrail` eventSource=ecr.amazonaws.com eventName=DescribeImageScanF
   description as finding_description, requestParameters.imageId.imageDigest as imageDigest,
   requestParameters.repositoryName as image | eval finding = finding_name.", ".finding_description
   | eval phase="release" | eval severity="high" | stats min(_time) as firstTime max(_time)
-  as lastTime by awsRegion, eventName, eventSource, imageDigest, image, user, userName,
+  as lastTime by awsRegion, eventName, eventSource, imageDigest, image, userName,
   src_ip, finding, phase, severity | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
   | `aws_ecr_container_scanning_findings_high_filter`'
 how_to_implement: You must install splunk AWS add on and Splunk App for AWS. This

--- a/detections/cloud/aws_ecr_container_scanning_findings_medium.yml
+++ b/detections/cloud/aws_ecr_container_scanning_findings_medium.yml
@@ -15,7 +15,7 @@ search: '`cloudtrail` eventSource=ecr.amazonaws.com eventName=DescribeImageScanF
   requestParameters.repositoryName as image | eval finding = finding_name.", ".finding_description
   | eval phase="release" | eval severity="medium" | stats min(_time) as firstTime
   max(_time) as lastTime by awsRegion, eventName, eventSource, imageDigest, image,
-  user, userName, src_ip, finding, phase, severity | `security_content_ctime(firstTime)`
+   userName, src_ip, finding, phase, severity | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)` | `aws_ecr_container_scanning_findings_medium_filter`'
 how_to_implement: You must install splunk AWS add on and Splunk App for AWS. This
   search works with AWS CloudTrail logs.

--- a/detections/endpoint/office_document_executing_macro_code.yml
+++ b/detections/endpoint/office_document_executing_macro_code.yml
@@ -13,7 +13,7 @@ description: this detection was designed to identifies suspicious office documen
   or other malware component. It is really good practice to disable macro by default
   to avoid automatically execute macro code while opening or closing a office document
   files.
-search: '`sysmon` EventCode=7 process_name IN ("WINWORD.EXE", "EXCEL.EXE", "POWERPNT.EXE")
+search: '`sysmon` EventCode=7 parent_process_name IN ("WINWORD.EXE", "EXCEL.EXE", "POWERPNT.EXE")
   ImageLoaded IN ("*\\VBE7INTL.DLL","*\\VBE7.DLL", "*\\VBEUI.DLL") | stats min(_time)
   as firstTime max(_time) as lastTime values(ImageLoaded) as AllImageLoaded count
   by Computer EventCode Image process_name ProcessId ProcessGuid | `security_content_ctime(firstTime)`

--- a/tests/application/path_traversal_spl_injection.test.yml
+++ b/tests/application/path_traversal_spl_injection.test.yml
@@ -10,3 +10,4 @@ tests:
     data: https://raw.githubusercontent.com/splunk/attack_data/master/datasets/attack_techniques/T1083/splunk/path_traversal_spl_injection.txt
     source: c:\opt\splunk\var\log\splunk\splunkd_ui_access.log
     sourcetype: splunkd_ui_access
+    custom_index: _internal

--- a/tests/application/splunk_dos_via_malformed_s2s_request.test.yml
+++ b/tests/application/splunk_dos_via_malformed_s2s_request.test.yml
@@ -11,3 +11,4 @@ tests:
     source: /opt/splunk/var/log/splunk/splunkd.log
     sourcetype: splunkd
     update_timestamp: true
+    custom_index: _internal


### PR DESCRIPTION
Fixes some detections that were failing in CI/CD because they didn't include custom_index AND fixes some detections that were failing (I think) because they  included a stats field (user) that does not exist in the raw data. Also fixes a field which was renamed in a sysmon update.

Double-check that the meaning of the logic in the detection did not change.