### PR TITLE
Removing extra characters around field name

### DIFF
--- a/detections/application/okta_risk_threshold_exceeded.yml
+++ b/detections/application/okta_risk_threshold_exceeded.yml
@@ -22,7 +22,7 @@ search:
   dc(source) as source_count from datamodel=Risk.All_Risk by All_Risk.risk_object,All_Risk.risk_object_type
   All_Risk.analyticstories | `drop_dm_object_name("All_Risk")` | eval "annotations.mitre_attack"="annotations.mitre_attack.mitre_technique_id",
   risk_threshold=100 | where All_Risk.analyticstories IN ("Suspicious Okta Activity",
-  "Okta MFA Exhaustion")  risk_score > $risk_threshold$ | `get_risk_severity(risk_score)`
+  "Okta MFA Exhaustion")  risk_score > risk_threshold | `get_risk_severity(risk_score)`
   | `okta_risk_threshold_exceeded_filter`'
 how_to_implement:
   Ensure "Suspicious Okta Activity" and "Okta MFA Exhaustion" analytic


### PR DESCRIPTION
### Details

Instead of `$risk_threshold$`, I think we just need `risk_threshold`

This resolves #2623 

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
