### PR TITLE
SSA Regex Bugfixes

### DIFF
--- a/bin/contentctl_project/contentctl_infrastructure/builder/backend_splunk_ba.py
+++ b/bin/contentctl_project/contentctl_infrastructure/builder/backend_splunk_ba.py
@@ -34,7 +34,7 @@ class SplunkBABackend(TextQueryBackend):
     add_escaped : ClassVar[str] = "\\"
 
     re_expression : ClassVar[str] = "match_regex({field}, /(?i){regex}/)=true"
-    re_escape_char : ClassVar[str] = "\\"
+    re_escape_char : ClassVar[str] = ""
     re_escape : ClassVar[Tuple[str]] = ('"',)
 
     cidr_expression : ClassVar[str] = "{value}"

--- a/dev_ssa/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
+++ b/dev_ssa/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
@@ -16,15 +16,21 @@ search:
     - reg.exe
     - cmd.exe
   selection2:
-    process.cmd_line|re:
-    - HKEY_LOCAL_MACHINE\System
-    - HKEY_LOCAL_MACHINE\SAM
-    - HKEY_LOCAL_MACHINE\Security
-    - HKLM\System
-    - HKLM\SAM
-    - HKLM\Security
+    process.cmd_line|contains:
+    - HKEY_LOCAL_MACHINE\\\\\\\\System
+    - HKEY_LOCAL_MACHINE\\\\\\\\system
+    - HKEY_LOCAL_MACHINE\\\\\\\\SAM
+    - HKEY_LOCAL_MACHINE\\\\\\\\sam
+    - HKEY_LOCAL_MACHINE\\\\\\\\Security
+    - HKEY_LOCAL_MACHINE\\\\\\\\security
+    - HKLM\\\\\\\\System
+    - HKLM\\\\\\\\system
+    - HKLM\\\\\\\\SAM
+    - HKLM\\\\\\\\sam
+    - HKLM\\\\\\\\Security
+    - HKLM\\\\\\\\security
   selection3:
-    process.cmd_line|re: save
+    process.cmd_line|contains: save
   condition: selection1 and (selection2) and selection3
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the process name, parent process, and command-line executions from your

--- a/dev_ssa/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
+++ b/dev_ssa/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
@@ -16,21 +16,15 @@ search:
     - reg.exe
     - cmd.exe
   selection2:
-    process.cmd_line|contains:
-    - HKEY_LOCAL_MACHINE\\\\\\\\System
-    - HKEY_LOCAL_MACHINE\\\\\\\\system
-    - HKEY_LOCAL_MACHINE\\\\\\\\SAM
-    - HKEY_LOCAL_MACHINE\\\\\\\\sam
-    - HKEY_LOCAL_MACHINE\\\\\\\\Security
-    - HKEY_LOCAL_MACHINE\\\\\\\\security
-    - HKLM\\\\\\\\System
-    - HKLM\\\\\\\\system
-    - HKLM\\\\\\\\SAM
-    - HKLM\\\\\\\\sam
-    - HKLM\\\\\\\\Security
-    - HKLM\\\\\\\\security
+    process.cmd_line|re:
+    - HKEY_LOCAL_MACHINE\\System
+    - HKEY_LOCAL_MACHINE\\SAM
+    - HKEY_LOCAL_MACHINE\\Security
+    - HKLM\\System
+    - HKLM\\SAM
+    - HKLM\\Security
   selection3:
-    process.cmd_line|contains: save
+    process.cmd_line|re: save
   condition: selection1 and (selection2) and selection3
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the process name, parent process, and command-line executions from your

--- a/dev_ssa/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
+++ b/dev_ssa/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
@@ -1,6 +1,6 @@
 name: Attempted Credential Dump From Registry via Reg exe
 id: 14038953-e5f2-4daf-acff-5452062baf03
-version: 2
+version: 3
 date: '2021-11-29'
 author: Jose Hernandez, Splunk
 status: production

--- a/dev_ssa/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dev_ssa/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -25,7 +25,7 @@ search:
     - sqlps.exe
     - pwsh.exe
   selection2:
-    process.cmd_line|re: '[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h(i*d*d*e*n*)\s+'
+    process.cmd_line|re: '[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h'
   condition: selection1 and selection2
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be

--- a/dev_ssa/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dev_ssa/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -1,6 +1,6 @@
 name: Windows Powershell Connect to Internet With Hidden Window
 id: 477e068e-8b6d-11ec-b6c1-81af21670352
-version: 1
+version: 2
 date: '2022-02-11'
 author: Jose Hernandez, David Dorsey, Michael Haag Splunk
 status: production

--- a/dev_ssa/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dev_ssa/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -25,7 +25,7 @@ search:
     - sqlps.exe
     - pwsh.exe
   selection2:
-    process.cmd_line|re: (?i)[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h(i*d*d*e*n*)\s+
+    process.cmd_line|re: '[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h(i*d*d*e*n*)\s+'
   condition: selection1 and selection2
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be

--- a/dev_ssa/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dev_ssa/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -25,7 +25,7 @@ search:
     - sqlps.exe
     - pwsh.exe
   selection2:
-    process.cmd_line|re: '[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h'
+    process.cmd_line|re: '[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h(i*d*d*e*n*)\s+'
   condition: selection1 and selection2
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be

--- a/dev_ssa/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dev_ssa/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -24,9 +24,8 @@ search:
     - sqltoolsps.exe
     - sqlps.exe
     - pwsh.exe
-    - pwsh.exe
   selection2:
-    process.cmd_line|re: (?i)[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+[^-]
+    process.cmd_line|re: (?i)[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h(i*d*d*e*n*)\s+
   condition: selection1 and selection2
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be

--- a/dist/ssa/srs/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
+++ b/dist/ssa/srs/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
@@ -1,6 +1,6 @@
 name: Attempted Credential Dump From Registry via Reg exe
 id: 14038953-e5f2-4daf-acff-5452062baf03
-version: 2
+version: 3
 description: The following analytic identifies the use of `reg.exe` attempting to
   export Windows registry keys that contain hashed credentials. Adversaries will utilize
   this technique to capture and perform offline password cracking.

--- a/dist/ssa/srs/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
+++ b/dist/ssa/srs/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
@@ -21,15 +21,12 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   "string", null) | eval actor_process_file_name=ucast(map_get(actor_process_file,"name"),
   "string", null) | eval device=ucast(map_get(input_event,"device"), "map<string,
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
-  null) | where (process_file_name="reg.exe" OR process_file_name="cmd.exe") AND (like(process_cmd_line,
-  "%HKEY_LOCAL_MACHINE\\\\System%") OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\system%")
-  OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\SAM%") OR like(process_cmd_line,
-  "%HKEY_LOCAL_MACHINE\\\\sam%") OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\Security%")
-  OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\security%") OR like(process_cmd_line,
-  "%HKLM\\\\System%") OR like(process_cmd_line, "%HKLM\\\\system%") OR like(process_cmd_line,
-  "%HKLM\\\\SAM%") OR like(process_cmd_line, "%HKLM\\\\sam%") OR like(process_cmd_line,
-  "%HKLM\\\\Security%") OR like(process_cmd_line, "%HKLM\\\\security%")) AND like(process_cmd_line,
-  "%save%") 
+  null) | where (process_file_name="reg.exe" OR process_file_name="cmd.exe") AND (match_regex(process_cmd_line,
+  /(?i)HKEY_LOCAL_MACHINE\\System/)=true OR match_regex(process_cmd_line, /(?i)HKEY_LOCAL_MACHINE\\SAM/)=true
+  OR match_regex(process_cmd_line, /(?i)HKEY_LOCAL_MACHINE\\Security/)=true OR match_regex(process_cmd_line,
+  /(?i)HKLM\\System/)=true OR match_regex(process_cmd_line, /(?i)HKLM\\SAM/)=true
+  OR match_regex(process_cmd_line, /(?i)HKLM\\Security/)=true) AND match_regex(process_cmd_line,
+  /(?i)save/)=true 
   | eval body=create_map(
     "devices", [
         create_map(

--- a/dist/ssa/srs/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
+++ b/dist/ssa/srs/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
@@ -21,12 +21,15 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   "string", null) | eval actor_process_file_name=ucast(map_get(actor_process_file,"name"),
   "string", null) | eval device=ucast(map_get(input_event,"device"), "map<string,
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
-  null) | where (process_file_name="reg.exe" OR process_file_name="cmd.exe") AND (match_regex(process_cmd_line,
-  /(?i)HKEY_LOCAL_MACHINE\\System/)=true OR match_regex(process_cmd_line, /(?i)HKEY_LOCAL_MACHINE\\SAM/)=true
-  OR match_regex(process_cmd_line, /(?i)HKEY_LOCAL_MACHINE\\Security/)=true OR match_regex(process_cmd_line,
-  /(?i)HKLM\\System/)=true OR match_regex(process_cmd_line, /(?i)HKLM\\SAM/)=true
-  OR match_regex(process_cmd_line, /(?i)HKLM\\Security/)=true) AND match_regex(process_cmd_line,
-  /(?i)save/)=true 
+  null) | where (process_file_name="reg.exe" OR process_file_name="cmd.exe") AND (like(process_cmd_line,
+  "%HKEY_LOCAL_MACHINE\\\\System%") OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\system%")
+  OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\SAM%") OR like(process_cmd_line,
+  "%HKEY_LOCAL_MACHINE\\\\sam%") OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\Security%")
+  OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\security%") OR like(process_cmd_line,
+  "%HKLM\\\\System%") OR like(process_cmd_line, "%HKLM\\\\system%") OR like(process_cmd_line,
+  "%HKLM\\\\SAM%") OR like(process_cmd_line, "%HKLM\\\\sam%") OR like(process_cmd_line,
+  "%HKLM\\\\Security%") OR like(process_cmd_line, "%HKLM\\\\security%")) AND like(process_cmd_line,
+  "%save%") 
   | eval body=create_map(
     "devices", [
         create_map(

--- a/dist/ssa/srs/ssa___windows_os_credential_dumping_with_ntdsutil_export_ntds.yml
+++ b/dist/ssa/srs/ssa___windows_os_credential_dumping_with_ntdsutil_export_ntds.yml
@@ -69,6 +69,7 @@ references:
 - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/cc753343(v=ws.11)
 - https://2017.zeronights.org/wp-content/uploads/materials/ZN17_Kheirkhabarov_Hunting_for_Credentials_Dumping_in_Windows_Environment.pdf
 - https://strontic.github.io/xcyclopedia/library/vss_ps.dll-97B15BDAE9777F454C9A6BA25E938DB3.html
+- https://www.microsoft.com/en-us/security/blog/2023/05/24/volt-typhoon-targets-us-critical-infrastructure-with-living-off-the-land-techniques/
 tags:
   required_fields:
   - process.pid
@@ -109,6 +110,7 @@ tags:
     - Credential Dumping
     - HAFNIUM Group
     - Living Off The Land
+    - Volt Typhoon
     cis20:
     - CIS 10
     kill_chain_phases:

--- a/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -29,7 +29,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
   OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
-  AND match_regex(process_cmd_line, /(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h(i*d*d*e*n*)\\s+/)=true
+  AND match_regex(process_cmd_line, /(?i)[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h(i*d*d*e*n*)\s+/)=true
   
   | eval body=create_map(
     "devices", [

--- a/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -29,7 +29,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
   OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
-  AND match_regex(process_cmd_line, /(?i)[\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\s+h/)=true
+  AND match_regex(process_cmd_line, /(?i)[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h/)=true
   
   | eval body=create_map(
     "devices", [

--- a/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -29,7 +29,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
   OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
-  AND match_regex(process_cmd_line, /(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h(i*d*d*e*n*)\\s+/)=true
+  AND match_regex(process_cmd_line, /(?i)[\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\s+h/)=true
   
   | eval body=create_map(
     "devices", [

--- a/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -28,8 +28,8 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   "string", null) | eval device=ucast(map_get(input_event,"device"), "map<string,
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
-  OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe"
-  OR process_file_name="pwsh.exe") AND match_regex(process_cmd_line, /(?i)(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+[^-]/)=true
+  OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
+  AND match_regex(process_cmd_line, /(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h(i*d*d*e*n*)\\s+/)=true
   
   | eval body=create_map(
     "devices", [

--- a/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -1,6 +1,6 @@
 name: Windows Powershell Connect to Internet With Hidden Window
 id: 477e068e-8b6d-11ec-b6c1-81af21670352
-version: 1
+version: 2
 description: The following hunting analytic identifies PowerShell commands utilizing
   the WindowStyle parameter to hide the window on the compromised endpoint. This combination
   of command-line options is suspicious because it is overriding the default PowerShell

--- a/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/dist/ssa/srs/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -29,7 +29,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
   OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
-  AND match_regex(process_cmd_line, /(?i)[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h/)=true
+  AND match_regex(process_cmd_line, /(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h(i*d*d*e*n*)\\s+/)=true
   
   | eval body=create_map(
     "devices", [

--- a/ssa_detections/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
+++ b/ssa_detections/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
@@ -27,15 +27,12 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   "string", null) | eval actor_process_file_name=ucast(map_get(actor_process_file,"name"),
   "string", null) | eval device=ucast(map_get(input_event,"device"), "map<string,
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
-  null) | where (process_file_name="reg.exe" OR process_file_name="cmd.exe") AND (like(process_cmd_line,
-  "%HKEY_LOCAL_MACHINE\\\\System%") OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\system%")
-  OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\SAM%") OR like(process_cmd_line,
-  "%HKEY_LOCAL_MACHINE\\\\sam%") OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\Security%")
-  OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\security%") OR like(process_cmd_line,
-  "%HKLM\\\\System%") OR like(process_cmd_line, "%HKLM\\\\system%") OR like(process_cmd_line,
-  "%HKLM\\\\SAM%") OR like(process_cmd_line, "%HKLM\\\\sam%") OR like(process_cmd_line,
-  "%HKLM\\\\Security%") OR like(process_cmd_line, "%HKLM\\\\security%")) AND like(process_cmd_line,
-  "%save%") --finding_report--'
+  null) | where (process_file_name="reg.exe" OR process_file_name="cmd.exe") AND (match_regex(process_cmd_line,
+  /(?i)HKEY_LOCAL_MACHINE\\System/)=true OR match_regex(process_cmd_line, /(?i)HKEY_LOCAL_MACHINE\\SAM/)=true
+  OR match_regex(process_cmd_line, /(?i)HKEY_LOCAL_MACHINE\\Security/)=true OR match_regex(process_cmd_line,
+  /(?i)HKLM\\System/)=true OR match_regex(process_cmd_line, /(?i)HKLM\\SAM/)=true
+  OR match_regex(process_cmd_line, /(?i)HKLM\\Security/)=true) AND match_regex(process_cmd_line,
+  /(?i)save/)=true --finding_report--'
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the process name, parent process, and command-line executions from your
   endpoints. If you are using Sysmon, you must have at least version 6.0.4 of the

--- a/ssa_detections/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
+++ b/ssa_detections/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
@@ -1,6 +1,6 @@
 name: Attempted Credential Dump From Registry via Reg exe
 id: 14038953-e5f2-4daf-acff-5452062baf03
-version: 2
+version: 3
 date: '2021-11-29'
 author: Jose Hernandez, Splunk
 type: TTP

--- a/ssa_detections/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
+++ b/ssa_detections/endpoint/ssa___attempted_credential_dump_from_registry_via_reg_exe.yml
@@ -27,12 +27,15 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   "string", null) | eval actor_process_file_name=ucast(map_get(actor_process_file,"name"),
   "string", null) | eval device=ucast(map_get(input_event,"device"), "map<string,
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
-  null) | where (process_file_name="reg.exe" OR process_file_name="cmd.exe") AND (match_regex(process_cmd_line,
-  /(?i)HKEY_LOCAL_MACHINE\\System/)=true OR match_regex(process_cmd_line, /(?i)HKEY_LOCAL_MACHINE\\SAM/)=true
-  OR match_regex(process_cmd_line, /(?i)HKEY_LOCAL_MACHINE\\Security/)=true OR match_regex(process_cmd_line,
-  /(?i)HKLM\\System/)=true OR match_regex(process_cmd_line, /(?i)HKLM\\SAM/)=true
-  OR match_regex(process_cmd_line, /(?i)HKLM\\Security/)=true) AND match_regex(process_cmd_line,
-  /(?i)save/)=true --finding_report--'
+  null) | where (process_file_name="reg.exe" OR process_file_name="cmd.exe") AND (like(process_cmd_line,
+  "%HKEY_LOCAL_MACHINE\\\\System%") OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\system%")
+  OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\SAM%") OR like(process_cmd_line,
+  "%HKEY_LOCAL_MACHINE\\\\sam%") OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\Security%")
+  OR like(process_cmd_line, "%HKEY_LOCAL_MACHINE\\\\security%") OR like(process_cmd_line,
+  "%HKLM\\\\System%") OR like(process_cmd_line, "%HKLM\\\\system%") OR like(process_cmd_line,
+  "%HKLM\\\\SAM%") OR like(process_cmd_line, "%HKLM\\\\sam%") OR like(process_cmd_line,
+  "%HKLM\\\\Security%") OR like(process_cmd_line, "%HKLM\\\\security%")) AND like(process_cmd_line,
+  "%save%") --finding_report--'
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the process name, parent process, and command-line executions from your
   endpoints. If you are using Sysmon, you must have at least version 6.0.4 of the

--- a/ssa_detections/endpoint/ssa___windows_os_credential_dumping_with_ntdsutil_export_ntds.yml
+++ b/ssa_detections/endpoint/ssa___windows_os_credential_dumping_with_ntdsutil_export_ntds.yml
@@ -48,11 +48,13 @@ references:
 - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/cc753343(v=ws.11)
 - https://2017.zeronights.org/wp-content/uploads/materials/ZN17_Kheirkhabarov_Hunting_for_Credentials_Dumping_in_Windows_Environment.pdf
 - https://strontic.github.io/xcyclopedia/library/vss_ps.dll-97B15BDAE9777F454C9A6BA25E938DB3.html
+- https://www.microsoft.com/en-us/security/blog/2023/05/24/volt-typhoon-targets-us-critical-infrastructure-with-living-off-the-land-techniques/
 tags:
   analytic_story:
   - Credential Dumping
   - HAFNIUM Group
   - Living Off The Land
+  - Volt Typhoon
   asset_type: Endpoint
   confidence: 50
   impact: 100

--- a/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -34,8 +34,8 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   "string", null) | eval device=ucast(map_get(input_event,"device"), "map<string,
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
-  OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe"
-  OR process_file_name="pwsh.exe") AND match_regex(process_cmd_line, /(?i)(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+[^-]/)=true
+  OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
+  AND match_regex(process_cmd_line, /(?i)(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h(i*d*d*e*n*)\\s+/)=true
   --finding_report--'
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be

--- a/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -35,7 +35,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
   OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
-  AND match_regex(process_cmd_line, /(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h(i*d*d*e*n*)\\s+/)=true
+  AND match_regex(process_cmd_line, /(?i)[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h(i*d*d*e*n*)\s+/)=true
   --finding_report--'
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be

--- a/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -1,6 +1,6 @@
 name: Windows Powershell Connect to Internet With Hidden Window
 id: 477e068e-8b6d-11ec-b6c1-81af21670352
-version: 1
+version: 2
 date: '2022-02-11'
 author: Jose Hernandez, David Dorsey, Michael Haag Splunk
 type: Anomaly

--- a/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -35,7 +35,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
   OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
-  AND match_regex(process_cmd_line, /(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h/)=true
+  AND match_regex(process_cmd_line, /(?i)[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h/)=true
   --finding_report--'
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be

--- a/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -35,7 +35,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
   OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
-  AND match_regex(process_cmd_line, /(?i)(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h(i*d*d*e*n*)\\s+/)=true
+  AND match_regex(process_cmd_line, /(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h(i*d*d*e*n*)\\s+/)=true
   --finding_report--'
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be

--- a/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -35,7 +35,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
   OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
-  AND match_regex(process_cmd_line, /(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h(i*d*d*e*n*)\\s+/)=true
+  AND match_regex(process_cmd_line, /(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h/)=true
   --finding_report--'
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be

--- a/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
+++ b/ssa_detections/endpoint/ssa___windows_powershell_connect_to_internet_with_hidden_window.yml
@@ -35,7 +35,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (process_file_name="powershell_ise.exe" OR process_file_name="powershell.exe"
   OR process_file_name="sqltoolsps.exe" OR process_file_name="sqlps.exe" OR process_file_name="pwsh.exe")
-  AND match_regex(process_cmd_line, /(?i)[\-|\/]w(in*d*o*w*s*t*y*l*e*)*\s+h/)=true
+  AND match_regex(process_cmd_line, /(?i)[\\-|\\/]w(in*d*o*w*s*t*y*l*e*)*\\s+h(i*d*d*e*n*)\\s+/)=true
   --finding_report--'
 how_to_implement: You must be ingesting data that records process activity from your
   hosts to populate the Endpoint data model in the Processes node. You must also be

--- a/ssa_detections/endpoint/ssa___windows_remote_create_service.yml
+++ b/ssa_detections/endpoint/ssa___windows_remote_create_service.yml
@@ -29,7 +29,7 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   "string", null) | eval device=ucast(map_get(input_event,"device"), "map<string,
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
   null) | where (match_regex(process_cmd_line, /(?i)create/)=true OR match_regex(process_cmd_line,
-  /(?i)\\\\/)=true) AND process_file_name="sc.exe" --finding_report--'
+  /(?i)\\/)=true) AND process_file_name="sc.exe" --finding_report--'
 how_to_implement: To successfully implement this search you need to be ingesting information
   on process that include the name of the process responsible for the changes from
   your endpoints into the `Endpoint` datamodel in the `Processes` node. In addition,

--- a/ssa_detections/endpoint/ssa___windows_service_create_with_tscon.yml
+++ b/ssa_detections/endpoint/ssa___windows_service_create_with_tscon.yml
@@ -33,7 +33,8 @@ search: ' | from read_ba_enriched_events() | eval timestamp = ucast(map_get(inpu
   "string", null) | eval actor_process_file_name=ucast(map_get(actor_process_file,"name"),
   "string", null) | eval device=ucast(map_get(input_event,"device"), "map<string,
   any>", null) | eval device_hostname=ucast(map_get(device,"hostname"), "string",
-  null) | where like(process_cmd_line, "%/dest:rdp-tcp%") --finding_report--'
+  null) | where match_regex(process_cmd_line, /(?i)/dest:rdp-tcp/)=true AND process_file_name="sc.exe"
+  --finding_report--'
 how_to_implement: To successfully implement this search you need to be ingesting information
   on process that include the name of the process responsible for the changes from
   your endpoints into the `Endpoint` datamodel in the `Processes` node. In addition,


### PR DESCRIPTION
### Details

`ssa___windows_powershell_connect_to_internet_with_hidden_window.yml`: 
- removed duplicate pwsh.exe
- adjusted regex

Made a code change to how we convert regex from the sigma format in `dev_ssa/` that was causing issues with escape characters.

Converted `ssa___attempted_credential_dump_from_registry_via_reg_exe.yml` to use `contains` instead of `re` to avoid additional issues with escape characters.

Reconverted and regenerated all SSA detections.

Testing in replies


### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
