### PR TITLE
Updated search to use XML fields - domain_group_discovery_with_adsisearcher

### DIFF
--- a/detections/endpoint/domain_group_discovery_with_adsisearcher.yml
+++ b/detections/endpoint/domain_group_discovery_with_adsisearcher.yml
@@ -9,10 +9,10 @@ description: The following analytic utilizes PowerShell Script Block Logging (Ev
   to identify the `[Adsisearcher]` type accelerator being used to query Active Directory
   for domain groups. Red Teams and adversaries may leverage `[Adsisearcher]` to enumerate
   domain groups for situational awareness and Active Directory Discovery.
-search: '`powershell` EventCode=4104 (Message = "*[adsisearcher]*" AND Message = "*(objectcategory=group)*"
-  AND Message = "*findAll()*") | stats count min(_time) as firstTime max(_time) as
-  lastTime by EventCode Message ComputerName User | `security_content_ctime(firstTime)`
-  | `domain_group_discovery_with_adsisearcher_filter`'
+search: '`powershell` EventCode=4104 (ScriptBlockText = "*[adsisearcher]*" AND ScriptBlockText = "*(objectcategory=group)*" AND ScriptBlockText = "*findAll()*")
+| stats count min(_time) as firstTime max(_time) as lastTime by EventCode ScriptBlockText Computer UserID 
+| `security_content_ctime(firstTime)` 
+| `domain_group_discovery_with_adsisearcher_filter`'
 how_to_implement: To successfully implement this analytic, you will need to enable
   PowerShell Script Block Logging on some or all endpoints. Additional setup here
   https://docs.splunk.com/Documentation/UBA/5.0.4.1/GetDataIn/AddPowerShell#Configure_module_logging_for_PowerShell.
@@ -49,9 +49,9 @@ tags:
   required_fields:
   - _time
   - EventCode
-  - Message
-  - ComputerName
-  - User
+  - ScriptBlockText
+  - Computer
+  - UserID
   risk_score: 18
   security_domain: endpoint
   asset_type: Endpoint


### PR DESCRIPTION
Changed the search block to use XML fields. Additionally, the User field has been replaced by UserID which will only be the user SID, which will need to be enriched/matched.

Updated Required Fields.

### Details

_What does this PR have in it? Screenshots are worth 1000 words 😄_

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
