### PR TITLE
Fix generate API

### DIFF
--- a/.github/workflows/build-and-validate.yml
+++ b/.github/workflows/build-and-validate.yml
@@ -112,6 +112,7 @@ jobs:
           rm -rf dist/escu/default/data/ui/panels/*.xml
           python contentctl.py --path . ${{ steps.vars.outputs.skip_enrichment_var }} generate --product ESCU --output dist/escu
           python contentctl.py --path . ${{ steps.vars.outputs.skip_enrichment_var }} generate --product SSA --output dist/ssa
+          python contentctl.py --path . ${{ steps.vars.outputs.skip_enrichment_var }} generate --product API --output dist/api
       
       - name: Copy lookups .mlmodel files
         run: |
@@ -153,6 +154,7 @@ jobs:
           tar -zxf content-pack-build-ssa.tar.gz
           mv dist/escu      DA-ESS-ContentUpdate
           mv dist/ssa       SSA_Content
+          mv dist/api       API_Content
           
           #Build ESCU Content
           #Do not use slim for speed, simplicity, and compatability
@@ -164,6 +166,10 @@ jobs:
           tar -zcf SSA_Content-latest.tar.gz SSA_Content  
           sha256sum SSA_Content-latest.tar.gz >> checksum.txt
 
+          #Package the API Content
+          tar -zcf API_Content-latest.tar.gz API_Content  
+          sha256sum API_Content-latest.tar.gz >> checksum.txt
+
       
       - name: store_artifacts
         uses: actions/upload-artifact@v2
@@ -172,6 +178,7 @@ jobs:
           path: |
             build/DA-ESS-ContentUpdate-latest.tar.gz
             build/SSA_Content-latest.tar.gz
+            build/API_Content-latest.tar.gz
             build/checksum.txt
 
           
@@ -307,8 +314,12 @@ jobs:
         run: |
           mkdir latest-escu
           tar -zxf DA-ESS-ContentUpdate-latest.tar.gz -C latest-escu --strip-components=1
+          
           mkdir latest-ssa
           tar -zxf SSA_Content-latest.tar.gz -C latest-ssa --strip-components=1
+
+          mkdir latest-api
+          tar -zxf API_Content-latest.tar.gz -C latest-api --strip-components=1
       
       - name: Install Python Dependencies
         run: |
@@ -336,6 +347,7 @@ jobs:
           mkdir dist
           mv latest-escu dist/escu
           mv latest-ssa dist/ssa
+          mv latest-api dist/api
           # configure git to prep for commit
           git config user.email "research@splunk.com"
           git config user.name "research bot"
@@ -343,7 +355,7 @@ jobs:
           git add dist/*
           git add docs/*
           git add detections/*
-          git commit --allow-empty -m "updating docs and package bits [ci skip]"
+          git commit --allow-empty -m "Update dist/escu, dist/ssa, and dist/api folders with the latest content associated with this tag "
           # Push quietly to prevent showing the token in log
           #No need to provide any credentials
           git push
@@ -375,6 +387,8 @@ jobs:
         run: |
           cp DA-ESS-ContentUpdate-latest.tar.gz DA-ESS-ContentUpdate-${{ steps.vars.outputs.tag }}.tar.gz
           cp SSA_Content-latest.tar.gz SSA_Content-${{ steps.vars.outputs.tag }}.tar.gz
+          cp API_Content-latest.tar.gz API_Content-${{ steps.vars.outputs.tag }}.tar.gz
+
           #No checksum on the reports
           cp report.tar.gz report-${{ steps.vars.outputs.tag }}.tar.gz
           cp checksum.txt checksum-${{ steps.vars.outputs.tag }}.txt
@@ -387,6 +401,7 @@ jobs:
           files: |
             DA-ESS-ContentUpdate-${{ steps.vars.outputs.tag }}.tar.gz
             SSA_Content-${{ steps.vars.outputs.tag }}.tar.gz
+            API_Content-${{ steps.vars.outputs.tag }}.tar.gz
             report-${{ steps.vars.outputs.tag }}.tar.gz
             checksum-${{ steps.vars.outputs.tag }}.txt
   

--- a/.github/workflows/build-and-validate.yml
+++ b/.github/workflows/build-and-validate.yml
@@ -66,13 +66,13 @@ jobs:
       #Previous config chose which branch/tag to operate on.
       #I think Github is smart enough to choose based on whether it's a pull request or push + other info?
       - name: Check out the repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         #with:
         #  repository: splunk/security-content #check out https://github.com/mitre/cti.git, defaults to HEAD
         #  path: "security-content"
 
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9' #Available versions here - https://github.com/actions/python-versions/releases  easy to change/make a matrix/use pypy
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
@@ -101,10 +101,6 @@ jobs:
           python contentctl.py -p . ${{ steps.vars.outputs.skip_enrichment_var }} validate -pr SSA 
 
 
-      #Now generate the documentation (uses Node)
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14' #can easily be changed to a different version
       
       - name: contentctl generate
         run: |
@@ -174,7 +170,7 @@ jobs:
 
       
       - name: store_artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: content-latest
           path: |
@@ -194,12 +190,12 @@ jobs:
     steps:
 
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: 'develop'
 
       #Download the artifacts we want to check
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: content-latest
           path: build/
@@ -226,7 +222,7 @@ jobs:
           tar -cvzf report.tar.gz report/
       
       - name: store_artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: appinspect_reports
           path: |
@@ -234,7 +230,7 @@ jobs:
      
       #Still store the report, even if we have failed (otherwise we don't know why/how we failed)
       - name: store_artifacts_on_failure
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: appinspect_reports_failure
@@ -249,7 +245,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: 'develop'
 
@@ -258,7 +254,7 @@ jobs:
           sudo apt update -qq
           sudo apt install jq -qq
      
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9' #Available versions here - https://github.com/actions/python-versions/releases  easy to change/make a matrix/use pypy
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
@@ -298,17 +294,17 @@ jobs:
     steps:
 
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.SECURITY_CONTENT_ADMIN_TASKS }}
           ref: 'develop'
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9' #Available versions here - https://github.com/actions/python-versions/releases  easy to change/make a matrix/use pypy
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: content-latest
 
@@ -372,11 +368,11 @@ jobs:
     steps:
 
       #Get the artifacts that we need
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: content-latest
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: appinspect_reports
 
@@ -415,7 +411,7 @@ jobs:
     steps:
 
       #Get the artifacts that we need
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: content-latest
 
@@ -440,12 +436,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: 'develop'
 
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9' #Available versions here - https://github.com/actions/python-versions/releases  easy to change/make a matrix/use pypy
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified

--- a/.github/workflows/build-and-validate.yml
+++ b/.github/workflows/build-and-validate.yml
@@ -144,6 +144,7 @@ jobs:
             tar -czf build/content-pack-build-escu.tar.gz dist/escu/*
             # update build number and version for ssa
             tar -czf build/content-pack-build-ssa.tar.gz dist/ssa/*
+            tar -czf build/content-pack-build-api.tar.gz dist/api/*
       
       
       - name: Build ESCU
@@ -152,6 +153,7 @@ jobs:
           cd build
           tar -zxf content-pack-build-escu.tar.gz
           tar -zxf content-pack-build-ssa.tar.gz
+          tar -zxf content-pack-build-api.tar.gz
           mv dist/escu      DA-ESS-ContentUpdate
           mv dist/ssa       SSA_Content
           mv dist/api       API_Content

--- a/bin/contentctl_project/contentctl_infrastructure/builder/security_content_story_builder.py
+++ b/bin/contentctl_project/contentctl_infrastructure/builder/security_content_story_builder.py
@@ -15,13 +15,19 @@ from bin.contentctl_project.contentctl_infrastructure.builder.yml_reader import 
 class SecurityContentStoryBuilder(StoryBuilder):
     story: Story
     check_references: bool
+    app_name: str
 
     def __init__(self, output_path:Union[str,None]=None, check_references: bool = False):
         self.check_references = check_references
         self.app_name = self.get_app_name_from_manifest(output_path)
 
     def get_app_name_from_manifest(self, output_path:Union[str,None])->str:
-        if output_path is None:
+        
+        if output_path is None: 
+            return "ESCU"
+        
+        elif "dist/api" in output_path:
+            print("API does not have an 'app.manifest' file - assuming app is ESCU")
             return "ESCU"
         
         try:

--- a/contentctl.py
+++ b/contentctl.py
@@ -411,6 +411,7 @@ def main(args):
         return args.func(args)
     except Exception as e:
         print(f"Error for function [{args.func.__name__}]: {str(e)}")
+        sys.exit(1)
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
Lack of app.manifest file in the dist/api
folder causes an exception to be raised.
While this was caught by contentctl,
it did not return a nonzero error code, 
so it did not interrupt the CI/CD process
and the process assumed that contentctl
ran correctly.