### PR TITLE
Nterl0k - [T1649] - I am certify-able.

### DIFF
--- a/detections/endpoint/detect_certify_command_line_arguments.yml
+++ b/detections/endpoint/detect_certify_command_line_arguments.yml
@@ -66,7 +66,7 @@ tags:
 tests:
 - name: True Positive Test
   attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse.log
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse_sysmon.log
     source: XmlWinEventLog:Security
     sourcetype: XmlWinEventLog
     update_timestamp: true

--- a/detections/endpoint/detect_certify_command_line_arguments.yml
+++ b/detections/endpoint/detect_certify_command_line_arguments.yml
@@ -1,0 +1,72 @@
+name: Detect Certify Command Line Arguments
+id: e6d2dc61-a8b9-4b03-906c-da0ca75d71b8
+version: 1
+date: '2023-06-25'
+author: Steven Dick
+status: production
+type: TTP
+description: The following analytic identifies when the attacker tool Certify or Certipy are used to enumerate Active Directory Certificate Services (AD CS) environments. The default command line arguments of these tools are similar and perform near identical enumeration or exploitation functions.
+data_source:
+- Windows Security Event ID 4688
+- Sysmon Event ID 1
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where Processes.process IN ("* find *","* auth *","* request *","* req *","* download *",) AND Processes.process IN ("* /vulnerable*","* /enrolleeSuppliesSubject *","* /json /outfile*","* /ca*", "* -username *","* -u *") by Processes.dest Processes.user Processes.parent_process Processes.process_name Processes.process Processes.process_id Processes.parent_process_id 
+| `drop_dm_object_name(Processes)` 
+| `security_content_ctime(firstTime)` 
+| `security_content_ctime(lastTime)`
+| `detect_certify_command_line_arguments_filter`'
+how_to_implement: To successfully implement this search, you need to be ingesting logs with the process name, parent process, and command-line executions from your endpoints.
+known_false_positives:  Unknown
+references:
+- https://github.com/GhostPack/Certify
+- https://github.com/ly4k/Certipy
+- https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+tags:
+  analytic_story:
+  - Windows Certificate Services
+  - Ingress Tool Transfer
+  asset_type: Endpoint
+  confidence: 90
+  impact: 100
+  message: Certify/Certipy arguments detected on $dest$.
+  mitre_attack_id:
+  - T1649
+  - T1105
+  observable:
+  - name: dest
+    type: hostname
+    role:
+    - Victim
+  - name: user
+    type: username
+    role:
+    - Victim	
+  - name: process
+    type: process
+    role:
+    - Attacker
+  - name: process_name
+    type: process_name
+    role:
+    - Attacker
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - Processes.dest 
+  - Processes.user 
+  - Processes.parent_process 
+  - Processes.process_name 
+  - Processes.process 
+  - Processes.process_id 
+  - Processes.parent_process_id 
+  risk_score: 90
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse.log
+    source: XmlWinEventLog:Security
+    sourcetype: XmlWinEventLog
+    update_timestamp: true

--- a/detections/endpoint/detect_certify_with_powershell_script_block_logging.yml
+++ b/detections/endpoint/detect_certify_with_powershell_script_block_logging.yml
@@ -63,7 +63,7 @@ tags:
 tests:
 - name: True Positive Test
   attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse.log
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse_powershell.log
     source: XmlWinEventLog:Security
     sourcetype: XmlWinEventLog
     update_timestamp: true

--- a/detections/endpoint/detect_certify_with_powershell_script_block_logging.yml
+++ b/detections/endpoint/detect_certify_with_powershell_script_block_logging.yml
@@ -1,0 +1,69 @@
+name: Detect Certify With PowerShell Script Block Logging
+id: f533ca6c-9440-4686-80cb-7f294c07812a
+version: 1
+date: '2023-06-25'
+author: Steven Dick
+status: production
+type: TTP
+description: The following analytic identifies when the attacker tool  Certify is used through an in-memory PowerShell function to enumerate Active Directory Certificate Services (AD CS) environments. The default command line arguments for the binary version of this tools are similar to PowerShell calls and perform near identical enumeration or exploitation functions.
+data_source:
+- PowerShell Event ID 4104
+search: '`powershell` EventCode=4104 (ScriptBlockText IN ("*find *") AND ScriptBlockText IN ("* /vulnerable*","* -vulnerable*","* /enrolleeSuppliesSubject *","* /json /outfile*")) OR (ScriptBlockText IN (,"*auth *","*req *",) AND ScriptBlockText IN ("* -ca *","* -username *","* -u *")) OR (ScriptBlockText IN ("*request *","*download *") AND ScriptBlockText IN ("* /ca:*"))
+| stats count min(_time) as firstTime max(_time) as lastTime list(ScriptBlockText) as command Values(OpCode) as reason values(Path) as file_name values(UserID) as user by _time Computer EventCode 
+| `security_content_ctime(firstTime)`
+| `security_content_ctime(lastTime)`
+| eval file_name = case(isnotnull(file_name),file_name,true(),"unknown")
+| eval signature = substr(command,0,256)
+| rename Computer as dest,EventCode as signature_id
+| `detect_certify_with_powershell_script_block_logging_filter`'
+how_to_implement: To successfully implement this analytic, you will need to enable PowerShell Script Block Logging on some or all endpoints. Additional setup here https://docs.splunk.com/Documentation/UBA/5.0.4.1/GetDataIn/AddPowerShell#Configure_module_logging_for_PowerShell..
+known_false_positives: Unknown, partial script block matches.  
+references:
+- https://github.com/GhostPack/Certify
+- https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+tags:
+  analytic_story:
+  - Windows Certificate Services
+  - Malicious PowerShell
+  asset_type: Endpoint
+  confidence: 90
+  impact: 100
+  message: Certify arguments through PowerShell detected on $dest$.
+  mitre_attack_id:
+  - T1649
+  - T1059
+  - T1059.001
+  observable:
+  - name: dest
+    type: hostname
+    role:
+    - Victim
+  - name: user
+    type: username
+    role:
+    - Victim	
+  - name: command
+    type: process
+    role:
+    - Attacker
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - ScriptBlockText
+  - OpCode
+  - Path
+  - user
+  - Computer 
+  - EventCode
+  risk_score: 90
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse.log
+    source: XmlWinEventLog:Security
+    sourcetype: XmlWinEventLog
+    update_timestamp: true

--- a/detections/endpoint/detect_certipy_file_modifications.yml
+++ b/detections/endpoint/detect_certipy_file_modifications.yml
@@ -79,7 +79,7 @@ tags:
 tests:
 - name: True Positive Test
   attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse.log
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse_sysmon.log
     source: XmlWinEventLog:Security
     sourcetype: XmlWinEventLog
     update_timestamp: true

--- a/detections/endpoint/detect_certipy_file_modifications.yml
+++ b/detections/endpoint/detect_certipy_file_modifications.yml
@@ -1,0 +1,85 @@
+name: Detect Certipy File Modifications
+id: 7e3df743-b1d8-4631-8fa8-bd5819688876
+version: 1
+date: '2023-06-25'
+author: Steven Dick
+status: production
+type: TTP
+description: The following analytic identifies when the attacker tool Certipy is used to enumerate an Active Directory Certificate Services (AD CS) environments. The default behavior of this toolkit drops a number of file uniquely named files or file extensions related to it's information gathering and exfiltration process.
+data_source:
+- Windows Security Event ID 4663
+- Sysmon Event ID 11,15,26
+search: '| tstats `security_content_summariesonly` count min(_time) AS firstTime max(_time) AS lastTime values(Processes.process_current_directory) as process_current_directory FROM datamodel=Endpoint.Processes where Processes.action="allowed" BY _time span=1h Processes.user Processes.dest Processes.process_id Processes.process_name Processes.process Processes.process_path Processes.parent_process_name Processes.parent_process Processes.process_guid Processes.action
+|`drop_dm_object_name(Processes)` 
+| join max=0 dest process_guid [| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Filesystem where Filesystem.file_name IN ("*_certipy.zip", "*_certipy.txt", "*_certipy.json", "*.ccache") by Filesystem.file_create_time Filesystem.process_id Filesystem.process_guid Filesystem.file_name Filesystem.file_path Filesystem.dest
+| `drop_dm_object_name(Filesystem)` 
+]
+| fields firstTime lastTime user dest file_create_time file_name file_path parent_process_name parent_process process_name process_path process_current_directory process process_guid process_id
+| where isnotnull(file_name)
+| `security_content_ctime(firstTime)` 
+| `security_content_ctime(lastTime)`
+| `detect_certipy_file_modifications_filter`'
+how_to_implement: To successfully implement this search, you need to be ingesting logs with the process name, parent process, and command-line executions from your endpoints as well as file creation or deletion events. 
+known_false_positives: Unknown
+references:
+- https://github.com/ly4k/Certipy
+tags:
+  analytic_story:
+  - Windows Certificate Services
+  - Data Exfiltration
+  - Ingress Tool Transfer
+  asset_type: Endpoint
+  confidence: 90
+  impact: 50
+  message: Suspicious files related to Certipy detected on $dest$
+  mitre_attack_id:
+  - T1649
+  - T1560
+  observable:
+  - name: dest
+    type: hostname
+    role:
+    - Victim
+  - name: user
+    type: username
+    role:
+    - Victim
+  - name: file_name
+    type: file_name
+    role:
+    - Attacker
+  - name: process_name
+    type: process_name
+    role:
+    - Attacker
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - Processes.user 
+  - Processes.dest 
+  - Processes.process_id 
+  - Processes.process_name 
+  - Processes.process 
+  - Processes.process_path 
+  - Processes.parent_process_name 
+  - Processes.parent_process 
+  - Processes.process_guid 
+  - Processes.action
+  - Filesystem.file_create_time 
+  - Filesystem.process_id 
+  - Filesystem.process_guid 
+  - Filesystem.file_name 
+  - Filesystem.file_path 
+  - Filesystem.dest
+  risk_score: 45
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse.log
+    source: XmlWinEventLog:Security
+    sourcetype: XmlWinEventLog
+    update_timestamp: true

--- a/detections/endpoint/detect_certipy_file_modifications.yml
+++ b/detections/endpoint/detect_certipy_file_modifications.yml
@@ -5,7 +5,7 @@ date: '2023-06-25'
 author: Steven Dick
 status: production
 type: TTP
-description: The following analytic identifies when the attacker tool Certipy is used to enumerate an Active Directory Certificate Services (AD CS) environments. The default behavior of this toolkit drops a number of file uniquely named files or file extensions related to it's information gathering and exfiltration process.
+description: The following analytic identifies when the attacker tool Certipy is used to enumerate Active Directory Certificate Services (AD CS) environments. The default behavior of this toolkit drops a number of file uniquely named files or file extensions related to it's information gathering and exfiltration process.
 data_source:
 - Windows Security Event ID 4663
 - Sysmon Event ID 11,15,26
@@ -31,7 +31,7 @@ tags:
   asset_type: Endpoint
   confidence: 90
   impact: 50
-  message: Suspicious files related to Certipy detected on $dest$
+  message: Suspicious files related to Certipy detected on $dest$.
   mitre_attack_id:
   - T1649
   - T1560

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
@@ -5,10 +5,7 @@ date: '2023-05-25'
 author: Steven Dick
 status: production
 type: TTP
-description: The following analytic identifies when a new certificate is requested and/or granted against the 
-Active Directory Certificate Services (AD CS) using a Subject Alternative Name (SAN). This action by its self 
-is not malicious, however improperly configured certificate templates can be abused to permit privilege 
-escalation and environment compromise due to over permissive settings (AD CS ESC1).
+description: The following analytic identifies when a new certificate is requested and/or granted against the Active Directory Certificate Services (AD CS) using a Subject Alternative Name (SAN). This action by its self is not malicious, however improperly configured certificate templates can be abused to permit privilege escalation and environment compromise due to over permissive settings (AD CS ESC1)
 data_source:
 - Windows Security Event ID 4886,4887
 search: '`wineventlog_security` EventCode IN (4886,4887) Attributes="*SAN:*upn*" Attributes="*CertificateTemplate:*"
@@ -28,12 +25,8 @@ dest = upper(coalesce(req_dest_1,req_dest_2)), src = upper(coalesce(req_src,Comp
 | fields - req_*
 | rename Attributes as object_attrs, EventCode as signature_id, name as signature, RequestId as ssl_serial, Requester as ssl_subject_common_name
 | `windows_steal_authentication_certificates_esc1_abuse_filter`'
-how_to_implement: To implement this analytic, enhanced Audit Logging must be enabled
-  on AD CS and within Group Policy Management for CS server. See Page 115 of first
-  reference. Recommend throttle correlation by RequestId/ssl_serial at minimum.
-known_false_positives: False positives may be generated in environments where administrative users or processes
-are allowed to generate certificates with Subject Alternative Names. Sources or templates used in these 
-processes may need to be tuned out for accurate function. 
+how_to_implement: To implement this analytic, enhanced Audit Logging must be enabled on AD CS and within Group Policy Management for CS server. See Page 115 of first reference. Recommend throttle correlation by RequestId/ssl_serial at minimum.
+known_false_positives: False positives may be generated in environments where administrative users or processes are allowed to generate certificates with Subject Alternative Names. Sources or templates used in these processes may need to be tuned out for accurate function. 
 references:
 - https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
 - https://github.com/ly4k/Certipy#esc1

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
@@ -1,0 +1,86 @@
+name: Windows Steal Authentication Certificates - ESC1 Abuse
+id: cbe761fc-d945-4c8c-a71d-e26d12255d32
+version: 1
+date: '2023-05-25'
+author: Steven Dick
+status: production
+type: TTP
+description: The following analytic identifies when a new certificate is requested and/or granted against the 
+Active Directory Certificate Services (AD CS) using a Subject Alternative Name (SAN). This action by its self 
+is not malicious, however improperly configured certificate templates can be abused to permit privilege 
+escalation and environment compromise due to over permissive settings (AD CS ESC1).
+data_source:
+- Windows Security Event ID 4886,4887
+search: '`wineventlog_security` EventCode IN (4886,4887) Attributes="*SAN:*upn*" Attributes="*CertificateTemplate:*"
+| stats count min(_time) as firstTime max(_time) as lastTime values(name) as name values(status) as status values(Subject) as ssl_subject values(SubjectKeyIdentifier) as ssl_hash by Computer, EventCode, Requester, Attributes, RequestId
+| `security_content_ctime(firstTime)` 
+| `security_content_ctime(lastTime)`
+| rex field=Attributes "(?i)CertificateTemplate:(?<object>[^\r\n]+)"
+| rex field=Attributes "(?i)ccm:(?<req_src>[^\r\n]+)"
+| rex max_match=10 field=Attributes "(?i)(upn=(?<req_user_1>[^\r\n&]+))"
+| rex max_match=10 field=Attributes "(?i)(dns=(?<req_dest_1>[^\r\n&]+))"
+| rex field=Requester "(.+\\\\)?(?<src_user>[^\r\n]+)"
+| eval flavor_text = case(EventCode=="4886","A suspicious certificate was requested using request ID: ".'RequestId',EventCode=="4887","A suspicious certificate was issued using request ID: ".'RequestId'.". To revoke this certifacte use this request ID or the SSL fingerprint [".'ssl_hash'."]"), risk_score = case(EventCode=="4886",40,EventCode=="4887",60), user = upper(coalesce(req_user_1,req_user_2)), dest = upper(coalesce(req_dest_1,req_dest_2)), src = upper(coalesce(req_src,Computer))
+| fields - req_*
+| rename Attributes as object_attrs, EventCode as signature_id, name as signature, RequestId as ssl_serial, Requester as ssl_subject_common_name
+| `windows_steal_authentication_certificates_esc1_abuse`'
+how_to_implement: To implement this analytic, enhanced Audit Logging must be enabled
+  on AD CS and within Group Policy Management for CS server. See Page 115 of first
+  reference. Recommend throttle correlation by RequestId/ssl_serial at minimum.
+known_false_positives: False positives may be generated in environments where administrative users or processes
+are allowed to generate certificates with Subject Alternative Names. Sources or templates used in these 
+processes may need to be tuned out for accurate function. 
+references:
+- https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+- https://github.com/ly4k/Certipy#esc1
+- https://pentestlaboratories.com/2021/11/08/threat-hunting-certificate-account-persistence/
+tags:
+  analytic_story:
+  - Windows Certificate Services
+  asset_type: Endpoint
+  confidence: 80
+  impact: 100
+  message: Possible AD CS ESC1 activity by $src_user$ - $flavor_text$
+  mitre_attack_id:
+  - T1649
+  observable:
+  - name: dest
+    type: hostname
+    role:
+    - Victim
+  - name: src_user
+    type: username
+    role:
+    - Victim
+  - name: user
+    type: username
+    role:
+    - Victim	
+  - name: ssl_hash
+    type: other
+    role:
+    - Attacker
+  - name: ssl_serial
+    type: other
+    role:
+    - Attacker
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - Attributes 
+  - Computer
+  - EventCode
+  - Requester
+  - RequestId
+  risk_score: 80
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certipy_abuse/certipy_esc1_abuse.log
+    source: XmlWinEventLog:Security
+    sourcetype: XmlWinEventLog
+    update_timestamp: true

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
@@ -12,7 +12,8 @@ escalation and environment compromise due to over permissive settings (AD CS ESC
 data_source:
 - Windows Security Event ID 4886,4887
 search: '`wineventlog_security` EventCode IN (4886,4887) Attributes="*SAN:*upn*" Attributes="*CertificateTemplate:*"
-| stats count min(_time) as firstTime max(_time) as lastTime values(name) as name values(status) as status values(Subject) as ssl_subject values(SubjectKeyIdentifier) as ssl_hash by Computer, EventCode, Requester, Attributes, RequestId
+| stats count min(_time) as firstTime max(_time) as lastTime values(name) as name values(status) as status values(Subject) as ssl_subject
+values(SubjectKeyIdentifier) as ssl_hash by Computer, EventCode, Requester, Attributes, RequestId
 | `security_content_ctime(firstTime)` 
 | `security_content_ctime(lastTime)`
 | rex field=Attributes "(?i)CertificateTemplate:(?<object>[^\r\n]+)"
@@ -20,7 +21,10 @@ search: '`wineventlog_security` EventCode IN (4886,4887) Attributes="*SAN:*upn*"
 | rex max_match=10 field=Attributes "(?i)(upn=(?<req_user_1>[^\r\n&]+))"
 | rex max_match=10 field=Attributes "(?i)(dns=(?<req_dest_1>[^\r\n&]+))"
 | rex field=Requester "(.+\\\\)?(?<src_user>[^\r\n]+)"
-| eval flavor_text = case(EventCode=="4886","A suspicious certificate was requested using request ID: ".'RequestId',EventCode=="4887","A suspicious certificate was issued using request ID: ".'RequestId'.". To revoke this certifacte use this request ID or the SSL fingerprint [".'ssl_hash'."]"), risk_score = case(EventCode=="4886",40,EventCode=="4887",60), user = upper(coalesce(req_user_1,req_user_2)), dest = upper(coalesce(req_dest_1,req_dest_2)), src = upper(coalesce(req_src,Computer))
+| eval flavor_text = case(EventCode=="4886","A suspicious certificate was requested using request ID: ".'RequestId',EventCode=="4887",
+"A suspicious certificate was issued using request ID: ".'RequestId'.". To revoke this certifacte use this request ID or the SSL fingerprint [".'ssl_hash'."]"),
+risk_score = case(EventCode=="4886",30,EventCode=="4887",60), user = upper(coalesce(req_user_1,req_user_2)), 
+dest = upper(coalesce(req_dest_1,req_dest_2)), src = upper(coalesce(req_src,Computer))
 | fields - req_*
 | rename Attributes as object_attrs, EventCode as signature_id, name as signature, RequestId as ssl_serial, Requester as ssl_subject_common_name
 | `windows_steal_authentication_certificates_esc1_abuse`'
@@ -38,7 +42,7 @@ tags:
   analytic_story:
   - Windows Certificate Services
   asset_type: Endpoint
-  confidence: 80
+  confidence: 60
   impact: 100
   message: Possible AD CS ESC1 activity by $src_user$ - $flavor_text$
   mitre_attack_id:
@@ -75,7 +79,7 @@ tags:
   - EventCode
   - Requester
   - RequestId
-  risk_score: 80
+  risk_score: 60
   security_domain: endpoint
 tests:
 - name: True Positive Test

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
@@ -84,7 +84,7 @@ tags:
 tests:
 - name: True Positive Test
   attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certipy_abuse/certipy_esc1_abuse.log
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse.log
     source: XmlWinEventLog:Security
     sourcetype: XmlWinEventLog
     update_timestamp: true

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
@@ -77,7 +77,7 @@ tags:
 tests:
 - name: True Positive Test
   attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse.log
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse_winsecurity.log
     source: XmlWinEventLog:Security
     sourcetype: XmlWinEventLog
     update_timestamp: true

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_abuse.yml
@@ -27,7 +27,7 @@ risk_score = case(EventCode=="4886",30,EventCode=="4887",60), user = upper(coale
 dest = upper(coalesce(req_dest_1,req_dest_2)), src = upper(coalesce(req_src,Computer))
 | fields - req_*
 | rename Attributes as object_attrs, EventCode as signature_id, name as signature, RequestId as ssl_serial, Requester as ssl_subject_common_name
-| `windows_steal_authentication_certificates_esc1_abuse`'
+| `windows_steal_authentication_certificates_esc1_abuse_filter`'
 how_to_implement: To implement this analytic, enhanced Audit Logging must be enabled
   on AD CS and within Group Policy Management for CS server. See Page 115 of first
   reference. Recommend throttle correlation by RequestId/ssl_serial at minimum.

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
@@ -1,0 +1,103 @@
+name: Windows Steal Authentication Certificates - ESC1 Authentication
+id: f0306acf-a6ab-437a-bbc6-8628f8d5c97e
+version: 1
+date: '2023-05-25'
+author: Steven Dick
+status: production
+type: TTP
+description: The following analytic identifies when a new certificate is granted against the Active Directory 
+Certificate Services (AD CS) using a Subject Alternative Name (SAN) and then immediately used for authentication.
+This action alone may not be malicious, however improperly configured certificate templates can be abused to 
+permit privilege escalation and environment compromise due to over permissive settings (AD CS ESC1).
+data_source:
+- Windows Security Event ID 4887,4768
+search: '`wineventlog_security` EventCode IN (4887) Attributes="*SAN:*upn*" Attributes="*CertificateTemplate:*"
+| stats count min(_time) as firstTime max(_time) as lastTime values(name) as name values(status) as status values(Subject) as ssl_subject 
+values(SubjectKeyIdentifier) as ssl_hash by Computer, EventCode, Requester, Attributes, RequestId
+| rex field=Attributes "(?i)CertificateTemplate:(?<object>[^\r\n]+)"
+| rex field=Attributes "(?i)ccm:(?<req_src>[^\r\n]+)"
+| rex max_match=10 field=Attributes "(?i)(upn=(?<req_user_1>[^\r\n&]+))"
+| rex max_match=10 field=Attributes "(?i)(dns=(?<req_dest_1>[^\r\n&]+))"
+| rex field=Requester "(.+\\\\)?(?<src_user>[^\r\n]+)"
+| rename Attributes as object_attrs, EventCode as signature_id, name as signature, RequestId as ssl_serial, Requester as ssl_subject_common_name
+| eval user = upper(coalesce(req_user_1,req_user_2))
+| join user
+    [
+    | search `wineventlog_security` EventCode=4768 CertThumbprint=*
+    | rename TargetUserName as user, Computer as auth_dest, IpAddress as auth_src
+    | fields auth_src,auth_dest,user
+    ]
+| eval src = upper(coalesce(auth_src,req_src)), dest = upper(coalesce(auth_dest,req_dest_1,req_dest_2)), risk_score = 80
+| eval flavor_text = case(signature_id=="4887", "User account [".'user'."] authenticated after a 
+suspicious certificate was issued for it by [".'src_user'."] using certificate request ID: ".'ssl_serial')
+| fields - req_* auth_*
+| `security_content_ctime(firstTime)` 
+| `security_content_ctime(lastTime)`
+| `windows_steal_authentication_certificates_esc1_auth`'
+how_to_implement: To implement this analytic, enhanced Audit Logging must be enabled
+  on AD CS and within Group Policy Management for CS server. See Page 115 of first
+  reference. Recommend throttle correlation by RequestId/ssl_serial at minimum.
+known_false_positives: False positives may be generated in environments where administrative users or processes
+are allowed to generate certificates with Subject Alternative Names. Sources or templates used in these 
+processes may need to be tuned out for accurate function. 
+references:
+- https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+- https://github.com/ly4k/Certipy#esc1
+- https://pentestlaboratories.com/2021/11/08/threat-hunting-certificate-account-persistence/
+tags:
+  analytic_story:
+  - Windows Certificate Services
+  asset_type: Endpoint
+  confidence: 80
+  impact: 100
+  message: Possible AD CS ESC1 authentication - $flavor_text$
+  mitre_attack_id:
+  - T1649
+  observable:
+  - name: src
+    type: hostname
+    role:
+    - Victim
+  - name: dest
+    type: hostname
+    role:
+    - Victim
+  - name: src_user
+    type: username
+    role:
+    - Victim
+  - name: user
+    type: username
+    role:
+    - Victim	
+  - name: ssl_hash
+    type: other
+    role:
+    - Attacker
+  - name: ssl_serial
+    type: other
+    role:
+    - Attacker
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - Attributes 
+  - Computer
+  - EventCode
+  - Requester
+  - RequestId
+  - TargetUserName
+  - Computer
+  - IpAddress
+  risk_score: 80
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certipy_abuse/certipy_esc1_abuse.log
+    source: XmlWinEventLog:Security
+    sourcetype: XmlWinEventLog
+    update_timestamp: true

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
@@ -89,7 +89,7 @@ tags:
 tests:
 - name: True Positive Test
   attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse.log
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse_winsecurity.log
     source: XmlWinEventLog:Security
     sourcetype: XmlWinEventLog
     update_timestamp: true

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
@@ -33,7 +33,7 @@ suspicious certificate was issued for it by [".'src_user'."] using certificate r
 | fields - req_* auth_*
 | `security_content_ctime(firstTime)` 
 | `security_content_ctime(lastTime)`
-| `windows_steal_authentication_certificates_esc1_auth`'
+| `windows_steal_authentication_certificates_esc1_auth_filter`'
 how_to_implement: To implement this analytic, enhanced Audit Logging must be enabled
   on AD CS and within Group Policy Management for CS server. See Page 115 of first
   reference. Recommend throttle correlation by RequestId/ssl_serial at minimum.

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
@@ -97,7 +97,7 @@ tags:
 tests:
 - name: True Positive Test
   attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certipy_abuse/certipy_esc1_abuse.log
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse.log
     source: XmlWinEventLog:Security
     sourcetype: XmlWinEventLog
     update_timestamp: true

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
@@ -5,15 +5,11 @@ date: '2023-05-25'
 author: Steven Dick
 status: production
 type: TTP
-description: The following analytic identifies when a new certificate is granted against the Active Directory 
-Certificate Services (AD CS) using a Subject Alternative Name (SAN) and then immediately used for authentication.
-This action alone may not be malicious, however improperly configured certificate templates can be abused to 
-permit privilege escalation and environment compromise due to over permissive settings (AD CS ESC1).
+description: The following analytic identifies when a suspicious certificate is granted using Active Directory Certificate Services (AD CS) with a Subject Alternative Name (SAN) and then immediately used for authentication. This action alone may not be malicious, however improperly configured certificate templates can be abused to permit privilege escalation and environment compromise due to over permissive settings (AD CS ESC1).
 data_source:
 - Windows Security Event ID 4887,4768
 search: '`wineventlog_security` EventCode IN (4887) Attributes="*SAN:*upn*" Attributes="*CertificateTemplate:*"
-| stats count min(_time) as firstTime max(_time) as lastTime values(name) as name values(status) as status values(Subject) as ssl_subject 
-values(SubjectKeyIdentifier) as ssl_hash by Computer, EventCode, Requester, Attributes, RequestId
+| stats count min(_time) as firstTime max(_time) as lastTime values(name) as name values(status) as status values(Subject) as ssl_subject values(SubjectKeyIdentifier) as ssl_hash by Computer, EventCode, Requester, Attributes, RequestId
 | rex field=Attributes "(?i)CertificateTemplate:(?<object>[^\r\n]+)"
 | rex field=Attributes "(?i)ccm:(?<req_src>[^\r\n]+)"
 | rex max_match=10 field=Attributes "(?i)(upn=(?<req_user_1>[^\r\n&]+))"
@@ -28,18 +24,13 @@ values(SubjectKeyIdentifier) as ssl_hash by Computer, EventCode, Requester, Attr
     | fields auth_src,auth_dest,user
     ]
 | eval src = upper(coalesce(auth_src,req_src)), dest = upper(coalesce(auth_dest,req_dest_1,req_dest_2)), risk_score = 90
-| eval flavor_text = case(signature_id=="4887", "User account [".'user'."] authenticated after a 
-suspicious certificate was issued for it by [".'src_user'."] using certificate request ID: ".'ssl_serial')
+| eval flavor_text = case(signature_id=="4887", "User account [".'user'."] authenticated after a suspicious certificate was issued for it by [".'src_user'."] using certificate request ID: ".'ssl_serial')
 | fields - req_* auth_*
 | `security_content_ctime(firstTime)` 
 | `security_content_ctime(lastTime)`
 | `windows_steal_authentication_certificates_esc1_auth_filter`'
-how_to_implement: To implement this analytic, enhanced Audit Logging must be enabled
-  on AD CS and within Group Policy Management for CS server. See Page 115 of first
-  reference. Recommend throttle correlation by RequestId/ssl_serial at minimum.
-known_false_positives: False positives may be generated in environments where administrative users or processes
-are allowed to generate certificates with Subject Alternative Names. Sources or templates used in these 
-processes may need to be tuned out for accurate function. 
+how_to_implement: To implement this analytic, enhanced Audit Logging must be enabled on AD CS and within Group Policy Management for CS server. See Page 115 of first reference. Recommend throttle correlation by RequestId/ssl_serial at minimum.
+known_false_positives: False positives may be generated in environments where administrative users or processes are allowed to generate certificates with Subject Alternative Names for authentication. Sources or templates used in these processes may need to be tuned out for accurate function. 
 references:
 - https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
 - https://github.com/ly4k/Certipy#esc1
@@ -53,6 +44,7 @@ tags:
   message: Possible AD CS ESC1 authentication - $flavor_text$
   mitre_attack_id:
   - T1649
+  - T1550
   observable:
   - name: src
     type: hostname

--- a/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates_esc1_auth.yml
@@ -27,7 +27,7 @@ values(SubjectKeyIdentifier) as ssl_hash by Computer, EventCode, Requester, Attr
     | rename TargetUserName as user, Computer as auth_dest, IpAddress as auth_src
     | fields auth_src,auth_dest,user
     ]
-| eval src = upper(coalesce(auth_src,req_src)), dest = upper(coalesce(auth_dest,req_dest_1,req_dest_2)), risk_score = 80
+| eval src = upper(coalesce(auth_src,req_src)), dest = upper(coalesce(auth_dest,req_dest_1,req_dest_2)), risk_score = 90
 | eval flavor_text = case(signature_id=="4887", "User account [".'user'."] authenticated after a 
 suspicious certificate was issued for it by [".'src_user'."] using certificate request ID: ".'ssl_serial')
 | fields - req_* auth_*
@@ -48,7 +48,7 @@ tags:
   analytic_story:
   - Windows Certificate Services
   asset_type: Endpoint
-  confidence: 80
+  confidence: 90
   impact: 100
   message: Possible AD CS ESC1 authentication - $flavor_text$
   mitre_attack_id:
@@ -92,7 +92,7 @@ tags:
   - TargetUserName
   - Computer
   - IpAddress
-  risk_score: 80
+  risk_score: 90
   security_domain: endpoint
 tests:
 - name: True Positive Test

--- a/detections/endpoint/windows_suspect_process_with_authentication_traffic.yml
+++ b/detections/endpoint/windows_suspect_process_with_authentication_traffic.yml
@@ -76,7 +76,7 @@ tags:
 tests:
 - name: True Positive Test
   attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certipy_abuse/certipy_esc1_abuse.log
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse_sysmon.log
     source: XmlWinEventLog:Security
     sourcetype: XmlWinEventLog
     update_timestamp: true

--- a/detections/endpoint/windows_suspect_process_with_authentication_traffic.yml
+++ b/detections/endpoint/windows_suspect_process_with_authentication_traffic.yml
@@ -1,0 +1,82 @@
+name: Windows Suspect Process With Authentication Traffic
+id: 953322db-128a-4ce9-8e89-56e039e33d98
+version: 1
+date: '2023-06-13'
+author: Steven Dick
+status: production
+type: Anomaly
+description: This analytic identifies executables running from public or temporary locations that are communicating over windows domain
+ authentication ports/protocol. The ports/protocols include LDAP(389), LDAPS(636), and Kerberos(88). Authentications from applications 
+ running from user controlled locations may not be malicious, however actors often attempt to access domain resources after initial 
+ compromise from executables in these locations.
+data_source:
+- Sysmon Event ID 3
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime values(All_Traffic.process_id) as process_id 
+from datamodel=Network_Traffic.All_Traffic where All_Traffic.dest_port IN ("88","389","636") 
+AND All_Traffic.app IN ("*\\users\\*", "*\\programdata\\*", "*\\temp\\*", "*\\Windows\\Tasks\\*", "*\\appdata\\*", "*\\perflogs\\*") 
+by All_Traffic.app,All_Traffic.src,All_Traffic.src_ip,All_Traffic.user,All_Traffic.dest,All_Traffic.dest_ip,All_Traffic.dest_port
+| `drop_dm_object_name(All_Traffic)` 
+| rex field=app ".*\\\(?<process_name>.*)$"
+| rename app as process
+| `security_content_ctime(firstTime)` 
+| `security_content_ctime(lastTime)`
+| `windows_suspect_process_with_auth_traffic_filter`'
+how_to_implement: To implement this analytic, Sysmon should be installed in the environment and generating network events for 
+  userland and/or known public writable locations. 
+known_false_positives: Known applications running from these locations for legitimate purposes. Targeting only kerberos (port 88)
+ may significantly reduce noise.
+references:
+- Most attacker toolkits offer some degree of interaction with AD/LDAP.
+- https://attack.mitre.org/techniques/T1069/002/
+- https://book.hacktricks.xyz/network-services-pentesting/pentesting-kerberos-88 
+tags:
+  analytic_story:
+  - Active Directory Discovery
+  asset_type: Endpoint
+  confidence: 50
+  impact: 50
+  message: The process $process_name$ on $src$ has been communicating with $dest$ on $dest_port$.
+  mitre_attack_id:
+  - T1087
+  - T1087.002
+  - T1204
+  - T1204.002
+  observable:
+  - name: src
+    type: hostname
+    role:
+    - Victim
+  - name: dest
+    type: hostname
+    role:
+    - Victim
+  - name: user
+    type: username
+    role:
+    - Victim	
+  - name: process_name
+    type: other
+    role:
+    - Attacker
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - _time
+  - All_Traffic.app
+  - All_Traffic.src
+  - All_Traffic.src_ip
+  - All_Traffic.user
+  - All_Traffic.dest
+  - All_Traffic.dest_ip
+  - All_Traffic.dest_port
+  risk_score: 25
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1649/certipy_abuse/certipy_esc1_abuse.log
+    source: XmlWinEventLog:Security
+    sourcetype: XmlWinEventLog
+    update_timestamp: true

--- a/lookups/attacker_tools.csv
+++ b/lookups/attacker_tools.csv
@@ -27,3 +27,5 @@ SilverBullet.exe,Malware was discovered in our monitoring of honey pots that abu
 kportscan3.exe, KPortScan 3.0 is a widely used port scanning tool on Hacking Forums to perform network scanning on the internal networks.
 advanced_port_scanner.exe,Advanced Port Scanner is a free network scanner allowing you to quickly find open ports on network computers and retrieve versions of programs running on the detected ports.
 mimikatz.exe,utility Mimikatz is an open-source application that allows users to view and save authentication credentials such as Kerberos tickets.
+certify.exe,A tool used to enumerate and abuse misconfigurations in Active Directory Certificate Services (AD CS).
+certipy.exe,A tool used to enumerate and abuse misconfigurations in Active Directory Certificate Services (AD CS).


### PR DESCRIPTION
### Details

Adds a number of detections for ADCS abuse, specifically ESC1 using common attacker tools Certify and the python derivative Certipy. 

Pending approval of https://github.com/splunk/attack_data/pull/809 

Added certify.exe and ceripy.exe, common compile names of these attacker tools, the attacker tool lookup.

https://github.com/GhostPack/Certify 
https://github.com/ly4k/Certipy

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
