### PR TITLE
Print error instead of bailing out on enrichment failure

### DIFF
--- a/bin/contentctl_project/contentctl_infrastructure/builder/cve_enrichment.py
+++ b/bin/contentctl_project/contentctl_infrastructure/builder/cve_enrichment.py
@@ -78,10 +78,9 @@ class CveEnrichment():
         except TypeError as TypeErr:
             # there was a error calling the circl api lets just empty the object
             print("WARNING, issue enriching {0}, with error: {1}".format(cve_id, str(TypeErr)))
-            sys.exit(1)
+            cve_enriched = dict()
             
         except Exception as e:
             print("WARNING - {0}".format(str(e)))
-            sys.exit(1)
     
         return cve_enriched


### PR DESCRIPTION
# PR Template for new Detections

### Details

Going back to printing errors instead of failing on CVE enrichment

### Author Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>`
- [ ] Make sure that CI/CD [detection-testing and build-and-validate](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Is there an Atomic Test? Is GUID on the test file under array: `atomic_test_guid`, [example]()?


### Review Checklist

- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
