### PR TITLE
add crowdstrike fdr to baseline

### DIFF
--- a/bin/docker_detection_tester/modules/validate_args.py
+++ b/bin/docker_detection_tester/modules/validate_args.py
@@ -77,7 +77,7 @@ setup_schema = {
                 "Splunk Add-on for CrowdStrike FDR": {
                     "app_number": 5579,
                     "app_version": "1.2.0",
-                    "http_path": "https://attack-range-appbinaries/Latest/splunk-add-on-for-crowdstrike-fdr_120.tgz"
+                    "http_path": "https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/Latest/splunk-add-on-for-crowdstrike-fdr_120.tgz"
                   },
                 "ADD_ON_FOR_LINUX_SYSMON": {
                     "app_number": 6176,

--- a/bin/docker_detection_tester/modules/validate_args.py
+++ b/bin/docker_detection_tester/modules/validate_args.py
@@ -74,7 +74,11 @@ setup_schema = {
             "default": {
                
                 # The default apps below were taken from the attack_range loadout: https://github.com/splunk/attack_range/blob/develop/attack_range.conf.template
-
+                "Splunk Add-on for CrowdStrike FDR": {
+                    "app_number": 5579,
+                    "app_version": "1.2.0",
+                    "http_path": "https://attack-range-appbinaries/Latest/splunk-add-on-for-crowdstrike-fdr_120.tgz"
+                  },
                 "ADD_ON_FOR_LINUX_SYSMON": {
                     "app_number": 6176,
                     "app_version": "1.0.4",

--- a/bin/docker_detection_tester/test_config_github_actions.json
+++ b/bin/docker_detection_tester/test_config_github_actions.json
@@ -1,5 +1,10 @@
 {
   "apps": {
+      "Splunk Add-on for CrowdStrike FDR": {
+        "app_number": 5579,
+        "app_version": "1.2.0",
+        "http_path": "https://attack-range-appbinaries/Latest/splunk-add-on-for-crowdstrike-fdr_120.tgz"
+      },
       "ADD_ON_FOR_LINUX_SYSMON": {
         "app_number": 6176,
         "app_version": "1.0.4",

--- a/bin/docker_detection_tester/test_config_github_actions.json
+++ b/bin/docker_detection_tester/test_config_github_actions.json
@@ -3,7 +3,7 @@
       "Splunk Add-on for CrowdStrike FDR": {
         "app_number": 5579,
         "app_version": "1.2.0",
-        "http_path": "https://attack-range-appbinaries/Latest/splunk-add-on-for-crowdstrike-fdr_120.tgz"
+        "http_path": "https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/Latest/splunk-add-on-for-crowdstrike-fdr_120.tgz"
       },
       "ADD_ON_FOR_LINUX_SYSMON": {
         "app_number": 6176,


### PR DESCRIPTION
adding the crowdstrike fdr app to the baseline
in order to support ingestion of crowdstrike fdr data:
https://splunkbase.splunk.com/app/5579