### PR TITLE
Risk objects require fields be present

### DIFF
--- a/detections/endpoint/windows_modify_registry_enablelinkedconnections.yml
+++ b/detections/endpoint/windows_modify_registry_enablelinkedconnections.yml
@@ -15,7 +15,7 @@ description: The following analytic identifies a suspicious registry modificatio
   By default, Windows does not enable this feature to enhance security.
 search: '| tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Registry 
   WHERE (Registry.registry_path= "*\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLinkedConnections" Registry.registry_value_data = "0x00000001") 
-  BY _time span=1h Registry.registry_path Registry.registry_key_name Registry.registry_value_name Registry.registry_value_data Registry.process_guid 
+  BY _time span=1h Registry.registry_path Registry.registry_key_name Registry.registry_value_name Registry.registry_value_data Registry.process_guid Registry.dest
   | `drop_dm_object_name(Registry)` 
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 

--- a/detections/endpoint/windows_modify_registry_longpathsenabled.yml
+++ b/detections/endpoint/windows_modify_registry_longpathsenabled.yml
@@ -15,7 +15,7 @@ description: The following analytic identifies a suspicious registry modificatio
   Enabling the LongPathsEnabled setting allows you to work with file paths longer than 260 characters.
 search: '| tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Registry 
   WHERE (Registry.registry_path= "*\\CurrentControlSet\\Control\\FileSystem\\LongPathsEnabled" Registry.registry_value_data = "0x00000001") 
-  BY _time span=1h Registry.registry_path Registry.registry_key_name Registry.registry_value_name Registry.registry_value_data Registry.process_guid 
+  BY _time span=1h Registry.registry_path Registry.registry_key_name Registry.registry_value_name Registry.registry_value_data Registry.process_guid Registry.dest
   | `drop_dm_object_name(Registry)` 
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 


### PR DESCRIPTION
### Details

Added a field to two detections so that risk objects could be created.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
