### PR TITLE
Fix Macro and Sourcetypes in Test Files

### DIFF
--- a/detections/application/splunk_rce_via_splunk_secure_gateway__splunk_mobile_alerts_feature.yml
+++ b/detections/application/splunk_rce_via_splunk_secure_gateway__splunk_mobile_alerts_feature.yml
@@ -6,7 +6,7 @@ author: Rod Soto
 type: Hunting
 datamodel: []
 description: This hunting search provides information on possible exploitation attempts against Splunk Secure Gateway App Mobile Alerts feature in Splunk versions 9.0, 8.2.x, 8.1.x. An authenticated user can run arbitrary operating system commands remotely through the use of specially crafted requests to the mobile alerts feature in the Splunk Secure Gateway app. 
-search: '`splunkd_webx` uri_path="/servicesNS/nobody/splunk_secure_gateway/storage/collections/data/mobile_alerts*" sort="notification.created_at:-1" | table  clientip file host method uri_query sort | `splunk_rce_via_splunk_secure_gateway__splunk_mobile_alerts_feature_filter`'
+search: '`splunkda` uri_path="/servicesNS/nobody/splunk_secure_gateway/storage/collections/data/mobile_alerts*" sort="notification.created_at:-1" | table  clientip file host method uri_query sort | `splunk_rce_via_splunk_secure_gateway__splunk_mobile_alerts_feature_filter`'
 how_to_implement: This search only applies if Splunk Mobile Gateway is deployed in the vulnerable Splunk versions. 
 known_false_positives:  This detection does not require you to ingest any new data. The detection does require the ability to search the _internal index. Focus of this search is "uri_path=/servicesNS/nobody/splunk_secure_gateway/storage/collections/data/mobile_alerts*" which is the injection point.
 references:

--- a/detections/application/splunk_xss_in_save_table_dialog_header_in_search_page.yml
+++ b/detections/application/splunk_xss_in_save_table_dialog_header_in_search_page.yml
@@ -6,7 +6,7 @@ author: Rod Soto
 type: Hunting
 datamodel: []
 description: This is a hunting search to find persistent cross-site scripting XSS code that was included while inputing data in 'Save Table' dialog in Splunk Enterprise (8.1.12,8.2.9,9.0.2). A remote user with "power" Splunk role can store this code that can lead to persistent cross site scripting.
-search: '`splunkda` method=POST  uri=/en-US/splunkd/__raw/servicesNS/nobody/search/datamodel/model | table _time host status clientip user uri | `splunk_xss_in_save_table_dialog_header_in_search_page_filter`'
+search: '`splunkd_webx` method=POST  uri=/en-US/splunkd/__raw/servicesNS/nobody/search/datamodel/model | table _time host status clientip user uri | `splunk_xss_in_save_table_dialog_header_in_search_page_filter`'
 how_to_implement: Watch for POST requests combined with XSS script strings or obfuscation against the injection point /en-US/splunkd/__raw/servicesNS/nobody/search/datamodel/model.
 known_false_positives: If host is vulnerable and XSS script strings are inputted they will show up in search. Not all Post requests are malicious as they will show when users create and save dashboards. This search may produce several results with non malicious POST requests. Only affects Splunk Web enabled instances. 
 references:

--- a/macros/splunkd_webx.yml
+++ b/macros/splunkd_webx.yml
@@ -1,4 +1,4 @@
-definition: index=_internal sourcetype=access_combined_wcookie 
+definition: index=_internal sourcetype=splunk_web_access
 description: customer specific splunk configurations(eg- index, source, sourcetype).
   Replace the macro definition with configurations for your Splunk Environmnent.
 name: splunkd_webx

--- a/tests/application/splunk_rce_via_splunk_secure_gateway__splunk_mobile_alerts_feature.test.yml
+++ b/tests/application/splunk_rce_via_splunk_secure_gateway__splunk_mobile_alerts_feature.test.yml
@@ -8,7 +8,7 @@ tests:
   attack_data:
   - file_name: splunk_rce_via_secure_gateway_splunk_mobile_alerts_feature.txt
     data: https://raw.githubusercontent.com/splunk/attack_data/master/datasets/attack_techniques/T1210/splunk/splunk_rce_via_secure_gateway_splunk_mobile_alerts_feature.txt
-    source: /opt/splunk/var/log/splunk/web_access.log
-    sourcetype: access_combined_wcookie
+    source: /opt/splunk/var/log/splunk/splunkd_access.log
+    sourcetype: splunkd_access
     custom_index: _internal 
     update_timestamp: true

--- a/tests/application/splunk_reflected_xss_in_the_templates_lists_radio.test.yml
+++ b/tests/application/splunk_reflected_xss_in_the_templates_lists_radio.test.yml
@@ -9,6 +9,6 @@ tests:
   - file_name: splunk_reflected_xss_in_templates_lists_radio.txt
     data: https://raw.githubusercontent.com/splunk/attack_data/master/datasets/attack_techniques/T1189/splunk/splunk_reflected_xss_in_templates_lists_radio.txt
     source: /opt/splunk/var/log/splunk/web_access.log
-    sourcetype: access_combined_wcookie
+    sourcetype: splunk_web_access 
     custom_index: _internal
     update_timestamp: true

--- a/tests/application/splunk_stored_xss_via_data_model_objectname_field.test.yml
+++ b/tests/application/splunk_stored_xss_via_data_model_objectname_field.test.yml
@@ -9,6 +9,6 @@ tests:
   - file_name: splunk_stored_xss_via_data_model_objectname_field.txt
     data: https://raw.githubusercontent.com/splunk/attack_data/master/datasets/attack_techniques/T1189/splunk/splunk_stored_xss_via_data_model_objectname_field.txt
     source: /opt/splunk/var/log/splunk/web_access.log
-    sourcetype: access_combined_wcookie
+    sourcetype: splunk_web_access
     custom_index: _internal
     update_timestamp: true

--- a/tests/application/splunk_xss_in_save_table_dialog_header_in_search_page.test.yml
+++ b/tests/application/splunk_xss_in_save_table_dialog_header_in_search_page.test.yml
@@ -8,7 +8,7 @@ tests:
   attack_data:
   - file_name: splunk_xss_in_save_table_dialog_in_search_page.txt
     data: https://raw.githubusercontent.com/splunk/attack_data/master/datasets/attack_techniques/T1189/splunk/splunk_xss_in_save_table_dialog_in_search_page.txt
-    source: /opt/splunk/var/log/splunk/splunkd_access.log
-    sourcetype: splunkd_access
+    source: /opt/splunk/var/log/splunk/web_access.log
+    sourcetype: splunk_web_access
     custom_index: _internal 
     update_timestamp: true


### PR DESCRIPTION
Fixes a number of detections that use an incorrect sourcetype in their macro.
These detections pass testing because data is also replayed into the wrong
sourcetype.  
The relevant macro(s) and test files will be updated and test will be verified again.