### PR TITLE
Re-add multiline formatting to make it easier to read

### DIFF
--- a/detections/endpoint/windows_steal_authentication_certificates___esc1_auth.yml
+++ b/detections/endpoint/windows_steal_authentication_certificates___esc1_auth.yml
@@ -10,7 +10,27 @@ data_source:
   - Windows Security 4887
   - Windows Security 4768
 search: >-
-  `wineventlog_security` EventCode IN (4887) Attributes="*SAN:*upn*" Attributes="*CertificateTemplate:*" | stats count min(_time) as firstTime max(_time) as lastTime values(name) as name values(status) as status values(Subject) as ssl_subject values(SubjectKeyIdentifier) as ssl_hash by Computer, EventCode, Requester, Attributes, RequestId | rex field=Attributes "(?i)CertificateTemplate:(?<object>[^\r\n]+)" | rex field=Attributes "(?i)ccm:(?<req_src>[^\r\n]+)" | rex max_match=10 field=Attributes "(?i)(upn=(?<req_user_1>[^\r\n&]+))"| rex max_match=10 field=Attributes "(?i)(dns=(?<req_dest_1>[^\r\n&]+))"| rex field=Requester "(.+\\\\)?(?<src_user>[^\r\n]+)"| rename Attributes as object_attrs, EventCode as signature_id, name as signature, RequestId as ssl_serial, Requester as ssl_subject_common_name | eval user = lower(coalesce(req_user_1,req_user_2)) | join user [ | search `wineventlog_security` EventCode=4768 CertThumbprint=* | rename TargetUserName as user, Computer as auth_dest, IpAddress as auth_src | fields auth_src,auth_dest,user ] | eval src = upper(coalesce(auth_src,req_src)), dest = upper(coalesce(auth_dest,req_dest_1,req_dest_2)), risk_score = 90 | eval flavor_text = case(signature_id=="4887", "User account [".'user'."] authenticated after a suspicious certificate was issued for it by [".'src_user'."] using certificate request ID: ".'ssl_serial') | fields - req_* auth_* | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`| `windows_steal_authentication_certificates___esc1_authentication_filter`
+  `wineventlog_security` EventCode IN (4887) Attributes="*SAN:*upn*" Attributes="*CertificateTemplate:*"
+  | stats count min(_time) as firstTime max(_time) as lastTime values(name) as name values(status) as status values(Subject) as ssl_subject values(SubjectKeyIdentifier) as ssl_hash by Computer, EventCode, Requester, Attributes, RequestId
+  | rex field=Attributes "(?i)CertificateTemplate:(?<object>[^\r\n]+)"
+  | rex field=Attributes "(?i)ccm:(?<req_src>[^\r\n]+)"
+  | rex max_match=10 field=Attributes "(?i)(upn=(?<req_user_1>[^\r\n&]+))"
+  | rex max_match=10 field=Attributes "(?i)(dns=(?<req_dest_1>[^\r\n&]+))"
+  | rex field=Requester "(.+\\\\)?(?<src_user>[^\r\n]+)"
+  | rename Attributes as object_attrs, EventCode as signature_id, name as signature, RequestId as ssl_serial, Requester as ssl_subject_common_name
+  | eval user = lower(coalesce(req_user_1,req_user_2)) 
+  | join user
+  [
+  | search `wineventlog_security` EventCode=4768 CertThumbprint=*
+  | rename TargetUserName as user, Computer as auth_dest, IpAddress as auth_src
+  | fields auth_src,auth_dest,user
+  ]
+  | eval src = upper(coalesce(auth_src,req_src)), dest = upper(coalesce(auth_dest,req_dest_1,req_dest_2)), risk_score = 90
+  | eval flavor_text = case(signature_id=="4887", "User account [".'user'."] authenticated after a suspicious certificate was issued for it by [".'src_user'."] using certificate request ID: ".'ssl_serial')
+  | fields - req_* auth_*
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `windows_steal_authentication_certificates___esc1_authentication_filter`
 how_to_implement: To implement this analytic, enhanced Audit Logging must be enabled on AD CS and within Group Policy Management for CS server. See Page 115 of first reference. Recommend throttle correlation by RequestId/ssl_serial at minimum.
 known_false_positives: False positives may be generated in environments where administrative users or processes are allowed to generate certificates with Subject Alternative Names for authentication. Sources or templates used in these processes may need to be tuned out for accurate function.
 references:


### PR DESCRIPTION
Figured out some yaml formatting intricacies and made search easier to read, especially
in research.splunk.com 
