### PR TITLE
Substitute "identifes" by "identifies" in aws_iam_delete_policy.yml

### DIFF
--- a/detections/cloud/aws_iam_delete_policy.yml
+++ b/detections/cloud/aws_iam_delete_policy.yml
@@ -5,7 +5,7 @@ date: '2021-04-01'
 author: Michael Haag, Splunk
 status: production
 type: Hunting
-description: The following detection identifes when a policy is deleted on AWS. This
+description: The following detection identifies when a policy is deleted on AWS. This
   does not identify whether successful or failed, but the error messages tell a story
   of suspicious attempts. There is a specific process to follow when deleting a policy.
   First, detach the policy from all users, groups, and roles that the policy is attached


### PR DESCRIPTION
### Details

Substitute the word "identifes" by "identifies".

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.

I don't know if the version has to be updated for this small change.
