### PR TITLE
Fix badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <a href="https://github.com/splunk/security_content/releases">
         <img src="https://img.shields.io/github/v/release/splunk/security_content" /></a>
     <a href="https://github.com/splunk/security_content/actions/workflows/build-and-validate.yml/badge.svg?branch=develop">
-        <img src="https://img.shields.io/github/workflow/status/splunk/security_content/build-and-validate/develop" /></a>
+        <img src="https://img.shields.io/github/actions/workflow/status/splunk/security_content/build-and-validate.yml?branch=develop" /></a>
     <a href="https://github.com/splunk/security_content">
         <img src="https://security-content.s3-us-west-2.amazonaws.com/reporting/detection_count.svg" /></a>
     <a href="https://github.com/splunk/security_content">


### PR DESCRIPTION
### Details

Resolution for [this](https://github.com/badges/shields/issues/8671) which was causing the badge to improperly display at the top of the README.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
