### PR TITLE
Minor fix for clop_common_exec_parameter detection

### DIFF
--- a/detections/endpoint/clop_common_exec_parameter.yml
+++ b/detections/endpoint/clop_common_exec_parameter.yml
@@ -14,7 +14,7 @@ description: The following analytics are designed to identifies some CLOP ransom
   since it is waiting for some parameter to execute properly.
 data_source:
 - Sysmon Event ID 1
-search: '| tstats `security_content_summariesonly`count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where Processes.process_name != "*temp.dat*" Processes.process = "*runrun*" OR Processes.process = "*temp.dat*"
   by Processes.dest Processes.user Processes.parent_process Processes.parent_process_name Processes.process_name Processes.process Processes.process_id Processes.parent_process_id
   | `drop_dm_object_name(Processes)`

--- a/detections/endpoint/clop_common_exec_parameter.yml
+++ b/detections/endpoint/clop_common_exec_parameter.yml
@@ -14,12 +14,10 @@ description: The following analytics are designed to identifies some CLOP ransom
   since it is waiting for some parameter to execute properly.
 data_source:
 - Sysmon Event ID 1
-search: '| tstats `security_content_summariesonly` values(Processes.process) as cmdline
-  values(Processes.parent_process_name) as parent_process values(Processes.process_name)
-  count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
-  where Processes.process_name != "*temp.dat*" Processes.process = "*runrun*" OR Processes.process
-  = "*temp.dat*" by Processes.dest Processes.user Processes.parent_process Processes.process_name
-  Processes.process Processes.process_id Processes.parent_process_id | `drop_dm_object_name(Processes)`
+search: '| tstats `security_content_summariesonly`count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
+  where Processes.process_name != "*temp.dat*" Processes.process = "*runrun*" OR Processes.process = "*temp.dat*"
+  by Processes.dest Processes.user Processes.parent_process Processes.parent_process_name Processes.process_name Processes.process Processes.process_id Processes.parent_process_id
+  | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `clop_common_exec_parameter_filter`'
 how_to_implement: To successfully implement this search you need to be ingesting information
   on process that include the name of the process responsible for the changes from


### PR DESCRIPTION
### Details
- Removing duplicate field references in aggregate part of tstats. Assuming there is no need for a cmdline and process field with the same information.
- adding parent_process_name to `by` part of tstats, in order for the risk_message and threat_object to work correctly


### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
