### PR TITLE
Adding autolabels for content

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+Detections:
+- changed-files:
+  - any-glob-to-any-file: 
+    - detections/**
+    - dev/**
+
+Stories:
+- changed-files:
+  - any-glob-to-any-file: stories/*
+
+Playbooks:
+- changed-files:
+  - any-glob-to-any-file: playbooks/*
+
+Macros:
+- changed-files:
+  - any-glob-to-any-file: macros/*
+
+Lookups:
+- changed-files:
+  - any-glob-to-any-file: lookups/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,3 +15,4 @@ jobs:
     - uses: actions/labeler@v5
       with:
         sync-labels: true
+        configuration-path: '.github/labeler.yml'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with: 
+        repository: "splunk/security_content"
+    - uses: actions/labeler@v5
+      with:
+        sync-labels: true


### PR DESCRIPTION
### Details

Adds a new simple GitHub Action workflow. It adds labels to PRs based upon the contents changed within them. I've added a handful of labels based upon the type of content we have in our repo, but we can expand it more if we want.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
