### PR TITLE
Added "Lateral Movement" story back package

### DIFF
--- a/stories/deprecated/lateral_movement.yml
+++ b/stories/deprecated/lateral_movement.yml
@@ -1,0 +1,19 @@
+name: Lateral Movement
+id: 399d65dc-1f08-499b-a259-abd9051f38ad
+version: 2
+date: '2020-02-04'
+author: David Dorsey, Splunk
+type: batch
+description: " DEPRECATED IN FAVOR OF ACTIVE DIRECTORY LATERAL MOVEMENT. Detect and investigate tactics, techniques, and procedures around how attackers move laterally within the enterprise. Because lateral movement can expose the adversary to detection, it should be an important focus for security analysts."
+narrative: "Once attackers gain a foothold within an enterprise, they will seek to expand their accesses and leverage techniques that facilitate lateral movement. Attackers will often spend quite a bit of time and effort moving laterally. Because lateral movement renders an attacker the most vulnerable to detection, it's an excellent focus for detection and investigation. Indications of lateral movement can include the abuse of system utilities (such as `psexec.exe`), unauthorized use of remote desktop services, `file/admin$` shares, WMI, PowerShell, pass-the-hash, or the abuse of scheduled tasks. Organizations must be extra vigilant in detecting lateral movement techniques and look for suspicious activity in and around high-value strategic network assets, such as Active Directory, which are often considered the primary target or \"crown jewels\" to a persistent threat actor. An adversary can use lateral movement for multiple purposes, including remote execution of tools, pivoting to additional systems, obtaining access to specific information or files, access to additional credentials, exfiltrating data, or delivering a secondary effect. Adversaries may use legitimate credentials alongside inherent network and operating-system functionality to remotely connect to other systems and remain under the radar of network defenders. If there is evidence of lateral movement, it is imperative for analysts to collect evidence of the associated offending hosts. For example, an attacker might leverage host A to gain access to host B. From there, the attacker may try to move laterally to host C. In this example, the analyst should gather as much information as possible from all three hosts. It is also important to collect authentication logs for each host, to ensure that the offending accounts are well-documented. Analysts should account for all processes to ensure that the attackers did not install unauthorized software."
+references:
+- https://www.fireeye.com/blog/executive-perspective/2015/08/malware_lateral_move.html
+tags:
+  analytic_story: Lateral Movement
+  category:
+  - Adversary Tactics
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  usecase: Advanced Threat Detection


### PR DESCRIPTION
### Details

In ~ December '21, the "Lateral Movement" analytic story was renamed which caused an issue for any consumers of this app that had previously modified that story without cloning it. This PR adds it back as a deprecated story, with a note referencing the "Active Directory Lateral Movement" story that this was originally renamed to.

### Checklist

- [x] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [x] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [x] Validated SPL logic.
- [x] Validated tags, description, and how to implement.
- [x] Verified references match analytic.
