### PR TITLE
Fix date so its not in the future

### DIFF
--- a/stories/braodo_stealer.yml
+++ b/stories/braodo_stealer.yml
@@ -1,7 +1,7 @@
 name: Braodo Stealer
 id: ec5c8721-3c13-45ac-90e8-64c63a8fdc24
 version: 1
-date: '2024-11-24'
+date: '2024-10-24'
 author: Teoderick Contreras, Splunk
 description: Leverage searches that allow you to detect and investigate unusual activities that may be related to the Braodo Stealer malware, a malicious software designed to steal sensitive information from infected systems. This malware typically targets login credentials, browser history, cookies, and stored passwords. Braodo Stealer often infiltrates through phishing campaigns or malicious downloads, enabling attackers to gain unauthorized access to personal and financial data. By monitoring unusual system behaviors, such as unauthorized network connections or data exfiltration, you can help prevent data breaches and mitigate the impact of this threat.
 narrative: Braodo Stealer is a stealthy and dangerous piece of malware specifically engineered to siphon sensitive information from compromised systems. Often spread through phishing emails or disguised as legitimate downloads, it silently infiltrates a victim’s device. Once inside, it scours through browser histories, steals login credentials, captures cookies, and even extracts saved passwords from various applications. With this stolen data, cybercriminals can gain access to banking accounts, social media profiles, or business platforms. What makes Braodo Stealer particularly threatening is its ability to remain undetected, allowing attackers to exploit compromised systems for extended periods before the user becomes aware.


### PR DESCRIPTION
### Details

Change the date on the braodo_stealer.yml story so that its not in the future.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://docs.splunk.com/Documentation/SplunkCloud/8.2.2203/Admin/PrivateApps#Manage_lookups_in_Splunk_Cloud_Platform) but the short version is that any changes to lookup files need to bump the datestamp in the lookup CSV filename, and the reference to it in the YAML needs to be updated.