### PR TITLE
Update misnamed eventid

### DIFF
--- a/data_sources/windows_event_log_security_4688.yml
+++ b/data_sources/windows_event_log_security_4688.yml
@@ -1,7 +1,7 @@
 name: Windows Event Log Security 4688
 id: d195eb26-a81c-45ed-aeb3-25792e8a985a
-version: 1
-date: '2024-07-18'
+version: 2
+date: '2024-09-26'
 author: Patrick Bareiss, Splunk
 description: Data source object for Windows Event Log Security 4688
 source: XmlWinEventLog:Security
@@ -114,7 +114,7 @@ field_mappings:
       ParentProcessName|endswith: actor.process.file.name
       Computer: device.hostname
 convert_to_log_source:
-  - data_source: Sysmon Event ID 1
+  - data_source: Sysmon EventID 1
     mapping:
       NewProcessId: ProcessId #New_Process_ID in Hex
       NewProcessName: Image

--- a/detections/application/windows_ad_privileged_group_modification.yml
+++ b/detections/application/windows_ad_privileged_group_modification.yml
@@ -6,7 +6,7 @@ author: Dean Luxton
 status: experimental
 type: TTP
 data_source:
-- XmlWinEventLog:Security
+- Windows Event Log Security 4728
 description: Detect users added to privileged AD Groups. 
 search: '`wineventlog_security` EventCode IN (4728)
   | stats min(_time) as _time dc(user) as usercount, values(user) as user values(user_category) as user_category values(src_user_category) as src_user_category values(dvc) as dvc by signature, Group_Name,src_user

--- a/detections/application/windows_ad_privileged_group_modification.yml
+++ b/detections/application/windows_ad_privileged_group_modification.yml
@@ -1,7 +1,7 @@
 name: Windows AD Privileged Group Modification
 id: 187bf937-c436-4c65-bbcb-7539ffe02da1
-version: 1
-date: '2023-09-27'
+version: 2
+date: '2024-09-27'
 author: Dean Luxton
 status: experimental
 type: TTP

--- a/detections/endpoint/create_remote_thread_into_lsass.yml
+++ b/detections/endpoint/create_remote_thread_into_lsass.yml
@@ -1,13 +1,13 @@
 name: Create Remote Thread into LSASS
 id: 67d4dbef-9564-4699-8da8-03a151529edc
-version: 3
-date: '2024-08-14'
+version: 4
+date: '2024-09-26'
 author: Patrick Bareiss, Splunk
 status: production
 type: TTP
 description: "The following analytic detects the creation of a remote thread in the
   Local Security Authority Subsystem Service (LSASS). This behavior is identified
-  using Sysmon Event ID 8 logs, focusing on processes that create remote threads in
+  using Sysmon EventID 8 logs, focusing on processes that create remote threads in
   lsass.exe. This activity is significant because it is commonly associated with credential
   dumping, a tactic used by adversaries to steal user authentication credentials.
   If confirmed malicious, this could allow attackers to gain unauthorized access to

--- a/detections/endpoint/detect_regsvcs_with_network_connection.yml
+++ b/detections/endpoint/detect_regsvcs_with_network_connection.yml
@@ -1,13 +1,13 @@
 name: Detect Regsvcs with Network Connection
 id: e3e7a1c0-f2b9-445c-8493-f30a63522d1a
-version: 5
-date: '2024-08-14'
+version: 6
+date: '2024-09-26'
 author: Michael Haag, Splunk
 status: production
 type: TTP
 description: The following analytic identifies instances of Regsvcs.exe establishing
   a network connection to a public IP address, excluding private IP ranges. This detection
-  leverages Sysmon Event ID 3 logs to monitor network connections initiated by Regsvcs.exe.
+  leverages Sysmon EventID 3 logs to monitor network connections initiated by Regsvcs.exe.
   This activity is significant as Regsvcs.exe, a legitimate Microsoft-signed binary,
   can be exploited to bypass application control mechanisms and establish remote Command
   and Control (C2) channels. If confirmed malicious, this behavior could allow an

--- a/detections/endpoint/suspicious_process_dns_query_known_abuse_web_services.yml
+++ b/detections/endpoint/suspicious_process_dns_query_known_abuse_web_services.yml
@@ -1,13 +1,13 @@
 name: Suspicious Process DNS Query Known Abuse Web Services
 id: 3cf0dc36-484d-11ec-a6bc-acde48001122
-version: 3
-date: '2024-05-13'
+version: 4
+date: '2024-09-26'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
 description: The following analytic detects a suspicious process making DNS queries
   to known, abused text-paste web services, VoIP, instant messaging, and digital distribution
-  platforms. It leverages Sysmon Event ID 22 logs to identify queries from processes
+  platforms. It leverages Sysmon EventID 22 logs to identify queries from processes
   like cmd.exe, powershell.exe, and others. This activity is significant as it may
   indicate an attempt to download malicious files, a common initial access technique.
   If confirmed malicious, this could lead to unauthorized code execution, data exfiltration,

--- a/detections/endpoint/windows_dism_install_powershell_web_access.yml
+++ b/detections/endpoint/windows_dism_install_powershell_web_access.yml
@@ -1,14 +1,14 @@
 name: Windows DISM Install PowerShell Web Access
 id: fa6142a7-c364-4d11-9954-895dd9efb2d4
-version: 2
-date: '2024-09-24'
+version: 3
+date: '2024-09-26'
 author: Michael Haag, Splunk
-data_sources:
+data_source:
 - Windows Event Log Security 4688
 - Sysmon EventID 1
 type: TTP
 status: production
-description: The following analytic detects the installation of PowerShell Web Access using the Deployment Image Servicing and Management (DISM) tool. It leverages Sysmon Event ID 1 to identify the execution of `dism.exe` with specific parameters related to enabling the WindowsPowerShellWebAccess feature. This activity is significant because enabling PowerShell Web Access can facilitate remote execution of PowerShell commands, potentially allowing an attacker to gain unauthorized access to systems and networks. If confirmed malicious, this action could lead to further exploitation and compromise of the affected system.
+description: The following analytic detects the installation of PowerShell Web Access using the Deployment Image Servicing and Management (DISM) tool. It leverages Sysmon EventID 1 to identify the execution of `dism.exe` with specific parameters related to enabling the WindowsPowerShellWebAccess feature. This activity is significant because enabling PowerShell Web Access can facilitate remote execution of PowerShell commands, potentially allowing an attacker to gain unauthorized access to systems and networks. If confirmed malicious, this action could lead to further exploitation and compromise of the affected system.
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime 
     from datamodel=Endpoint.Processes 
     where Processes.process_name=dism.exe 

--- a/detections/endpoint/windows_enable_powershell_web_access.yml
+++ b/detections/endpoint/windows_enable_powershell_web_access.yml
@@ -1,9 +1,9 @@
 name: Windows Enable PowerShell Web Access
 id: 175bb2de-6227-416b-9678-9b61999cd21f
-version: 1
-date: '2024-09-03'
+version: 2
+date: '2024-09-26'
 author: Michael Haag, Splunk
-data_sources:
+data_source:
   - Powershell Script Block Logging 4104
 type: TTP
 status: production

--- a/detections/endpoint/windows_impair_defenses_disable_av_autostart_via_registry.yml
+++ b/detections/endpoint/windows_impair_defenses_disable_av_autostart_via_registry.yml
@@ -1,10 +1,10 @@
 name: Windows Impair Defenses Disable AV AutoStart via Registry
 id: 31a13f43-812e-4752-a6ca-c6c87bf03e83
-version: 1
-date: '2024-09-11'
+version: 2
+date: '2024-09-26'
 author: Teoderick Contreras, Splunk
-data_sources:
-- Sysmon Event ID 13
+data_source:
+- Sysmon EventID 13
 type: TTP
 status: production
 description: The following analytic detects modifications to the registry related to the disabling of autostart 

--- a/detections/endpoint/windows_modify_registry_utilize_progids.yml
+++ b/detections/endpoint/windows_modify_registry_utilize_progids.yml
@@ -1,10 +1,10 @@
 name: Windows Modify Registry Utilize ProgIDs
 id: 64fa82dd-fd11-472a-9e94-c221fffa591d
-version: 1
-date: '2024-09-18'
+version: 2
+date: '2024-09-26'
 author: Teoderick Contreras, Splunk
-data_sources:
-- Sysmon Event ID 13
+data_source:
+- Sysmon EventID 13
 type: Anomaly
 status: production
 description: The following analytic detects modifications to the Windows Registry specifically targeting Programmatic Identifier associations to bypass User Account Control (UAC) Windows OS feature. ValleyRAT may create or alter registry entries to targetted progIDs like `.pwn` files with malicious processes, allowing it to execute harmful scripts or commands when these files are opened. By monitoring for unusual changes in registry keys linked to ProgIDs, this detection enables security analysts to identify potential threats like ValleyRAT execution attempts. Early detection of these modifications helps mitigate unauthorized execution and prevents further exploitation of the system.

--- a/detections/endpoint/windows_modify_registry_valleyrat_c2_config.yml
+++ b/detections/endpoint/windows_modify_registry_valleyrat_c2_config.yml
@@ -1,9 +1,9 @@
 name: Windows Modify Registry ValleyRAT C2 Config
 id: ac59298a-8d81-4c02-8c9b-ffdac993891f
-version: 1
-date: '2024-09-11'
+version: 2
+date: '2024-09-26'
 author: Teoderick Contreras, Splunk
-data_sources:
+data_source:
 - Sysmon EventID 12 
 - Sysmon EventID 13
 type: TTP

--- a/detections/endpoint/windows_modify_registry_valleyrat_pwn_reg_entry.yml
+++ b/detections/endpoint/windows_modify_registry_valleyrat_pwn_reg_entry.yml
@@ -1,10 +1,10 @@
 name: Windows Modify Registry ValleyRat PWN Reg Entry
 id: 6947c44e-be1f-4dd9-b198-bc42be5be196
-version: 1
-date: '2024-09-11'
+version: 2
+date: '2024-09-26'
 author: Teoderick Contreras, Splunk
-data_sources:
-- Sysmon Event ID 13
+data_source:
+- Sysmon EventID 13
 type: TTP
 status: production
 description: The following analytic detects modifications to the Windows Registry specifically targeting `.pwn` file associations related to the ValleyRAT malware. ValleyRAT may create or alter registry entries to associate `.pwn` files with malicious processes, allowing it to execute harmful scripts or commands when these files are opened. By monitoring for unusual changes in registry keys linked to `.pwn` extensions, this detection enables security analysts to identify potential ValleyRAT infection attempts. Early detection of these modifications helps mitigate unauthorized execution and prevents further exploitation of the system.

--- a/detections/endpoint/windows_privileged_group_modification.yml
+++ b/detections/endpoint/windows_privileged_group_modification.yml
@@ -1,9 +1,9 @@
 name: Windows Privileged Group Modification
 id: b8cbef2c-2cc3-4550-b0fc-9715b7852df9
-version: 2
-date: '2024-08-15'
+version: 3
+date: '2024-09-26'
 author: Brandon Sternfield, Optiv + ClearShark
-data_sources:
+data_source:
 - Windows Event Log Security 4727
 - Windows Event Log Security 4731
 - Windows Event Log Security 4744

--- a/detections/endpoint/windows_scheduled_task_dll_module_loaded.yml
+++ b/detections/endpoint/windows_scheduled_task_dll_module_loaded.yml
@@ -1,10 +1,10 @@
 name: Windows Scheduled Task DLL Module Loaded
 id: bc5b2304-f241-419b-874a-e927f667b7b6
-version: 1
-date: '2024-09-11'
+version: 2
+date: '2024-09-26'
 author: Teoderick Contreras, Splunk
-data_sources:
-- Sysmon Event ID 7
+data_source:
+- Sysmon EventID 7
 type: TTP
 status: production
 description: The following analytic detects instances where the taskschd.dll is loaded by processes running in 

--- a/detections/endpoint/windows_scheduled_tasks_for_compmgmtlauncher_or_eventvwr.yml
+++ b/detections/endpoint/windows_scheduled_tasks_for_compmgmtlauncher_or_eventvwr.yml
@@ -1,9 +1,9 @@
 name: Windows Scheduled Tasks for CompMgmtLauncher or Eventvwr
 id: feb43b86-8c38-46cd-865e-20ce8a96c26c
-version: 1
-date: '2024-09-11'
+version: 2
+date: '2024-09-26'
 author: Teoderick Contreras, Splunk
-data_sources:
+data_source:
 - Windows Security 4698
 type: TTP
 status: production

--- a/detections/endpoint/wmi_permanent_event_subscription.yml
+++ b/detections/endpoint/wmi_permanent_event_subscription.yml
@@ -1,12 +1,12 @@
 name: WMI Permanent Event Subscription
 id: 71bfdb13-f200-4c6c-b2c9-a2e07adf437d
-version: 2
-date: '2024-05-26'
+version: 3
+date: '2024-09-26'
 author: Rico Valdez, Splunk
 status: experimental
 type: TTP
 description: |-
-  The following analytic detects the creation of permanent event subscriptions using Windows Management Instrumentation (WMI). It leverages Sysmon Event ID 5 data to identify instances where the event consumers are not the expected "NTEventLogEventConsumer." This activity is significant because it suggests an attacker is attempting to achieve persistence by running malicious scripts or binaries in response to specific system events. If confirmed malicious, this could lead to severe impacts such as data theft, ransomware deployment, or other damaging outcomes. Investigate the associated scripts or binaries to identify the source of the attack.
+  The following analytic detects the creation of permanent event subscriptions using Windows Management Instrumentation (WMI). It leverages Sysmon EventID 5 data to identify instances where the event consumers are not the expected "NTEventLogEventConsumer." This activity is significant because it suggests an attacker is attempting to achieve persistence by running malicious scripts or binaries in response to specific system events. If confirmed malicious, this could lead to severe impacts such as data theft, ransomware deployment, or other damaging outcomes. Investigate the associated scripts or binaries to identify the source of the attack.
 data_source: []
 search: '`wmi` EventCode=5861 Binding | rex field=Message "Consumer =\s+(?<consumer>[^;|^$]+)"
   | search consumer!="NTEventLogEventConsumer=\"SCM Event Log Consumer\"" | stats


### PR DESCRIPTION
A number of YMLs had issues around the data_source object(s) in the YMLs.
Either the wrong named were used for Sysmon EventID (a space was accidentally included), the key in the YML was `data_sources` instead of `data_source`, or other minor issues.
This PR should resolve those issues.