### PR TITLE
add missing version and id fields to story

### DIFF
--- a/stories/cisa_aa23_347a.yml
+++ b/stories/cisa_aa23_347a.yml
@@ -1,4 +1,6 @@
 name: CISA AA23-347A
+id: 257a2f28-fcbe-4226-8d1f-957880098331
+version: 2
 date: '2023-12-14'
 author: Teoderick Contreras, Rod Soto, Splunk
 description: Leverage searches that allow you to detect and investigate unusual activities


### PR DESCRIPTION
This story was missing the version and id fields.
This was allowed to happen due to a bug in contentctl which is tracked and fixed in the following branch: 
https://github.com/splunk/contentctl/pull/213