### PR TITLE
Fixed query for functionality

### DIFF
--- a/detections/endpoint/recursive_delete_of_directory_in_batch_cmd.yml
+++ b/detections/endpoint/recursive_delete_of_directory_in_batch_cmd.yml
@@ -11,8 +11,8 @@ description: This search is to detect a suspicious commandline designed to delet
   (reddot) where it it tries to delete the files in recycle bin to impaire user from
   recovering deleted files.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_cmd` Processes.process=*/c*  Processes.process=*
-  rd * Processes.process="*/s*" Processes.process="*/q*" by Processes.user Processes.process_name
+  as lastTime from datamodel=Endpoint.Processes where `process_cmd` Processes.process=*/c*  Processes.process="*
+  rd *"  Processes.process="*/s*" Processes.process="*/q*" by Processes.user Processes.process_name
   Processes.parent_process_name Processes.parent_process Processes.process Processes.process_id
   Processes.dest |`drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)` | `recursive_delete_of_directory_in_batch_cmd_filter`'


### PR DESCRIPTION
`Processes.process=* rd *` will never work, so modified it to be `Processes.process="* rd *"`

### Details

_What does this PR have in it? 
Literally added in two sets of double quotes to ensure the field=value works.

### Checklist

- [x] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
