### PR TITLE
Update account_discovery_with_net_app.yml

### DIFF
--- a/detections/endpoint/account_discovery_with_net_app.yml
+++ b/detections/endpoint/account_discovery_with_net_app.yml
@@ -6,7 +6,7 @@ author: Teoderick Contreras, Splunk
 type: TTP
 datamodel:
 - Endpoint
-description: this search is to detect a potential account discovery series of command
+description: This search is to detect a potential account discovery series of command
   used by several malware or attack to recon the target machine. This technique is
   also seen in some note worthy malware like trickbot where it runs a cmd process,
   or even drop its module that will execute the said series of net command. This series
@@ -16,7 +16,7 @@ description: this search is to detect a potential account discovery series of co
 search: '| tstats `security_content_summariesonly` values(Processes.process) as process
   values(Processes.parent_process) as parent_process values(Processes.process_id)
   as process_id count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
-  where `process_net` AND (Processes.process="*user*" OR  Processes.process="*config*"
+  where `process_net` AND (Processes.process="* user *" OR  Processes.process="*config*"
   OR Processes.process="*view /all*") by  Processes.process_name Processes.dest Processes.user
   Processes.parent_process_name | where count >=5 | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `account_discovery_with_net_app_filter`'


### PR DESCRIPTION
Changed Processes.process="*user*" to Processes.process="* user *". Without the spaces, this could erroneously trigger on things in filepaths that have 'user' in the name such as mapping a new share:
```net.exe use e: /persistent:yes \\userdata\accounting```

Also minor change to description so it starts with a capital letter.

### Details

_What does this PR have in it? Screenshots are worth 1000 words 😄_

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
