### PR TITLE
Removed incorrect notion link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This project gives you access to our repository of Analytic Stories, security gu
 # Get Content🛡
 The latest Splunk Security Content can be obtained via:
  
-### 🌐 [Website](https://www.notion.so/Splunk-c0afd5a0c59242a19f7ab555630b493d?pvs=21)
+### 🌐 [Website](https://research.splunk.com/)
 
 Best way to discover and access our content is by using the [research.splunk.com](https://research.splunk.com/) website.
 


### PR DESCRIPTION
Removed the incorrect link to notion with the research.splunk.com page. Informed Jose.

### Details

_What does this PR have in it? Screenshots are worth 1000 words 😄_

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
