### PR TITLE
[TR-3094] Removed sfc.exe, which has frequent collisions with AMP for Endpoints

### DIFF
--- a/ssa_detections/endpoint/ssa___system_process_running_from_unexpected_location.yml
+++ b/ssa_detections/endpoint/ssa___system_process_running_from_unexpected_location.yml
@@ -2,15 +2,10 @@ name: System Process Running from Unexpected Location
 id: 28179107-099a-464a-94d3-08301e6c055f
 version: 4
 date: '2022-03-24'
-author: Jose Hernadnez, Ignacio Bermudez Corrales, Splunk
+author: Jose Hernandez, Ignacio Bermudez Corrales, Splunk
 type: Anomaly
 status: production
-description: An attacker tries might try to use different version of a system command
-  without overriding original, or they might try to avoid some detection running the
-  process from a different folder. This detection checks that a list of system processes
-  run inside C:\\Windows\System32 or C:\\Windows\SysWOW64 The list of system processes
-  has been extracted from https://github.com/splunk/security_content/blob/develop/lookups/is_windows_system_file.csv
-  and the original detection https://github.com/splunk/security_content/blob/develop/detections/system_processes_run_from_unexpected_locations.yml
+description: An attacker might try to use a different version of a system command without overriding the original, or they might try to avoid some detections by running the process from a different folder. This detection checks that a list of system processes are run inside C:\\Windows\System32 or C:\\Windows\SysWOW64. The list of system processes has been extracted from https://github.com/splunk/security_content/blob/develop/lookups/is_windows_system_file.csv and the original detection https://github.com/splunk/security_content/blob/develop/detections/system_processes_run_from_unexpected_locations.yml
 data_source:
 - Windows Security 4688
 search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(input_event,"time"),"long",

--- a/ssa_detections/endpoint/ssa___system_process_running_from_unexpected_location.yml
+++ b/ssa_detections/endpoint/ssa___system_process_running_from_unexpected_location.yml
@@ -1,6 +1,6 @@
 name: System Process Running from Unexpected Location
 id: 28179107-099a-464a-94d3-08301e6c055f
-version: 4
+version: 5
 date: '2022-03-24'
 author: Jose Hernandez, Ignacio Bermudez Corrales, Splunk
 type: Anomaly

--- a/ssa_detections/endpoint/ssa___system_process_running_from_unexpected_location.yml
+++ b/ssa_detections/endpoint/ssa___system_process_running_from_unexpected_location.yml
@@ -61,7 +61,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   OR process_file_name="sort.exe" OR process_file_name="snmptrap.exe" OR process_file_name="smss.exe"
   OR process_file_name="slui.exe" OR process_file_name="sihost.exe" OR process_file_name="sigverif.exe"
   OR process_file_name="shutdown.exe" OR process_file_name="shrpubw.exe" OR process_file_name="shadow.exe"
-  OR process_file_name="sfc.exe" OR process_file_name="setx.exe" OR process_file_name="setupugc.exe"
+  OR process_file_name="setx.exe" OR process_file_name="setupugc.exe"
   OR process_file_name="setupcl.exe" OR process_file_name="setspn.exe" OR process_file_name="sethc.exe"
   OR process_file_name="sessionmsg.exe" OR process_file_name="services.exe" OR process_file_name="secinit.exe"
   OR process_file_name="sdiagnhost.exe" OR process_file_name="sdclt.exe" OR process_file_name="sdchange.exe"


### PR DESCRIPTION
### Details

Removed sfc.exe from `System Process Running from Unexpected Location`, which has frequent collisions with AMP for Endpoints' `SourceFire Collector`

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
