### PR TITLE
Fix incorrect datamodel in a couple of searches

### DIFF
--- a/detections/endpoint/msmpeng_application_dll_side_loading.yml
+++ b/detections/endpoint/msmpeng_application_dll_side_loading.yml
@@ -15,7 +15,7 @@ search: '|tstats `security_content_summariesonly` values(Filesystem.file_path) a
   file_path count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Filesystem
   where (Filesystem.file_name = "msmpeng.exe" OR Filesystem.file_name = "mpsvc.dll")  AND
   Filesystem.file_path != "*\\Program Files\\windows defender\\*" by Filesystem.file_create_time
-  Filesystem.process_id  Filesystem.file_name Filesystem.user | `drop_dm_object_name(Processes)`
+  Filesystem.process_id  Filesystem.file_name Filesystem.user | `drop_dm_object_name(Filesystem)`
   | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `msmpeng_application_dll_side_loading_filter`'
 how_to_implement: To successfully implement this search you need to be ingesting information
   on process that include the name of the Filesystem responsible for the changes from

--- a/detections/endpoint/remcos_rat_file_creation_in_remcos_folder.yml
+++ b/detections/endpoint/remcos_rat_file_creation_in_remcos_folder.yml
@@ -13,7 +13,7 @@ description: This search is to detect file creation in remcos folder in appdata 
 search: '|tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime FROM datamodel=Endpoint.Filesystem where Filesystem.file_name IN ("*.dat")
   Filesystem.file_path = "*\\remcos\\*" by _time Filesystem.file_name Filesystem.file_path
-  Filesystem.dest Filesystem.file_create_time | `drop_dm_object_name(Processes)` |
+  Filesystem.dest Filesystem.file_create_time | `drop_dm_object_name(Filesystem)` |
   `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `remcos_rat_file_creation_in_remcos_folder_filter`'
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the process name, parent process, and command-line executions from your


### PR DESCRIPTION
Remcos RAT File Creation in Remcos Folder and Msmpeng Application DLL Side Loading are both incorrectly using `drop_dm_object_name(Processes)` instead of `drop_dm_object_name(Filesystem)`.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
