### PR TITLE
Remove slim as a dependency

### DIFF
--- a/.github/workflows/build-and-validate.yml
+++ b/.github/workflows/build-and-validate.yml
@@ -144,15 +144,6 @@ jobs:
             # update build number and version for ssa
             tar -czf build/content-pack-build-ssa.tar.gz dist/ssa/*
       
-      - name: Download and Install Splunk Packaging Toolkit
-        run : |
-          source .venv/bin/activate
-          curl -Ls https://download.splunk.com/misc/packaging-toolkit/splunk-packaging-toolkit-1.0.1.tar.gz -o splunk-packaging-toolkit-latest.tar.gz
-          mkdir slim-latest
-          tar -zxf splunk-packaging-toolkit-latest.tar.gz -C slim-latest --strip-components=1
-          cd slim-latest
-          python -m pip install .
-          cd ..
       
       - name: Build ESCU
         run: |
@@ -162,25 +153,19 @@ jobs:
           tar -zxf content-pack-build-ssa.tar.gz
           mv dist/escu      DA-ESS-ContentUpdate
           mv dist/ssa       SSA_Content
-          slim package -o upload DA-ESS-ContentUpdate
-          cp upload/DA-ESS-ContentUpdate-*.tar.gz DA-ESS-ContentUpdate-latest.tar.gz
+          
+          #Build ESCU Content
+          #Do not use slim for speed, simplicity, and compatability
+          tar -zcf DA-ESS-ContentUpdate-latest.tar.gz DA-ESS-ContentUpdate
           sha256sum DA-ESS-ContentUpdate-latest.tar.gz > checksum.txt
-          #Do this copy so that we conform as much as possible, and have to make 
-          #as few changes as possible, once we start generating this as a real,
-          #properly packaged app
-          tar -zcf upload/SSA_Content-NO_SLIM.tar.gz SSA_Content  
-          cp upload/SSA_Content-*.tar.gz SSA_Content-latest.tar.gz
+          
+          #Build the SSA Content
+          #Do not use slim for speed, simplicity, and compatability
+          tar -zcf SSA_Content-latest.tar.gz SSA_Content  
           sha256sum SSA_Content-latest.tar.gz >> checksum.txt
 
-
-      - name: store_artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: package
-          path: |
-            build/upload
       
-      - name: store_artifacts_two
+      - name: store_artifacts
         uses: actions/upload-artifact@v2
         with:
           name: content-latest

--- a/bin/docker_detection_tester/detection_testing_execution.py
+++ b/bin/docker_detection_tester/detection_testing_execution.py
@@ -212,7 +212,8 @@ def generate_escu_app(persist_security_content: bool = False) -> str:
         # There remove the latest file if it exists
         commands = ["cd slim_packaging",
                     "cp -R ../dist/escu DA-ESS-ContentUpdate",
-                    "slim package -o upload DA-ESS-ContentUpdate",
+                    "mkdir upload",
+                    "tar -czf upload/DA-ESS-ContentUpdate*.tar.gz DA-ESS-ContentUpdate",
                     "cp upload/DA-ESS-ContentUpdate*.tar.gz %s" % (output_file_path_from_slim_latest)]
 
     else:
@@ -221,7 +222,8 @@ def generate_escu_app(persist_security_content: bool = False) -> str:
                     "mkdir slim_packaging",
                     "cd slim_packaging",
                     "cp -R ../dist/escu DA-ESS-ContentUpdate",
-                    "slim package -o upload DA-ESS-ContentUpdate",
+                    "mkdir upload",
+                    "tar -czf upload/DA-ESS-ContentUpdate*.tar.gz DA-ESS-ContentUpdate",
                     "cp upload/DA-ESS-ContentUpdate*.tar.gz %s" % (output_file_path_from_slim_latest)]
 
     ret = subprocess.run("; ".join(commands),

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ questionary==1.10.0
 requests==2.28.1
 six==1.16.0
 splunk-appinspect==2.25.0
-splunk-packaging-toolkit==1.0.1
 splunk-sdk==1.7.2
 wrapt-timeout-decorator==1.3.12.2
 xmltodict==0.13.0


### PR DESCRIPTION
slim causes an issue with Python3.10.
Because the structure of our app is so rigidly defined and built, 
it doesn't really get any benefits from slim - we simply tar the app.