### PR TITLE
Nterl0k - T1595 - Generic Scanning Behavior 

### DIFF
--- a/detections/endpoint/windows_detect-network_scanner_behavior.yml
+++ b/detections/endpoint/windows_detect-network_scanner_behavior.yml
@@ -7,7 +7,7 @@ status: production
 type: Anomaly
 description: The following analytic detects when an application is used to connect a large number of unique ports/targets within a short time frame. Network enumeration may be used by adversaries as a method of discovery, lateral movement, or remote execution. This analytic may require significant tuning depending on the organization and applications being actively used, highly recommended to pre-populate the filter macro prior to activation.
 data_source: 
-- Sysmon EID 3
+- Sysmon EventID 3
 search: '| tstats `security_content_summariesonly` count latest(All_Traffic.dest_port) as dest_port dc(All_Traffic.dest_port) as port_count dc(All_Traffic.dest) as dest_count min(_time) as firstTime max(_time) as lastTime values(All_Traffic.process_id) as process_id from datamodel=Network_Traffic.All_Traffic where sourcetype=XmlWinEventLog All_Traffic.app = "*\\*" All_Traffic.dest_port < 32000 NOT All_Traffic.dest_port IN (8443,8080,5353,3268,443,389,88,80,53,25) by host,All_Traffic.app,All_Traffic.src,All_Traffic.src_ip,All_Traffic.user _time span=5m
 | `drop_dm_object_name(All_Traffic)`
 | rex field=app ".*\\\(?<process_name>.*)$"

--- a/detections/endpoint/windows_detect-network_scanner_behavior.yml
+++ b/detections/endpoint/windows_detect-network_scanner_behavior.yml
@@ -1,0 +1,65 @@
+name: Windows Detect Network Scanner Behavior
+id: 78e678d2-bf64-4fe6-aa52-2f7b11dddee7
+version: 1
+date: '2024-12-26'
+author: Steven Dick
+status: production
+type: Anomaly
+description: The following analytic detects when an application is used to connect a large number of unique ports/targets within a short time frame. Network enumeration may be used by adversaries as a method of discovery, lateral movement, or remote execution. This analytic may require significant tuning depending on the organization and applications being actively used, highly recommended to pre-populate the filter macro prior to activation.
+data_source: 
+- Sysmon EID 3
+search: '| tstats `security_content_summariesonly` count latest(All_Traffic.dest_port) as dest_port dc(All_Traffic.dest_port) as port_count dc(All_Traffic.dest) as dest_count min(_time) as firstTime max(_time) as lastTime values(All_Traffic.process_id) as process_id from datamodel=Network_Traffic.All_Traffic where sourcetype=XmlWinEventLog All_Traffic.app = "*\\*" All_Traffic.dest_port < 32000 NOT All_Traffic.dest_port IN (8443,8080,5353,3268,443,389,88,80,53,25) by host,All_Traffic.app,All_Traffic.src,All_Traffic.src_ip,All_Traffic.user _time span=5m
+| `drop_dm_object_name(All_Traffic)`
+| rex field=app ".*\\\(?<process_name>.*)$"
+| where port_count > 10 OR dest_count > 10
+| stats latest(src) as src, latest(src_ip) as src_ip, max(dest_count) as dest_count, max(port_count) as port_count, latest(dest_port) as dest_port, min(firstTime) as firstTime, max(lastTime) as lastTime, max(count) as count by host,user,app,process_name
+| `security_content_ctime(firstTime)`
+| `security_content_ctime(lastTime)`
+| `windows_detect_network_scanner_behavior_filter`'
+how_to_implement: This detection relies on Sysmon EID3 events being ingested AND tagged into the networking datamodel.
+known_false_positives: Various, could be noisy depending on processes in the organization and sysmon configuration used. Adjusted port/dest count thresholds as needed.
+references:
+- https://attack.mitre.org/techniques/T1595
+tags:
+  asset_type: Endpoint
+  confidence: 50
+  impact: 50
+  message: A process exhibiting network scanning behavior [$process_name$] was detected on $src$
+  mitre_attack_id: 
+  - T1595
+  - T1595.001
+  - T1595.002
+  - T1423
+  observable: 
+  - name: src
+    type: system
+    role:
+    - Victim
+  - name: user
+    type: user
+    role:
+    - Victim
+  - name: process_name
+    type: process_name
+    role:
+    - Attacker
+  product: 
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields: 
+  - All_Traffic.dest_port
+  - host
+  - All_Traffic.app
+  - All_Traffic.src
+  - All_Traffic.src_ip
+  - All_Traffic.user 
+  - _time
+  risk_score: 25
+  security_domain: network
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1595/sysmon_scanning_events/sysmon_scanning_events.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/endpoint/windows_detect_network_scanner_behavior.yml
+++ b/detections/endpoint/windows_detect_network_scanner_behavior.yml
@@ -41,7 +41,6 @@ tags:
   - T1595
   - T1595.001
   - T1595.002
-  - T1423
   observable: 
   - name: src
     type: IP Address

--- a/detections/endpoint/windows_detect_network_scanner_behavior.yml
+++ b/detections/endpoint/windows_detect_network_scanner_behavior.yml
@@ -16,11 +16,23 @@ search: '| tstats `security_content_summariesonly` count latest(All_Traffic.dest
 | `security_content_ctime(firstTime)`
 | `security_content_ctime(lastTime)`
 | `windows_detect_network_scanner_behavior_filter`'
-how_to_implement: This detection relies on Sysmon EID3 events being ingested AND tagged into the networking datamodel.
+how_to_implement: This detection relies on Sysmon EventID 3 events being ingested AND tagged into the Network_Traffic datamodel.
 known_false_positives: Various, could be noisy depending on processes in the organization and sysmon configuration used. Adjusted port/dest count thresholds as needed.
 references:
 - https://attack.mitre.org/techniques/T1595
+drilldown_searches:
+- name: View the detection results for - "$src$" and "$user$"
+  search: '%original_detection_search% | search  src = "$src$" user = "$user$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$src$" and "$user$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
 tags:
+  analytic_story:
+  - Network Discovery
+  - Windows Discovery Techniques
   asset_type: Endpoint
   confidence: 50
   impact: 50
@@ -32,15 +44,15 @@ tags:
   - T1423
   observable: 
   - name: src
-    type: system
+    type: IP Address
     role:
     - Victim
   - name: user
-    type: user
+    type: User
     role:
     - Victim
   - name: process_name
-    type: process_name
+    type: Process
     role:
     - Attacker
   product: 


### PR DESCRIPTION
### Details

Just a simple generic scanning behavior detection from Sysmon EID3 events. Optimized using Traffic datamodel.

Pending - https://github.com/splunk/attack_data/pull/922 

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://docs.splunk.com/Documentation/SplunkCloud/8.2.2203/Admin/PrivateApps#Manage_lookups_in_Splunk_Cloud_Platform) but the short version is that any changes to lookup files need to bump the datestamp in the lookup CSV filename, and the reference to it in the YAML needs to be updated.