### PR TITLE
Updated find and replace string

### DIFF
--- a/bin/contentctl_project/contentctl_core/application/use_cases/initialize.py
+++ b/bin/contentctl_project/contentctl_core/application/use_cases/initialize.py
@@ -164,7 +164,7 @@ class Initialize:
         self.simple_replace_line(filename, original, updated)
 
 
-        raw  ='''[{app_name} - '''
+        raw  ='''{app_name} - '''
         original = raw.format(app_name="ESCU")
         updated = raw.format(app_name=self.app_name)
         filename_root = os.path.join(self.path,"bin/contentctl_project/contentctl_infrastructure/adapter/templates/")


### PR DESCRIPTION
Find and replace string did not catch
all uses of "ESCU -" in template files.