### PR TITLE
Fix incorrect quotes in `linux_shells.yml`

### DIFF
--- a/macros/linux_shells.yml
+++ b/macros/linux_shells.yml
@@ -1,4 +1,4 @@
-definition: (Processes.process_name IN ("sh", "ksh", "zsh", "bash", "dash", "rbash", "fish", "csh', "tcsh', "ion", "eshell"))
+definition: (Processes.process_name IN ("sh", "ksh", "zsh", "bash", "dash", "rbash", "fish", "csh", "tcsh", "ion", "eshell"))
 description: customer specific splunk configurations(eg- index, source, sourcetype).
   Replace the macro definition with configurations for your Splunk Environmnent.
 name: linux_shells


### PR DESCRIPTION
### Details

I noticed that the `linux_shells.yml` file was mixing quotes, so this PR just fixes that.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
