### PR TITLE
Unit-test for forks

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -36,9 +36,10 @@ jobs:
             echo "Current Branch (Head Ref): ${{ github.head_ref }}"
             echo "Target Branch (Base Ref): ${{ github.base_ref }}"
             git pull > /dev/null 2>&1
-            git fetch origin pull/${{ github.event.pull_request.number }}/head:new_forked_branch_for_testing
+            #We checkout into a new branch - new_branch_for_testing to avoid name collisions with develop incase the forked PR is from develop
+            git fetch origin pull/${{ github.event.pull_request.number }}/head:new_branch_for_testing
             #We must specifically get the PR's target branch from security_content, not the one that resides in the fork PR's forked repo           
-            git switch new_forked_branch_for_testing
+            git switch new_branch_for_testing
             contentctl test --disable-tqdm --no-enable-integration-testing --post-test-behavior never_pause mode:changes --mode.target-branch ${{ github.base_ref }}
             echo "contentctl test - COMPLETED"
           continue-on-error: true

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -36,11 +36,9 @@ jobs:
             echo "Current Branch (Head Ref): ${{ github.head_ref }}"
             echo "Target Branch (Base Ref): ${{ github.base_ref }}"
             git pull > /dev/null 2>&1
-            git fetch origin pull/${{ github.event.pull_request.number }}/head:${{ github.head_ref }}
-            #We must specifically get the PR's target branch from security_content, not the one that resides in the fork PR's forked repo
-            git switch ${{ github.head_ref }}
-            #git checkout ${{ github.head_ref }}
-            #echo "The target branch for this PR is ${{ github.base_ref }}"
+            git fetch origin pull/${{ github.event.pull_request.number }}/head:new_forked_branch
+            #We must specifically get the PR's target branch from security_content, not the one that resides in the fork PR's forked repo           
+            git switch new_forked_branch
             contentctl test --disable-tqdm --no-enable-integration-testing --post-test-behavior never_pause mode:changes --mode.target-branch ${{ github.base_ref }}
             echo "contentctl test - COMPLETED"
           continue-on-error: true

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -36,9 +36,9 @@ jobs:
             echo "Current Branch (Head Ref): ${{ github.head_ref }}"
             echo "Target Branch (Base Ref): ${{ github.base_ref }}"
             git pull > /dev/null 2>&1
-            git fetch origin pull/${{ github.event.pull_request.number }}/head:new_forked_branch
+            git fetch origin pull/${{ github.event.pull_request.number }}/head:new_forked_branch_for_testing
             #We must specifically get the PR's target branch from security_content, not the one that resides in the fork PR's forked repo           
-            git switch new_forked_branch
+            git switch new_forked_branch_for_testing
             contentctl test --disable-tqdm --no-enable-integration-testing --post-test-behavior never_pause mode:changes --mode.target-branch ${{ github.base_ref }}
             echo "contentctl test - COMPLETED"
           continue-on-error: true


### PR DESCRIPTION
We recently ran into an error with unit testing job for a `fork:develop` branch due to branch name collision when we switch into "develop"

This PR attempts to checkout the source branch of a fork into a new branch name : `new_branch_for_testing`


Sample test that works when the the PR is from fork:develop

https://github.com/splunk/security_content/pull/3071