### PR TITLE
Updated search to use XML fields - malicious_powershell_executed_as_a_service

### DIFF
--- a/detections/endpoint/malicious_powershell_executed_as_a_service.yml
+++ b/detections/endpoint/malicious_powershell_executed_as_a_service.yml
@@ -8,12 +8,14 @@ datamodel:
 - Endpoint
 description: This detection is to identify the abuse the Windows SC.exe to execute
   malicious commands or payloads via PowerShell.
-search: ' `wineventlog_system` EventCode=7045 | eval l_Service_File_Name=lower(Service_File_Name)
-  | regex l_Service_File_Name="powershell[.\s]|powershell_ise[.\s]|pwsh[.\s]|psexec[.\s]"
-  | regex l_Service_File_Name="-nop[rofile\s]+|-w[indowstyle]*\s+hid[den]*|-noe[xit\s]+|-enc[odedcommand\s]+"
-  | stats count min(_time) as firstTime max(_time) as lastTime by EventCode Service_File_Name
-  Service_Name Service_Start_Type Service_Type Service_Account user | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` | `malicious_powershell_executed_as_a_service_filter`'
+search: ' `wineventlog_system` EventCode=7045 
+| eval l_ImagePath=lower(ImagePath) 
+| regex l_ImagePath="powershell[.\s]|powershell_ise[.\s]|pwsh[.\s]|psexec[.\s]" 
+| regex l_ImagePath="-nop[rofile\s]+|-w[indowstyle]*\s+hid[den]*|-noe[xit\s]+|-enc[odedcommand\s]+" 
+| stats count min(_time) as firstTime max(_time) as lastTime by EventCode ImagePath ServiceName StartType ServiceType AccountName UserID 
+| `security_content_ctime(firstTime)` 
+| `security_content_ctime(lastTime)` 
+| `malicious_powershell_executed_as_a_service_filter`'
 how_to_implement: To successfully implement this search, you need to be ingesting
   Windows System logs with the Service name, Service File Name Service Start type,
   and Service Type from your endpoints.
@@ -36,7 +38,7 @@ tags:
   kill_chain_phases:
   - Exploitation
   message: Identifies the abuse the Windows SC.exe to execute malicious powerShell
-    as a service $Service_File_Name$ by $user$ on $dest$
+    as a service $ImageName$ by $UserID$ on $dest$
   mitre_attack_id:
   - T1569
   - T1569.002
@@ -55,13 +57,13 @@ tags:
   - Splunk Cloud
   required_fields:
   - EventCode
-  - Service_File_Name
-  - Service_Type
+  - ImagePath
+  - ServiceType
   - _time
-  - Service_Name
-  - Service_Start_Type
-  - Service_Account
-  - user
+  - ServiceName
+  - StartType
+  - AccountName
+  - UserID
   risk_score: 72
   security_domain: endpoint
   asset_type: Endpoint


### PR DESCRIPTION
### Details

Changed the search block to reflect the XML fields. Like the PowerShell 4104s, the "user" field is now UserID and is only the user SID, which will need to be enriched (the TA doesn't do that).

Also updated the required_fields block.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
