### PR TITLE
updating badge and trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: build
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - develop
 jobs:
   build:
     #Note that the CircleCI job used a Container.  The way to do this with Github Actions

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 <p align="center">
     <a href="https://github.com/splunk/security_content/releases">
         <img src="https://img.shields.io/github/v/release/splunk/security_content" /></a>
-    <a href="https://github.com/splunk/security_content/actions/workflows/validate-and-build.yml/badge.svg?branch=develop">
-        <img src="https://github.com/splunk/security_content/actions/workflows/validate-and-build.yml/badge.svg?branch=develop" /></a>
+    <a href="https://github.com/splunk/security_content/actions/workflows/build.yml/badge.svg?branch=develop">
+        <img src="https://github.com/splunk/security_content/actions/workflows/build.yml/badge.svg?branch=develop" /></a>
     <a href="https://github.com/splunk/security_content">
         <img src="https://security-content.s3-us-west-2.amazonaws.com/reporting/detection_count.svg" /></a>
     <a href="https://github.com/splunk/security_content">


### PR DESCRIPTION
PR fixes the badge link in ReadME
adds a trigger to the build action to run every time when code is merged into develop!