### PR TITLE
Text4Haags - CVE-2022-42889

### DIFF
--- a/detections/web/exploit_public_facing_application_via_apache_commons_text.yml
+++ b/detections/web/exploit_public_facing_application_via_apache_commons_text.yml
@@ -1,0 +1,79 @@
+name: 'Exploit Public Facing Application via Apache Commons Text'
+id: 19a481e0-c97c-4d14-b1db-75a708eb592e
+version: 1
+date: '2022-10-26'
+author: Michael Haag, Splunk
+type: Anomaly
+datamodel:
+- Web
+description: The following analytic identifies activity related to Text4Shell, or the critical vulnerability CVE-2022-42889 in Apache Commons Text Library. Apache Commons Text versions 1.5 through 1.9 are affected, but it has been patched in version 1.10. The analytic may need to be tuned for your environment before enabling as a TTP, or direct Notable.
+  Apache Commons Text is a Java library described as a library focused on algorithms working on strings. We can see it as a general-purpose text manipulation toolkit.
+  This vulnerability affects the StringSubstitutor interpolator class, which is included in the Commons Text library. A default interpolator allows for string lookups that can lead to Remote Code Execution. This is due to a logic flaw that makes the script, dns, and url lookup keys interpolated by default, as opposed to what it should be, according to the documentation of the StringLookupFactory class. Those keys allow an attacker to execute arbitrary code via lookups.
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Web where Web.http_method IN (POST, GET) by Web.src Web.status Web.uri_path Web.dest Web.http_method Web.uri_query Web.http_user_agent
+  | `drop_dm_object_name("Web")`
+  | eval utf=if(like(lower(uri_query),"%:utf-8:http%"),2,0)
+  | eval lookup = if(like(lower(uri_query), "%url%") OR like(lower(uri_query), "%dns%") OR like(lower(uri_query), "%script%"),2,0)
+  | eval other_lookups = if(like(lower(uri_query), "%env%") OR like(lower(uri_query), "%file%") OR like(lower(uri_query), "%java%") OR like(lower(uri_query), "%localhost%") OR like(lower(uri_query), "%properties%") OR like(lower(uri_query), "%resource%") OR like(lower(uri_query), "%sys%") OR like(lower(uri_query), "%xml%") OR like(lower(uri_query), "%base%"),1,0)
+  | addtotals fieldname=Score utf lookup other_lookups
+  | fields Score, src, dest, status, uri_query, uri_path, http_method, http_user_agent firstTime lastTime
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | where Score >= 4
+  | `exploit_public_facing_application_via_apache_commons_text__filter`'
+how_to_implement: To implement, one must be collecting network traffic that is normalized in CIM and able to be queried via the Web datamodel. Or, take the chunks out needed and tie to a specific network source type to hunt in. Tune as needed, or remove the other_lookups statement. 
+known_false_positives: False positives are present when the values are set to 1 for utf and lookup. It's possible to raise this to TTP (direct notable) if removal of other_lookups occur and Score is raised to 2 (down from 4).
+references:
+  - https://sysdig.com/blog/cve-2022-42889-text4shell/
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-42889
+  - https://lists.apache.org/thread/n2bd4vdsgkqh2tm14l1wyc3jyol7s1om
+  - https://www.rapid7.com/blog/post/2022/10/17/cve-2022-42889-keep-calm-and-stop-saying-4shell/
+tags:
+  analytic_story:
+  - Text4Shell CVE-2022-42889
+  cve:
+  - CVE-2022-42889
+  asset_type: Web Server
+  cis20:
+  - CIS 3
+  - CIS 5
+  - CIS 16
+  confidence: 70
+  context:
+  - Source:Application Log
+  - Stage:Execution
+  dataset:
+  - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1190/text4shell/text4shell.log
+  impact: 70
+  kill_chain_phases:
+  - Exploitation
+  message: A URL was requested related to Text4Shell on $dest$ by $src$.
+  mitre_attack_id:
+  - T1505.003
+  - T1505
+  - T1190
+  nist:
+  - DE.CM
+  observable:
+  - name: dest
+    type: IP Address
+    role:
+    - Victim
+  - name: src
+    type: IP Address
+    role:
+    - Attacker
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - Web.http_method
+  - Web.src
+  - Web.dest
+  - Web.http_user_agent
+  risk_score: 49
+  security_domain: network
+  supported_tas:
+  - Splunk_TA_nginx

--- a/detections/web/exploit_public_facing_application_via_apache_commons_text.yml
+++ b/detections/web/exploit_public_facing_application_via_apache_commons_text.yml
@@ -20,7 +20,7 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | where Score >= 4
-  | `exploit_public_facing_application_via_apache_commons_text__filter`'
+  | `exploit_public_facing_application_via_apache_commons_text_filter`'
 how_to_implement: To implement, one must be collecting network traffic that is normalized in CIM and able to be queried via the Web datamodel. Or, take the chunks out needed and tie to a specific network source type to hunt in. Tune as needed, or remove the other_lookups statement. 
 known_false_positives: False positives are present when the values are set to 1 for utf and lookup. It's possible to raise this to TTP (direct notable) if removal of other_lookups occur and Score is raised to 2 (down from 4).
 references:

--- a/stories/text4shell_cve_2022_42889.yml
+++ b/stories/text4shell_cve_2022_42889.yml
@@ -1,0 +1,24 @@
+name: Text4Shell CVE-2022-42889
+id: 95ae800d-485e-47f7-866e-8be281aa497b
+version: 1
+date: '2022-10-26'
+author: Michael Haag, Splunk
+description: A new critical vulnerability CVE-2022-42889 a.k.a. Text4shell, similar to the old Spring4Shell and Log4Shell, was originally reported by Alvaro Munoz on the very popular Apache Commons Text library.
+narrative: Apache Commons Text is a Java library described as "a library focused on algorithms working on strings." We can see it as a general-purpose text manipulation toolkit.
+  This vulnerability affects the StringSubstitutor interpolator class, which is included in the Commons Text library. A default interpolator allows for string lookups that can lead to Remote Code Execution. This is due to a logic flaw that makes the "script," "dns," and "url" lookup keys interpolated by default, as opposed to what it should be, according to the documentation of the StringLookupFactory class. Those keys allow an attacker to execute arbitrary code via lookups.
+  In order to exploit the vulnerabilities, the following requirements must be met - Run a version of Apache Commons Text from version 1.5 to 1.9 and use the StringSubstitutor interpolator.
+  It is important to specify that the StringSubstitutor interpolator is not as widely used as the string substitution in Log4j, which led to Log4Shell.
+  According to the CVSSv3 system, it scores 9.8 as CRITICAL severity.
+  The severity is Critical due to the easy exploitability and huge potential impact in terms of confidentiality, integrity, and availability. As we showed in the previous section, you can take full control over the vulnerable system with a crafted request.
+  However, it is not likely the vulnerabilities will have the same impacts as the previous Log4Shell and Spring4Shell.
+references:
+  - https://sysdig.com/blog/cve-2022-42889-text4shell/
+tags:
+  analytic_story: Text4Shell CVE-2022-42889
+  category:
+  - Adversary Tactics
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  usecase: Application Security

--- a/tests/web/exploit_public_facing_application_via_apache_commons_text.test.yml
+++ b/tests/web/exploit_public_facing_application_via_apache_commons_text.test.yml
@@ -1,7 +1,7 @@
-name: Exploit Public Facing Application via Apache Commons Text  Unit Test
+name: Exploit Public Facing Application via Apache Commons Text Unit Test
 tests:
-- name: 'Exploit Public Facing Application via Apache Commons Text '
-  file: web/exploit_public_facing_application_via_apache_commons_text_.yml
+- name: 'Exploit Public Facing Application via Apache Commons Text'
+  file: web/exploit_public_facing_application_via_apache_commons_text.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: -24h
   latest_time: now

--- a/tests/web/exploit_public_facing_application_via_apache_commons_text_.test.yml
+++ b/tests/web/exploit_public_facing_application_via_apache_commons_text_.test.yml
@@ -1,0 +1,13 @@
+name: Exploit Public Facing Application via Apache Commons Text  Unit Test
+tests:
+- name: 'Exploit Public Facing Application via Apache Commons Text '
+  file: web/exploit_public_facing_application_via_apache_commons_text_.yml
+  pass_condition: '| stats count | where count > 0'
+  earliest_time: -24h
+  latest_time: now
+  attack_data:
+  - file_name: text4shell.log
+    data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1190/text4shell/text4shell.log
+    source: bro:http:json
+    sourcetype: bro:http:json
+    update_timestamp: true


### PR DESCRIPTION
## Details

Content related to - CVE-2022-42889

## new Analytics
- Exploit Public Facing Application via Apache Commons Text
## New Analytic Story
- Text4Shell CVE-2022-42889

![image](https://user-images.githubusercontent.com/5632822/198134176-d2adad01-783a-4e70-b770-a583e39dd449.png)