### PR TITLE
Update erroneous cloud security_domain

### DIFF
--- a/detections/cloud/abnormally_high_number_of_cloud_instances_destroyed.yml
+++ b/detections/cloud/abnormally_high_number_of_cloud_instances_destroyed.yml
@@ -66,4 +66,4 @@ tags:
   - All_Changes.object_category
   - All_Changes.user
   risk_score: 25
-  security_domain: cloud
+  security_domain: threat

--- a/detections/cloud/abnormally_high_number_of_cloud_instances_destroyed.yml
+++ b/detections/cloud/abnormally_high_number_of_cloud_instances_destroyed.yml
@@ -1,7 +1,7 @@
 name: Abnormally High Number Of Cloud Instances Destroyed
 id: ef629fc9-1583-4590-b62a-f2247fbf7bbf
-version: 3
-date: '2024-10-17'
+version: 4
+date: '2024-10-22'
 author: David Dorsey, Splunk
 status: experimental
 type: Anomaly

--- a/detections/cloud/abnormally_high_number_of_cloud_instances_launched.yml
+++ b/detections/cloud/abnormally_high_number_of_cloud_instances_launched.yml
@@ -62,4 +62,4 @@ tags:
   - All_Changes.object_category
   - All_Changes.user
   risk_score: 25
-  security_domain: cloud
+  security_domain: threat

--- a/detections/cloud/abnormally_high_number_of_cloud_instances_launched.yml
+++ b/detections/cloud/abnormally_high_number_of_cloud_instances_launched.yml
@@ -1,7 +1,7 @@
 name: Abnormally High Number Of Cloud Instances Launched
 id: f2361e9f-3928-496c-a556-120cd4223a65
-version: 4
-date: '2024-10-17'
+version: 5
+date: '2024-10-22'
 author: David Dorsey, Splunk
 status: experimental
 type: Anomaly

--- a/detections/cloud/asl_aws_iam_failure_group_deletion.yml
+++ b/detections/cloud/asl_aws_iam_failure_group_deletion.yml
@@ -53,7 +53,7 @@ tags:
   - src_endpoint.ip
   - cloud.region
   risk_score: 5
-  security_domain: cloud
+  security_domain: access
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/cloud/asl_aws_iam_failure_group_deletion.yml
+++ b/detections/cloud/asl_aws_iam_failure_group_deletion.yml
@@ -1,7 +1,7 @@
 name: ASL AWS IAM Failure Group Deletion
 id: 8d12f268-c567-4557-9813-f8389e235c06
-version: 4
-date: '2024-09-30'
+version: 5
+date: '2024-10-22'
 author: Patrick Bareiss, Splunk
 status: production
 type: Anomaly

--- a/detections/cloud/asl_aws_iam_successful_group_deletion.yml
+++ b/detections/cloud/asl_aws_iam_successful_group_deletion.yml
@@ -1,7 +1,7 @@
 name: ASL AWS IAM Successful Group Deletion
 id: 1bbe54f1-93d7-4764-8a01-ddaa12ece7ac
-version: 3
-date: '2024-10-17'
+version: 4
+date: '2024-10-22'
 author: Patrick Bareiss, Splunk
 status: production
 type: Hunting

--- a/detections/cloud/asl_aws_iam_successful_group_deletion.yml
+++ b/detections/cloud/asl_aws_iam_successful_group_deletion.yml
@@ -58,7 +58,7 @@ tags:
   - src_endpoint.ip
   - cloud.region
   risk_score: 5
-  security_domain: cloud
+  security_domain: access
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/cloud/aws_iam_failure_group_deletion.yml
+++ b/detections/cloud/aws_iam_failure_group_deletion.yml
@@ -52,7 +52,7 @@ tags:
   - errorCode
   - requestParameters.groupName
   risk_score: 5
-  security_domain: cloud
+  security_domain: access
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/cloud/aws_iam_failure_group_deletion.yml
+++ b/detections/cloud/aws_iam_failure_group_deletion.yml
@@ -1,7 +1,7 @@
 name: AWS IAM Failure Group Deletion
 id: 723b861a-92eb-11eb-93b8-acde48001122
-version: 4
-date: '2024-09-30'
+version: 5
+date: '2024-10-22'
 author: Michael Haag, Splunk
 status: production
 type: Anomaly

--- a/detections/cloud/aws_iam_successful_group_deletion.yml
+++ b/detections/cloud/aws_iam_successful_group_deletion.yml
@@ -1,7 +1,7 @@
 name: AWS IAM Successful Group Deletion
 id: e776d06c-9267-11eb-819b-acde48001122
-version: 3
-date: '2024-10-17'
+version: 4
+date: '2024-10-22'
 author: Michael Haag, Splunk
 status: production
 type: Hunting

--- a/detections/cloud/aws_iam_successful_group_deletion.yml
+++ b/detections/cloud/aws_iam_successful_group_deletion.yml
@@ -65,7 +65,7 @@ tags:
   - errorCode
   - requestParameters.groupName
   risk_score: 5
-  security_domain: cloud
+  security_domain: access
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/cloud/aws_lambda_updatefunctioncode.yml
+++ b/detections/cloud/aws_lambda_updatefunctioncode.yml
@@ -1,7 +1,7 @@
 name: AWS Lambda UpdateFunctionCode
 id: 211b80d3-6340-4345-11ad-212bf3d0d111
-version: 3
-date: '2024-10-17'
+version: 4
+date: '2024-10-22'
 author: Bhavin Patel, Splunk
 status: production
 type: Hunting

--- a/detections/cloud/aws_lambda_updatefunctioncode.yml
+++ b/detections/cloud/aws_lambda_updatefunctioncode.yml
@@ -54,7 +54,7 @@ tags:
   - userAgent
   - errorCode
   risk_score: 63
-  security_domain: cloud
+  security_domain: threat
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/cloud/risk_rule_for_dev_sec_ops_by_repository.yml
+++ b/detections/cloud/risk_rule_for_dev_sec_ops_by_repository.yml
@@ -1,7 +1,7 @@
 name: Risk Rule for Dev Sec Ops by Repository
 id: 161bc0ca-4651-4c13-9c27-27770660cf67
-version: 3
-date: '2024-09-30'
+version: 4
+date: '2024-10-22'
 author: Bhavin Patel
 status: production
 type: Correlation

--- a/detections/cloud/risk_rule_for_dev_sec_ops_by_repository.yml
+++ b/detections/cloud/risk_rule_for_dev_sec_ops_by_repository.yml
@@ -42,7 +42,7 @@ tags:
   required_fields:
   - _time
   risk_score: 70
-  security_domain: cloud
+  security_domain: threat
 tests:
 - name: True Positive Test
   attack_data:


### PR DESCRIPTION
`security_domain: cloud` appeared in a number of detections, but this is not a valid value for the security_domain enumeration in Enterprise Security.
This has been fixed in the following contentctl PR:  https://github.com/splunk/contentctl/pull/314

Once that PR has been merged, this PR should be evaluated and merged as well.
