### PR TITLE
fix #2996

### DIFF
--- a/detections/endpoint/known_services_killed_by_ransomware.yml
+++ b/detections/endpoint/known_services_killed_by_ransomware.yml
@@ -1,7 +1,7 @@
 name: Known Services Killed by Ransomware
 id: 3070f8e0-c528-11eb-b2a0-acde48001122
-version: '6'
-date: '2024-11-28'
+version: 7
+date: '2024-12-09'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
@@ -18,8 +18,8 @@ data_source:
 search: '`wineventlog_system` EventCode=7036 param1 IN ("*Volume Shadow Copy*","*VSS*",
   "*backup*", "*sophos*", "*sql*", "*memtas*", "*mepocs*", "*veeam*", "*svc$*", "DefWatch",
   "ccEvtMgr", "ccSetMgr", "SavRoam", "RTVscan", "QBFCService", "QBIDPService", "Intuit.QuickBooks.FCS",
-  "QBCFMonitorService" "YooBackup", "YooIT", "*Veeam*", "PDVFSService", "BackupExecVSSProvider",
-  "BackupExecAgentAccelerator", "BackupExec*", "WdBoot", "WdFilter", "WdNisDrv", "WdNisSvc",
+  "QBCFMonitorService", "YooBackup", "YooIT", "*Veeam*", "PDVFSService", "BackupExec*",
+  "WdBoot", "WdFilter", "WdNisDrv", "WdNisSvc",
   "WinDefend", "wscsvc", "Sense", "sppsvc", "SecurityHealthService") param2="stopped"
   | stats count min(_time) as firstTime max(_time) as lastTime by EventCode param1
   dest | `security_content_ctime(lastTime)` | `security_content_ctime(firstTime)`


### PR DESCRIPTION
### Details

This PR aims to fix the issues raised by #2996 by adding the appropriate missing comma and removes the overlapping "BackupExecVSSProvider" and "BackupExecAgentAccelerator" that are already covered by "BackupExec*"

The list of services was gathered from https://news.sophos.com/en-us/2020/04/24/lockbit-ransomware-borrows-tricks-to-keep-up-with-revil-and-maze/ hence most of these do not need wildcards (as the op assumed).