### PR TITLE
Fix test naming

### DIFF
--- a/tests/cloud/aws_ecr_container_scanning_findings_low_informational_unknown.test.yml
+++ b/tests/cloud/aws_ecr_container_scanning_findings_low_informational_unknown.test.yml
@@ -1,4 +1,4 @@
-name: AWS ECR Container Scanning Findings Low Informational Unknwon Unit Test
+name: AWS ECR Container Scanning Findings Low Informational Unknown Unit Test
 tests:
 - name: AWS ECR Container Scanning Findings Low Informational Unknown
   file: cloud/aws_ecr_container_scanning_findings_low_informational_unknown.yml

--- a/tests/endpoint/creation_of_lsass_dump_with_taskmgr.test.yml
+++ b/tests/endpoint/creation_of_lsass_dump_with_taskmgr.test.yml
@@ -1,4 +1,4 @@
-name: Creation of lsass dump with taskmgr Unit Test
+name: Creation of lsass Dump with Taskmgr Unit Test
 tests:
 - name: Creation of lsass Dump with Taskmgr
   file: endpoint/creation_of_lsass_dump_with_taskmgr.yml

--- a/tests/endpoint/linux_ingress_tool_transfer_with_curl.test.yml
+++ b/tests/endpoint/linux_ingress_tool_transfer_with_curl.test.yml
@@ -1,6 +1,6 @@
-name: Linux Ingress Tool Transfer With Curl Unit Test
+name: Linux Ingress Tool Transfer with Curl Unit Test
 tests:
-- name: Linux Ingress Tool Transfer With Curl
+- name: Linux Ingress Tool Transfer with Curl
   file: endpoint/linux_ingress_tool_transfer_with_curl.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: -24h

--- a/tests/endpoint/suspicious_linux_discovery_commands.test.yml
+++ b/tests/endpoint/suspicious_linux_discovery_commands.test.yml
@@ -1,4 +1,4 @@
-name: Suspicious Linux Discovery Commands
+name: Suspicious Linux Discovery Commands Unit Test
 tests:
 - name: Suspicious Linux Discovery Commands
   file: endpoint/suspicious_linux_discovery_commands.yml

--- a/tests/endpoint/windows_disabled_users_failing_to_authenticate_kerberos.test.yml
+++ b/tests/endpoint/windows_disabled_users_failing_to_authenticate_kerberos.test.yml
@@ -1,6 +1,6 @@
-name: Windows Disabled Users Failing To Authenticate Using Kerberos Unit Test
+name: Windows Disabled Users Failing To Authenticate Kerberos Unit Test
 tests:
-- name: Windows Disabled Users Failing To Authenticate Using Kerberos
+- name: Windows Disabled Users Failing To Authenticate Kerberos
   file: endpoint/windows_disabled_users_failing_to_authenticate_kerberos.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: -24h

--- a/tests/endpoint/windows_diskshadow_proxy_execution.test.yml
+++ b/tests/endpoint/windows_diskshadow_proxy_execution.test.yml
@@ -1,6 +1,6 @@
-name: Windows Diskshadow proxy execution Unit Test
+name: Windows Diskshadow Proxy Execution Unit Test
 tests:
-- name: Windows Diskshadow proxy execution
+- name: Windows Diskshadow Proxy Execution
   file: endpoint/windows_diskshadow_proxy_execution.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: '-24h'

--- a/tests/endpoint/windows_indirect_command_execution_via_forfiles.test.yml
+++ b/tests/endpoint/windows_indirect_command_execution_via_forfiles.test.yml
@@ -1,6 +1,6 @@
-name: Windows Indirect Command Execution via forfiles Unit Test
+name:Windows Indirect Command Execution Via forfiles Unit Test
 tests:
-- name: Windows Indirect Command Excecution via forfiles
+- name: Windows Indirect Command Execution Via forfiles
   file: endpoint/windows_indirect_command_execution_via_forfiles.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: '-24h'

--- a/tests/endpoint/windows_indirect_command_execution_via_forfiles.test.yml
+++ b/tests/endpoint/windows_indirect_command_execution_via_forfiles.test.yml
@@ -1,4 +1,4 @@
-name:Windows Indirect Command Execution Via forfiles Unit Test
+name: Windows Indirect Command Execution Via forfiles Unit Test
 tests:
 - name: Windows Indirect Command Execution Via forfiles
   file: endpoint/windows_indirect_command_execution_via_forfiles.yml

--- a/tests/endpoint/windows_multi_hop_proxy_tor_website_query.test.yml
+++ b/tests/endpoint/windows_multi_hop_proxy_tor_website_query.test.yml
@@ -1,6 +1,6 @@
-name: Windows Multi-hop Proxy TOR Website Query Unit Test
+name: Windows Multi hop Proxy TOR Website Query Unit Test
 tests:
-- name: Windows Multi-hop Proxy TOR Website Query
+- name: Windows Multi hop Proxy TOR Website Query
   file: endpoint/windows_multi_hop_proxy_tor_website_query.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: -24h

--- a/tests/endpoint/windows_service_created_with_suspicious_service_path.test.yml
+++ b/tests/endpoint/windows_service_created_with_suspicious_service_path.test.yml
@@ -1,6 +1,6 @@
-name: Windows Service Created With Suspicious Service Path Unit Test
+name: Windows Service Created with Suspicious Service Path Unit Test
 tests:
-- name: Windows Service Created With Suspicious Service Path
+- name: Windows Service Created with Suspicious Service Path
   file: endpoint/windows_service_created_with_suspicious_service_path.yml
   pass_condition: '| stats count | where count > 0'
   earliest_time: -24h


### PR DESCRIPTION
This is a minor change that does not affect content at all.

A small number of tests contained an incorrect name for their related detections.
This fix has been made for the tests in question.
