### PR TITLE
fix search and conditions in sigma version of batch_file_write_to_sys…

### DIFF
--- a/dev/endpoint/batch_file_write_to_system32.yml
+++ b/dev/endpoint/batch_file_write_to_system32.yml
@@ -8,11 +8,14 @@ type: TTP
 description: The search looks for a batch file (.bat) written to the Windows system
   directory tree.
 data_source:
-- Sysmon Event ID 1
+- Sysmon Event ID 11
 search:
-  selection1:
-    Image|endswith: '*'
-  condition: selection1
+  selection:
+      TargetFilename|endswith: .bat
+      TargetFilename|contains:
+          - system32
+          - syswow64
+  condition: selection
 how_to_implement: To successfully implement this search you need to be ingesting information
   on process that include the name of the process responsible for the changes from
   your endpoints into the `Endpoint` datamodel in the `Processes` node. In addition,


### PR DESCRIPTION
…tem32.yml

### Details
This is connected to the issue: https://github.com/splunk/security_content/issues/2987
There are about 60 detections where the original SPL detections use joins and it seems as though all of them didn't translate properly to sigma (/dev/endpoint).
This detection specifically was translated to look for anything where `image|endswith: *`.
I've updated the detection to align with the provided description.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
