### PR TITLE
Nterl0k - T1087.002 - 4662 EventID AD Enumeration

### DIFF
--- a/detections/endpoint/windows_ad_abnormal_object_access_activity.yml
+++ b/detections/endpoint/windows_ad_abnormal_object_access_activity.yml
@@ -10,15 +10,14 @@ access to these objects may be evidence of attacker enumeration of Active Direct
 data_source:
 - Windows Security Event ID 4662
 search: '`wineventlog_security` EventCode=4662  
-| eval user = Caller_User_Name
 | `windows_ad_abnormal_object_access_filter`
-| stats min(_time) AS firstTime, max(_time) AS lastTime, dc(ObjectName) AS ObjectName_count, values(ObjectType) AS ObjectType, latest(Computer) AS dest count BY user
+| stats min(_time) AS firstTime, max(_time) AS lastTime, dc(ObjectName) AS ObjectName_count, values(ObjectType) AS ObjectType, latest(Computer) AS dest count BY SubjectUserName
 | eventstats avg(ObjectName_count) AS average stdev(ObjectName_count) AS standarddev
-| eval limit = round((average+(standarddev*3)),0) 
+| eval limit = round((average+(standarddev*3)),0), user = SubjectUserName 
 | where ObjectName_count > limit
 | `security_content_ctime(firstTime)` 
 | `security_content_ctime(lastTime)`'
-how_to_implement: Enabled Audit Directory Service Access via GPO and collect event code 4662 for relevant objects. Be aware
+how_to_implement: Enable Audit Directory Service Access via GPO and collect event code 4662 for relevant objects. Be aware
 Splunk filters this event by default on the Windows TA. Recommend pre-filtering any known service accounts that 
 frequently query AD to make detection more accurate. Setting wide search window of 48~72hr may smooth out misfires.
 known_false_positives: Service accounts or applications that routinely query Active Directory for information. 

--- a/detections/endpoint/windows_ad_abnormal_object_access_activity.yml
+++ b/detections/endpoint/windows_ad_abnormal_object_access_activity.yml
@@ -1,0 +1,61 @@
+name: Windows AD Abnormal Object Access Activity
+id: 71b289db-5f2c-4c43-8256-8bf26ae7324a
+version: 1
+date: '2023-06-01'
+author: Steven Dick
+status: production
+type: TTP
+description: Windows Active Directory contains numerous objects. A statistically significant increase in 
+access to these objects may be evidence of attacker enumeration of Active Directory..
+data_source:
+- Windows Security Event ID 4662
+search: '`wineventlog_security` EventCode=4662  
+| eval user = Caller_User_Name
+| `windows_ad_abnormal_object_access_filter`
+| stats min(_time) AS firstTime, max(_time) AS lastTime, dc(ObjectName) AS ObjectName_count, values(ObjectType) AS ObjectType, latest(Computer) AS dest count BY user
+| eventstats avg(ObjectName_count) AS average stdev(ObjectName_count) AS standarddev
+| eval limit = round((average+(standarddev*3)),0) 
+| where ObjectName_count > limit
+| `security_content_ctime(firstTime)` 
+| `security_content_ctime(lastTime)`'
+how_to_implement: Enabled Audit Directory Service Access via GPO and collect event code 4662 for relevant objects. Be aware
+Splunk filters this event by default on the Windows TA. Recommend pre-filtering any known service accounts that 
+frequently query AD to make detection more accurate. Setting wide search window of 48~72hr may smooth out misfires.
+known_false_positives: Service accounts or applications that routinely query Active Directory for information. 
+references:
+- https://medium.com/securonix-tech-blog/detecting-ldap-enumeration-and-bloodhound-s-sharphound-collector-using-active-directory-decoys-dfc840f2f644
+- https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4662
+tags:
+  analytic_story:
+  - Active Directory Discovery
+  asset_type: Endpoint
+  confidence: 50
+  impact: 50
+  message: The account $user$ accessed an abnormal amount ($ObjectName_count$) of [$ObjectType$] AD object(s) between $firstTime$ and $lastTime$.
+  mitre_attack_id:
+  - T1087
+  - T1087.002
+  observable:
+  - name: user
+    type: username
+    role:
+    - Victim
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - EventCode
+  - ObjectName 
+  - EventCode
+  - Caller_User_Name
+  risk_score: 25
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1087/4662_ad_enum/4662_priv_events.log
+    source: XmlWinEventLog:Security
+    sourcetype: XmlWinEventLog
+    update_timestamp: true

--- a/detections/endpoint/windows_ad_privileged_object_access_activity.yml
+++ b/detections/endpoint/windows_ad_privileged_object_access_activity.yml
@@ -1,0 +1,85 @@
+name: Windows AD Privileged Object Access Activity
+id: dc2f58bc-8cd2-4e51-962a-694b963acde0
+version: 1
+date: '2023-06-01'
+author: Steven Dick
+status: production
+type: TTP
+description: Windows Active Directory contains numerous objects that grant elevated access to the 
+domain they reside in. These objects should be rarely accessed by normal users or processes. Access 
+attempts to one or more of these objects may be evidence of attacker enumeration of Active Directory.
+data_source:
+- Windows Security Event ID 4662
+search: '`wineventlog_security` EventCode=4662 ObjectName IN (
+"CN=Account Operators,*",
+"CN=Administrators,*",
+"CN=Backup Operators,*",
+"CN=Cert Publishers,*",
+"CN=Certificate Service DCOM Access,*",
+"CN=Domain Admins,*",
+"CN=Domain Controllers,*",
+"CN=Enterprise Admins,*",
+"CN=Enterprise Read-only Domain Controllers,*",
+"CN=Group Policy Creator Owners,*",
+"CN=Incoming Forest Trust Builders,*",
+"CN=Microsoft Exchange Servers,*",
+"CN=Network Configuration Operators,*",
+"CN=Power Users,*",
+"CN=Print Operators,*",
+"CN=Read-only Domain Controllers,*",
+"CN=Replicators,*",
+"CN=Schema Admins,*",
+"CN=Server Operators,*",
+"CN=Exchange Trusted Subsystem,*",
+"CN=Exchange Windows Permission,*",
+"CN=Organization Management,*")
+| rex field=ObjectName "CN\=(?<object>[^,]+)" 
+| stats values(Computer) as dest, values(object) as object, dc(ObjectName) as object_count, min(_time) as firstTime, max(_time) as lastTime, count by Caller_User_Name
+| `security_content_ctime(firstTime)` 
+| `security_content_ctime(lastTime)`
+| eval user = Caller_User_Name, risk_score = case(object_count=1,40,object_count>1,object_count*30,true(),40)
+| `windows_ad_privileged_object_access_filter`'
+how_to_implement: Enabled Audit Directory Service Access via GPO and collect event code 4662 for relevant objects. Be aware
+Splunk filters this event by default on the Windows TA.
+known_false_positives: Service accounts or applications that routinely query Active Directory for information. 
+references:
+- https://medium.com/securonix-tech-blog/detecting-ldap-enumeration-and-bloodhound-s-sharphound-collector-using-active-directory-decoys-dfc840f2f644
+- https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4662
+tags:
+  analytic_story:
+  - Active Directory Discovery
+  asset_type: Endpoint
+  confidence: 50
+  impact: 50
+  message: The account $user$ accessed $object_count$ privileged AD object(s).
+  mitre_attack_id:
+  - T1087
+  - T1087.002
+  observable:
+  - name: user
+    type: username
+    role:
+    - Victim
+  - name: object
+    type: other
+    role:
+    - Attacker
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - EventCode
+  - ObjectName 
+  - EventCode
+  - Caller_User_Name
+  risk_score: 25
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1087/4662_ad_enum/4662_priv_events.log
+    source: XmlWinEventLog:Security
+    sourcetype: XmlWinEventLog
+    update_timestamp: true

--- a/detections/endpoint/windows_ad_privileged_object_access_activity.yml
+++ b/detections/endpoint/windows_ad_privileged_object_access_activity.yml
@@ -33,7 +33,7 @@ search: '`wineventlog_security` EventCode=4662 ObjectName IN (
 "CN=Exchange Trusted Subsystem,*",
 "CN=Exchange Windows Permission,*",
 "CN=Organization Management,*")
-| rex field=ObjectName "CN\=(?<object>[^,]+)" 
+| rex field=ObjectName "CN\=(?<object_name>[^,]+)" 
 | stats values(Computer) as dest, values(object_name) as object_name, dc(ObjectName) as object_count, min(_time) as firstTime, max(_time) as lastTime, count by SubjectUserName
 | `security_content_ctime(firstTime)` 
 | `security_content_ctime(lastTime)`

--- a/detections/endpoint/windows_ad_privileged_object_access_activity.yml
+++ b/detections/endpoint/windows_ad_privileged_object_access_activity.yml
@@ -39,7 +39,7 @@ search: '`wineventlog_security` EventCode=4662 ObjectName IN (
 | `security_content_ctime(lastTime)`
 | eval user = SubjectUserName, risk_score = case(object_count=1,40,object_count>1,object_count*30,true(),40)
 | `windows_ad_privileged_object_access_filter`'
-how_to_implement: Enabled Audit Directory Service Access via GPO and collect event code 4662 for relevant objects. Be aware
+how_to_implement: Enable Audit Directory Service Access via GPO and collect event code 4662 for relevant objects. Be aware
 Splunk filters this event by default on the Windows TA.
 known_false_positives: Service accounts or applications that routinely query Active Directory for information. 
 references:

--- a/detections/endpoint/windows_ad_privileged_object_access_activity.yml
+++ b/detections/endpoint/windows_ad_privileged_object_access_activity.yml
@@ -34,7 +34,7 @@ search: '`wineventlog_security` EventCode=4662 ObjectName IN (
 "CN=Exchange Windows Permission,*",
 "CN=Organization Management,*")
 | rex field=ObjectName "CN\=(?<object>[^,]+)" 
-| stats values(Computer) as dest, values(object) as object, dc(ObjectName) as object_count, min(_time) as firstTime, max(_time) as lastTime, count by SubjectUserName
+| stats values(Computer) as dest, values(object_name) as object_name, dc(ObjectName) as object_count, min(_time) as firstTime, max(_time) as lastTime, count by SubjectUserName
 | `security_content_ctime(firstTime)` 
 | `security_content_ctime(lastTime)`
 | eval user = SubjectUserName, risk_score = case(object_count=1,40,object_count>1,object_count*30,true(),40)
@@ -60,7 +60,7 @@ tags:
     type: username
     role:
     - Victim
-  - name: object
+  - name: object_name
     type: other
     role:
     - Attacker

--- a/detections/endpoint/windows_ad_privileged_object_access_activity.yml
+++ b/detections/endpoint/windows_ad_privileged_object_access_activity.yml
@@ -34,10 +34,10 @@ search: '`wineventlog_security` EventCode=4662 ObjectName IN (
 "CN=Exchange Windows Permission,*",
 "CN=Organization Management,*")
 | rex field=ObjectName "CN\=(?<object>[^,]+)" 
-| stats values(Computer) as dest, values(object) as object, dc(ObjectName) as object_count, min(_time) as firstTime, max(_time) as lastTime, count by Caller_User_Name
+| stats values(Computer) as dest, values(object) as object, dc(ObjectName) as object_count, min(_time) as firstTime, max(_time) as lastTime, count by SubjectUserName
 | `security_content_ctime(firstTime)` 
 | `security_content_ctime(lastTime)`
-| eval user = Caller_User_Name, risk_score = case(object_count=1,40,object_count>1,object_count*30,true(),40)
+| eval user = SubjectUserName, risk_score = case(object_count=1,40,object_count>1,object_count*30,true(),40)
 | `windows_ad_privileged_object_access_filter`'
 how_to_implement: Enabled Audit Directory Service Access via GPO and collect event code 4662 for relevant objects. Be aware
 Splunk filters this event by default on the Windows TA.


### PR DESCRIPTION
Pending https://github.com/splunk/attack_data/pull/816

### Details

Showcases when attackers enumerate AD in mass or for specific high priv (default) groups. 

Must allow 4662 events to be ingested by Splunk, which is typically advised against/filtered by the Windows TA.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
