### PR TITLE
Grammar correction in documentation template

### DIFF
--- a/bin/contentctl_project/contentctl_infrastructure/adapter/templates/doc_detections.j2
+++ b/bin/contentctl_project/contentctl_infrastructure/adapter/templates/doc_detections.j2
@@ -34,7 +34,7 @@ tags:
 ---
 
 {% if object.experimental is sameas true -%}
-### :warning: WARNING THIS IS A EXPERIMENTAL analytic
+### :warning: WARNING THIS IS AN EXPERIMENTAL analytic
 We have not been able to test, simulate, or build datasets for this object. Use at your own risk. This analytic is **NOT** supported.
 {% endif %}
 


### PR DESCRIPTION
Just a quick tweak to the wording on the template.