### PR TITLE
Added vpe_type tag to playbook yamls

### DIFF
--- a/playbooks/activedirectory_reset_password.yml
+++ b/playbooks/activedirectory_reset_password.yml
@@ -13,6 +13,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Automation
+  vpe_type: Classic
   playbook_fields:
   - compromisedUserName
   product:

--- a/playbooks/aws_disable_user_accounts.yml
+++ b/playbooks/aws_disable_user_accounts.yml
@@ -15,6 +15,7 @@ tags:
   platform_tags:
   - Cloud
   playbook_type: Input
+  vpe_type: Modern
   playbook_fields:
   - aws_username
   product:

--- a/playbooks/aws_find_inactive_users.yml
+++ b/playbooks/aws_find_inactive_users.yml
@@ -16,6 +16,7 @@ tags:
   platform_tags:
   - Cloud
   playbook_type: Automation
+  vpe_type: Modern
   playbook_fields: []
   product:
   - Splunk SOAR

--- a/playbooks/block_indicators.yml
+++ b/playbooks/block_indicators.yml
@@ -15,6 +15,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Automation
+  vpe_type: Classic
   playbook_fields:
   - destinationDnsDomain
   - destinationAddress

--- a/playbooks/crowdstrike_malware_triage.yml
+++ b/playbooks/crowdstrike_malware_triage.yml
@@ -13,6 +13,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Automation
+  vpe_type: Classic
   playbook_fields:
   - filePath
   - destinationAddress

--- a/playbooks/delete_detected_files.yml
+++ b/playbooks/delete_detected_files.yml
@@ -17,6 +17,7 @@ tags:
   - Executable File Written in Administrative SMB Share
   platform_tags: []
   playbook_type: Automation
+  vpe_type: Classic
   playbook_fields:
   - filePath
   - destinationAddress

--- a/playbooks/email_notification_for_malware.yml
+++ b/playbooks/email_notification_for_malware.yml
@@ -16,6 +16,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Automation
+  vpe_type: Classic
   playbook_fields:
   - fileHash
   - vaultId

--- a/playbooks/hunting.yml
+++ b/playbooks/hunting.yml
@@ -17,6 +17,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Automation
+  vpe_type: Classic
   playbook_fields:
   - fileHash
   - vault_id

--- a/playbooks/internal_host_splunk_investigate_log4j.yml
+++ b/playbooks/internal_host_splunk_investigate_log4j.yml
@@ -16,6 +16,7 @@ tags:
   - Log4Shell CVE-2021-44228
   platform_tags: []
   playbook_type: Input
+  vpe_type: Modern
   playbook_fields:
   - hostName
   - destinationAddress

--- a/playbooks/internal_host_ssh_investigate.yml
+++ b/playbooks/internal_host_ssh_investigate.yml
@@ -13,6 +13,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Input
+  vpe_type: Modern
   playbook_fields: []
   product:
   - Splunk SOAR

--- a/playbooks/internal_host_ssh_log4j_investigate.yml
+++ b/playbooks/internal_host_ssh_log4j_investigate.yml
@@ -13,6 +13,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Input
+  vpe_type: Modern
   playbook_fields: []
   product:
   - Splunk SOAR

--- a/playbooks/internal_host_ssh_log4j_respond.yml
+++ b/playbooks/internal_host_ssh_log4j_respond.yml
@@ -13,6 +13,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Input
+  vpe_type: Modern
   playbook_fields: []
   product:
   - Splunk SOAR

--- a/playbooks/internal_host_winrm_investigate.yml
+++ b/playbooks/internal_host_winrm_investigate.yml
@@ -13,6 +13,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Input
+  vpe_type: Modern
   playbook_fields: []
   product:
   - Splunk SOAR

--- a/playbooks/internal_host_winrm_log4j_investigate.yml
+++ b/playbooks/internal_host_winrm_log4j_investigate.yml
@@ -13,6 +13,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Input
+  vpe_type: Modern
   playbook_fields: []
   product:
   - Splunk SOAR

--- a/playbooks/internal_host_winrm_log4j_respond.yml
+++ b/playbooks/internal_host_winrm_log4j_respond.yml
@@ -13,6 +13,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Input
+  vpe_type: Modern
   playbook_fields: []
   product:
   - Splunk SOAR

--- a/playbooks/log4j_investigate.yml
+++ b/playbooks/log4j_investigate.yml
@@ -30,5 +30,6 @@ tags:
   - Detect Outbound LDAP Traffic
   playbook_fields: []
   playbook_type: Automation
+  vpe_type: Modern
   product:
   - Splunk SOAR

--- a/playbooks/log4j_respond.yml
+++ b/playbooks/log4j_respond.yml
@@ -30,5 +30,6 @@ tags:
   - Detect Outbound LDAP Traffic
   playbook_fields: []
   playbook_type: Automation
+  vpe_type: Modern
   product:
   - Splunk SOAR

--- a/playbooks/malware_hunt_and_contain.yml
+++ b/playbooks/malware_hunt_and_contain.yml
@@ -16,6 +16,7 @@ app_list:
 tags:
   platform_tags: []
   playbook_type: Automation
+  vpe_type: Classic
   playbook_fields:
   - fileHash
   product:

--- a/playbooks/ransomware_investigate_and_contain.yml
+++ b/playbooks/ransomware_investigate_and_contain.yml
@@ -23,6 +23,7 @@ tags:
   platform_tags:
   - Ransomware
   playbook_type: Automation
+  vpe_type: Classic
   playbook_fields:
   - ComputerName
   - Username

--- a/playbooks/risk_notable_block_indicators.yml
+++ b/playbooks/risk_notable_block_indicators.yml
@@ -19,6 +19,7 @@ tags:
   - note_title
   - note_content
   playbook_type: Automation
+  vpe_type: Modern
   platform_tags:
   - Risk Notable
   product:

--- a/playbooks/risk_notable_enrich.yml
+++ b/playbooks/risk_notable_enrich.yml
@@ -18,6 +18,7 @@ tags:
   - note_title
   - note_content
   playbook_type: Automation
+  vpe_type: Modern
   platform_tags:
   - Risk Notable
   product:

--- a/playbooks/risk_notable_import_data.yml
+++ b/playbooks/risk_notable_import_data.yml
@@ -35,6 +35,7 @@ tags:
   platform_tags:
   - Risk Notable
   playbook_type: Automation
+  vpe_type: Modern
   playbook_fields:
   - event_id
   - info_min_time

--- a/playbooks/risk_notable_investigate.yml
+++ b/playbooks/risk_notable_investigate.yml
@@ -15,6 +15,7 @@ tags:
   labels:
   - risk_notable
   playbook_type: Automation
+  vpe_type: Modern
   platform_tags:
   - Risk Notable
   product:

--- a/playbooks/risk_notable_merge_events.yml
+++ b/playbooks/risk_notable_merge_events.yml
@@ -18,6 +18,7 @@ tags:
   - note_title
   - note_content
   playbook_type: Automation
+  vpe_type: Modern
   platform_tags:
   - Risk Notable
   product:

--- a/playbooks/risk_notable_mitigate.yml
+++ b/playbooks/risk_notable_mitigate.yml
@@ -14,6 +14,7 @@ tags:
   labels:
   - risk_notable
   playbook_type: Automation
+  vpe_type: Modern
   platform_tags:
   - Risk Notable
   product:

--- a/playbooks/risk_notable_preprocess.yml
+++ b/playbooks/risk_notable_preprocess.yml
@@ -21,6 +21,7 @@ tags:
   platform_tags:
   - Risk Notable
   playbook_type: Automation
+  vpe_type: Modern
   playbook_fields:
   - event_id
   - info_min_time

--- a/playbooks/risk_notable_protect_assets_and_users.yml
+++ b/playbooks/risk_notable_protect_assets_and_users.yml
@@ -18,6 +18,7 @@ tags:
   - note_title
   - note_content
   playbook_type: Automation
+  vpe_type: Modern
   platform_tags:
   - Risk Notable
   product:

--- a/playbooks/risk_notable_review_indicators.yml
+++ b/playbooks/risk_notable_review_indicators.yml
@@ -17,5 +17,6 @@ tags:
   platform_tags:
   - Risk Notable
   playbook_type: Automation
+  vpe_type: Modern
   product:
   - Splunk SOAR

--- a/playbooks/risk_notable_verdict.yml
+++ b/playbooks/risk_notable_verdict.yml
@@ -17,5 +17,6 @@ tags:
   platform_tags:
   - Risk Notable
   playbook_type: Automation
+  vpe_type: Modern
   product:
   - Splunk SOAR

--- a/playbooks/start_investigation.yml
+++ b/playbooks/start_investigation.yml
@@ -13,5 +13,6 @@ tags:
   platform_tags: []
   playbook_fields: []
   playbook_type: Automation
+  vpe_type: Modern
   product:
   - Splunk SOAR

--- a/playbooks/threat_intel_investigate.yml
+++ b/playbooks/threat_intel_investigate.yml
@@ -14,6 +14,7 @@ tags:
   platform_tags:
   - threat_intel
   playbook_type: Automation
+  vpe_type: Modern
   playbook_fields: []
   product:
   - Splunk SOAR

--- a/playbooks/trustar_enrich_indicators.yml
+++ b/playbooks/trustar_enrich_indicators.yml
@@ -16,6 +16,7 @@ tags:
   - threat_intel
   - risk_notable
   playbook_type: Input
+  vpe_type: Modern
   playbook_fields: 
   - indicators
   product:


### PR DESCRIPTION
### Details

All Playbook yamls now have a tag `vpe_type` which can contain values of `Modern` or `Classic`

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
