### PR TITLE
More Observable cleanup

### DIFF
--- a/detections/deprecated/aws_cloud_provisioning_from_previously_unseen_region.yml
+++ b/detections/deprecated/aws_cloud_provisioning_from_previously_unseen_region.yml
@@ -49,7 +49,7 @@ tags:
   - T1535
   observable:
   - name: user
-    type: User Name
+    type: User
     role:
     - Victim
   - name: src_ip

--- a/detections/deprecated/detect_aws_api_activities_from_unapproved_accounts.yml
+++ b/detections/deprecated/detect_aws_api_activities_from_unapproved_accounts.yml
@@ -56,7 +56,7 @@ tags:
   - T1078.004
   observable:
   - name: user
-    type: User Name
+    type: User
     role:
     - Victim
   product:

--- a/detections/endpoint/excessive_usage_of_taskkill.yml
+++ b/detections/endpoint/excessive_usage_of_taskkill.yml
@@ -57,10 +57,6 @@ tags:
     type: Endpoint
     role:
     - Victim
-  - name: dest
-    type: Endpoint
-    role:
-    - Victim
   - name: parent_process_name
     type: Process Name
     role:

--- a/detections/endpoint/kerberos_pre_authentication_flag_disabled_in_useraccountcontrol.yml
+++ b/detections/endpoint/kerberos_pre_authentication_flag_disabled_in_useraccountcontrol.yml
@@ -38,7 +38,7 @@ tags:
   - T1558.004
   observable:
   - name: user
-    type: User Name
+    type: User
     role:
     - Victim
   product:

--- a/detections/endpoint/windows_alternate_datastream___base64_content.yml
+++ b/detections/endpoint/windows_alternate_datastream___base64_content.yml
@@ -49,7 +49,7 @@ tags:
     role:
     - Victim
   - name: user
-    type: User Name
+    type: User
     role:
     - Victim
   - name: file_name

--- a/detections/endpoint/windows_alternate_datastream___executable_content.yml
+++ b/detections/endpoint/windows_alternate_datastream___executable_content.yml
@@ -44,7 +44,7 @@ tags:
     role:
     - Victim
   - name: user
-    type: User Name
+    type: User
     role:
     - Victim
 

--- a/detections/endpoint/windows_alternate_datastream___process_execution.yml
+++ b/detections/endpoint/windows_alternate_datastream___process_execution.yml
@@ -49,7 +49,7 @@ tags:
     role:
     - Victim
   - name: user
-    type: User Name
+    type: User
     role:
     - Victim
   - name: process_name

--- a/detections/endpoint/windows_disable_or_modify_tools_via_taskkill.yml
+++ b/detections/endpoint/windows_disable_or_modify_tools_via_taskkill.yml
@@ -52,10 +52,6 @@ tags:
     type: Endpoint
     role:
     - Victim
-  - name: dest
-    type: Endpoint
-    role:
-    - Victim
   - name: parent_process_name
     type: Process Name
     role:

--- a/detections/endpoint/windows_uac_bypass_suspicious_child_process.yml
+++ b/detections/endpoint/windows_uac_bypass_suspicious_child_process.yml
@@ -54,7 +54,7 @@ tags:
     role:
     - Victim
   - name: user
-    type: User Name
+    type: User
     role:
     - Victim
   - name: process_name

--- a/detections/endpoint/windows_uac_bypass_suspicious_escalation_behavior.yml
+++ b/detections/endpoint/windows_uac_bypass_suspicious_escalation_behavior.yml
@@ -66,7 +66,7 @@ tags:
     role:
     - Victim
   - name: user
-    type: User Name
+    type: User
     role:
     - Victim
   - name: process_name


### PR DESCRIPTION
### Details

More cleanup of `tags.observable`- opting to force cases of `type: User Name` to `type: User` for now, as soon we'll be eliminating this complexity from the risk_object side, and simplifying the threat_object side.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://docs.splunk.com/Documentation/SplunkCloud/8.2.2203/Admin/PrivateApps#Manage_lookups_in_Splunk_Cloud_Platform) but the short version is that any changes to lookup files need to bump the datestamp in the lookup CSV filename, and the reference to it in the YAML needs to be updated.