### PR TITLE
Bump version 4 44 0

### DIFF
--- a/app_template/metadata/default.meta
+++ b/app_template/metadata/default.meta
@@ -5,19 +5,3 @@ export = system
 
 [savedsearches]
 owner = admin
-
-## Correlation Searches
-[correlationsearches]
-access = read : [ * ], write : [ * ]
-
-[governance]
-access = read : [ * ], write : [ * ]
-
-## Managed Configurations
-[managed_configurations]
-access = read : [ * ], write : [ * ]
-
-## Postprocess
-[postprocess]
-access = read : [ * ], write : [ * ]
-

--- a/contentctl.yml
+++ b/contentctl.yml
@@ -3,7 +3,7 @@ app:
   uid: 3449
   title: ES Content Updates
   appid: DA-ESS-ContentUpdate
-  version: 4.43.0
+  version: 4.44.0
   description: Explore the Analytic Stories included with ES Content Updates.
   prefix: ESCU
   label: ESCU


### PR DESCRIPTION
Bump version in prep for release and remove stanzas from default.meta.
These stanzas make Splunk say that a restart of the server is necessary after installation of ESCU when it should NOT be required.