### PR TITLE
Change Process.process_name to Processes.process_name

### DIFF
--- a/detections/endpoint/windows_cached_domain_credentials_reg_query.yml
+++ b/detections/endpoint/windows_cached_domain_credentials_reg_query.yml
@@ -13,7 +13,7 @@ description: The following analytic identifies a process command line related to
   Windows Server 2008. 
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where  `process_reg` AND Processes.process = "* query *" AND Processes.process = "*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*" AND Processes.process = "*CACHEDLOGONSCOUNT*"
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_change_default_file_association_for_no_file_ext.yml
+++ b/detections/endpoint/windows_change_default_file_association_for_no_file_ext.yml
@@ -12,7 +12,7 @@ description: This analytic is developed to detect suspicious process commandline
   like .txt to notepad.exe. 
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime  from datamodel=Endpoint.Processes 
   where `process_reg` AND Processes.process="* add *" AND Processes.process="* HKCR\\*" AND Processes.process="*\\shell\\open\\command*" AND  Processes.process= *Notepad.exe*
-  by  Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
+  by  Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)` 
   | rex field=process "Notepad\.exe (?<file_name_association>.*$)" 
   | rex field=file_name_association "\.(?<extension>[^\.]*$)"

--- a/detections/endpoint/windows_credentials_from_password_stores_query.yml
+++ b/detections/endpoint/windows_credentials_from_password_stores_query.yml
@@ -12,7 +12,7 @@ description: The following analytic identifies a process execution of Windows OS
   to gain privilege escalation and persistence in the targeted hosts for further attacks.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where Processes.process_name="cmdkey.exe" OR Processes.original_file_name = "cmdkey.exe" AND Processes.process = "*/list*"
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_credentials_in_registry_reg_query.yml
+++ b/detections/endpoint/windows_credentials_in_registry_reg_query.yml
@@ -14,7 +14,7 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   where `process_reg` AND Processes.process = "* query *" AND Processes.process IN ("*\\Software\\ORL\\WinVNC3\\Password*", 
   "*\\SOFTWARE\\RealVNC\\WinVNC4 /v password*", "*\\CurrentControlSet\\Services\\SNMP*", "*\\Software\\TightVNC\\Server*", 
   "*\\Software\\SimonTatham\\PuTTY\\Sessions*", "*\\Software\\OpenSSH\\Agent\\Keys*", "*password*")
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_information_discovery_fsutil.yml
+++ b/detections/endpoint/windows_information_discovery_fsutil.yml
@@ -12,7 +12,7 @@ description: The following analytic identifies a process execution of Windows OS
   WINPEAS post exploitation tool that is being used by ransomware prestige to gain privilege and persistence to the targeted host.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where Processes.process_name="fsutil.exe" OR Processes.original_file_name = "fsutil.exe" AND Processes.process = "*fsinfo*"
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_modify_registry_reg_restore.yml
+++ b/detections/endpoint/windows_modify_registry_reg_restore.yml
@@ -12,7 +12,7 @@ description: The following analytic identifies a process execution of reg.exe wi
   registry modification restriction in targeted host after gaining access to it.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where  `process_reg` AND Processes.process = "* restore *" 
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_password_managers_discovery.yml
+++ b/detections/endpoint/windows_password_managers_discovery.yml
@@ -15,7 +15,7 @@ description: The following analytic identifies a process command line that retri
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where Processes.process = "*dir *" OR  Processes.process = "*findstr*"
   AND Processes.process IN ( "*.kdbx*", "*credential*", "*key3.db*","*pass*", "*cred*", "*key4.db*", "*accessTokens*", "*access_tokens*", "*.htpasswd*", "*Ntds.dit*")
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_private_keys_discovery.yml
+++ b/detections/endpoint/windows_private_keys_discovery.yml
@@ -14,7 +14,7 @@ description: The following analytic identifies a process command line that retri
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where Processes.process = "*dir *" OR  Processes.process = "*findstr*"
   AND Processes.process IN ( "*.rdg*", "*.gpg*", "*.pgp*", "*.p12*", "*.der*", "*.csr*", "*.cer*", "*.ovpn*", "*.key*",  "*.ppk*", "*.p12*", "*.pem*", "*.pfx*", "*.p7b*", "*.asc*")
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_query_registry_reg_save.yml
+++ b/detections/endpoint/windows_query_registry_reg_save.yml
@@ -13,7 +13,7 @@ description: The following analytic identifies a process execution of reg.exe wi
   access to it.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where  `process_reg` AND Processes.process = "* save *" 
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_security_support_provider_reg_query.yml
+++ b/detections/endpoint/windows_security_support_provider_reg_query.yml
@@ -13,7 +13,7 @@ description: The following analytic identifies a process command line related to
   scrape password hashes or clear plain text passwords.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where `process_reg` AND Processes.process = "* query *" AND Processes.process = "*\\SYSTEM\\CurrentControlSet\\Control\\LSA*" Processes.process IN ("*RunAsPPL*" , "*LsaCfgFlags*")
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_service_stop_via_net__and_sc_application.yml
+++ b/detections/endpoint/windows_service_stop_via_net__and_sc_application.yml
@@ -12,7 +12,7 @@ description: This analytic identifies suspicious attempts to stop services on a 
   or files being processed or used by Windows OS Services.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime  from datamodel=Endpoint.Processes 
   where `process_net` OR  Processes.process_name = "sc.exe" OR Processes.original_file_name= "sc.exe" AND Processes.process="*stop*" 
-  by  Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
+  by  Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)` 
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 

--- a/detections/endpoint/windows_steal_or_forge_kerberos_tickets_klist.yml
+++ b/detections/endpoint/windows_steal_or_forge_kerberos_tickets_klist.yml
@@ -12,7 +12,7 @@ description: The following analytic identifies a process execution of Windows OS
   host. This hunting query can be a good pivot in possible kerberos attack or pass the hash technique. 
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where Processes.process_name="klist.exe" OR Processes.original_file_name = "klist.exe" Processes.parent_process_name IN ("cmd.exe", "powershell*")
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_system_network_config_discovery_display_dns.yml
+++ b/detections/endpoint/windows_system_network_config_discovery_display_dns.yml
@@ -13,7 +13,7 @@ description: The following analytic identifies a process command line that retri
   gathering network information.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where Processes.process_name="ipconfig.exe" OR Processes.original_file_name = "ipconfig.exe" AND Processes.process = "*/displaydns*"
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_system_network_connections_discovery_netsh.yml
+++ b/detections/endpoint/windows_system_network_connections_discovery_netsh.yml
@@ -13,7 +13,7 @@ description: The following analytic identifies a process execution of Windows OS
   TTP's threat behavior.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where `process_netsh`AND Processes.process = "* show *" Processes.process IN ("*state*", "*config*", "*wlan*", "*profile*")
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_system_user_discovery_via_quser.yml
+++ b/detections/endpoint/windows_system_user_discovery_via_quser.yml
@@ -15,7 +15,7 @@ description: The following analytic identifies a process execution of Windows OS
   and Date and time the user logged on.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where Processes.process_name="quser.exe" OR Processes.original_file_name = "quser.exe" 
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_wmi_process_and_service_list.yml
+++ b/detections/endpoint/windows_wmi_process_and_service_list.yml
@@ -14,7 +14,7 @@ description: The following analytic identifies suspicious process command line,
   related artifacts.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where `process_wmic` Processes.process IN ("*process list*", "*service list*")
-  by Process.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
+  by Processes.process_name Processes.original_file_name Processes.process Processes.process_id Processes.process_guid 
   Processes.parent_process_name Processes.parent_process Processes.parent_process_guid Processes.dest Processes.user 
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 


### PR DESCRIPTION
### Details
Found a small typo in a few searches, which was causing process_name to always be missing

### Checklist

- [x] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [x] Validated SPL logic.
- [x] Validated tags, description, and how to implement.
- [x] Verified references match analytic.
