### PR TITLE
Marked two detections as manual_test

### DIFF
--- a/detections/endpoint/crowdstrike_medium_severity_alert.yml
+++ b/detections/endpoint/crowdstrike_medium_severity_alert.yml
@@ -52,6 +52,10 @@ tags:
   - event.SeverityName
   risk_score: 49
   security_domain: endpoint
+  manual_test: This detection is marked manual test because the attack_data file and 
+    TA do not provide the src_host and src_ip fields.  src_host is required to be 
+    present for the Risk Message Validation Integration Testing. 
+    This will be investigated and is a tracked issue.
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/endpoint/crowdstrike_medium_severity_alert.yml
+++ b/detections/endpoint/crowdstrike_medium_severity_alert.yml
@@ -53,8 +53,8 @@ tags:
   risk_score: 49
   security_domain: endpoint
   manual_test: This detection is marked manual test because the attack_data file and 
-    TA do not provide the src_host and src_ip fields.  src_host is required to be 
-    present for the Risk Message Validation Integration Testing. 
+    TA do not provide the event.EndpointIp and event.EndpointName fields.  event.EndpointName 
+    is required to be present for the Risk Message Validation Integration Testing. 
     This will be investigated and is a tracked issue.
 tests:
 - name: True Positive Test

--- a/detections/endpoint/crowdstrike_privilege_escalation_for_non_admin_user.yml
+++ b/detections/endpoint/crowdstrike_privilege_escalation_for_non_admin_user.yml
@@ -52,6 +52,10 @@ tags:
   - event.SeverityName
   risk_score: 49
   security_domain: endpoint
+  manual_test: This detection is marked manual test because the attack_data file and 
+    TA do not provide the src_host and src_ip fields.  src_host is required to be 
+    present for the Risk Message Validation Integration Testing. 
+    This will be investigated and is a tracked issue.
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/endpoint/crowdstrike_privilege_escalation_for_non_admin_user.yml
+++ b/detections/endpoint/crowdstrike_privilege_escalation_for_non_admin_user.yml
@@ -53,8 +53,8 @@ tags:
   risk_score: 49
   security_domain: endpoint
   manual_test: This detection is marked manual test because the attack_data file and 
-    TA do not provide the src_host and src_ip fields.  src_host is required to be 
-    present for the Risk Message Validation Integration Testing. 
+    TA do not provide the event.EndpointIp and event.EndpointName fields. event.EndpointName 
+    is required to be present for the Risk Message Validation Integration Testing. 
     This will be investigated and is a tracked issue.
 tests:
 - name: True Positive Test


### PR DESCRIPTION
There is an issue tracking this internally.
 These detections currently fail validation of the Risk Message. We believe this is because the raw, exported data does not export the `event.EndpointIp` and `event.EndpointName` as required for the Risk Message to render properly.
However, we believe this is an artifact of the testing system and does not occur when data is ingested realtime in a production system.