### PR TITLE
Made ransomware notes lookup case insensitive.

### DIFF
--- a/dist/escu/default/transforms.conf
+++ b/dist/escu/default/transforms.conf
@@ -338,6 +338,7 @@ case_sensitive_match = false
 # description = A list of file extensions that are associated with ransomware
 match_type = WILDCARD(Extensions)
 min_matches = 1
+case_sensitive_match = false
 
 [ransomware_notes_lookup]
 filename = ransomware_notes.csv
@@ -345,6 +346,7 @@ default_match = false
 # description = A list of file names that are ransomware note files
 match_type = WILDCARD(ransomware_notes)
 min_matches = 1
+case_sensitive_match = false
 
 [remote_access_software]
 filename = remote_access_software.csv

--- a/lookups/ransomware_notes_lookup.yml
+++ b/lookups/ransomware_notes_lookup.yml
@@ -4,3 +4,4 @@ filename: ransomware_notes.csv
 match_type: WILDCARD(ransomware_notes)
 min_matches: 1
 name: ransomware_notes_lookup
+case_sensitive_match: 'false'


### PR DESCRIPTION
### Details

Made ransomware_notes_lookup case-insensitive. As most ransomware detection happens on Windows system, which writes file name as case insensitive manner. So its good idea to match them as case-insentive manner as well.

### Checklist

- [NA] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [x] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [x] Validated SPL logic.
- [NA] Validated tags, description, and how to implement.
- [NA] Verified references match analytic.
