### PR TITLE
fixing error with model dir and result column

### DIFF
--- a/detections/experimental/network/detect_suspicious_dns_txt_records_using_pretrained_model_in_dsdl.yml
+++ b/detections/experimental/network/detect_suspicious_dns_txt_records_using_pretrained_model_in_dsdl.yml
@@ -25,7 +25,7 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   | rename answer as text 
   | fields firstTime, lastTime, message_type,record_type,src,dest, text 
   | apply detect_suspicious_dns_txt_records_using_pretrained_model_in_dsdl 
-  | rename pred_is_unknown_proba as is_suspicious_score 
+  | rename predicted_is_unknown as is_suspicious_score 
   | where is_suspicious_score > 0.5 
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 

--- a/detections/experimental/network/detect_suspicious_dns_txt_records_using_pretrained_model_in_dsdl.yml
+++ b/detections/experimental/network/detect_suspicious_dns_txt_records_using_pretrained_model_in_dsdl.yml
@@ -41,7 +41,7 @@ how_to_implement: 'Steps to deploy detect suspicious DNS TXT records model into 
     deep learning model that needs to be deployed in DSDL app. Follow the steps
     for deployment here - `https://github.com/splunk/security_content/wiki/How-to-deploy-pre-trained-Deep-Learning-models-for-ESCU`.\
 
-  * Download the `artifacts .tar.gz` file from the link - TODO update link here=
+  * Download the `artifacts .tar.gz` file from the link - https://seal.splunkresearch.com/detect_suspicious_dns_txt_records_using_pretrained_model_in_dsdl.tar.gz
     Download the `detect_suspicious_dns_txt_records_using_pretrained_model_in_dsdl.ipynb`
     Jupyter notebook from https://github.com/splunk/security_content/notebooks\
 

--- a/notebooks/detect_suspicious_dns_txt_records_using_pretrained_model_in_dsdl.ipynb
+++ b/notebooks/detect_suspicious_dns_txt_records_using_pretrained_model_in_dsdl.ipynb
@@ -58,7 +58,7 @@
     "import pickle\n",
     "\n",
     "# global constants\n",
-    "MODEL_DIRECTORY = \"/srv/app/model/data/\"\n",
+    "MODEL_DIRECTORY = \"/srv/app/model/data/detect_suspicious_dns_txt_records_using_pretrained_model_in_dsdl/\"\n",
     "vocab_size = 10002\n",
     "embedding_dim = 64\n",
     "hidden_size = 64\n",
@@ -550,7 +550,7 @@
     "        is_unknown_probability_score.append(pred_proba)\n",
     "        is_unknown.append(pred)\n",
     "    output = pd.DataFrame()\n",
-    "    output['pred_is_unknown_proba'] = is_unknown_probability_score\n",
+    "    output['predicted_is_unknown'] = is_unknown_probability_score\n",
     "    output['pred_is_unknown'] = is_unknown\n",
     "    return output"
    ]


### PR DESCRIPTION
1. Fixed an issue with model directory, because model is extracted to a folder with name of the detection
2. Renamed a column in result 
<img width="1652" alt="Screen Shot 2023-01-24 at 2 44 23 PM" src="https://user-images.githubusercontent.com/107954762/214438324-616fe603-1c1e-4bb7-be16-0f534e2672fe.png">
3. Update the download link for the model in the yml file