### PR TITLE
Restore deleted analytics to deprecated

### DIFF
--- a/detections/deprecated/attempt_to_stop_security_service.yml
+++ b/detections/deprecated/attempt_to_stop_security_service.yml
@@ -1,0 +1,96 @@
+name: Attempt To Stop Security Service
+id: c8e349c6-b97c-486e-8949-bd7bcd1f3910
+version: 9
+date: '2025-01-24'
+author: Rico Valdez, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects attempts to stop security-related services
+  on an endpoint, which may indicate malicious activity. It leverages data from Endpoint
+  Detection and Response (EDR) agents, specifically searching for processes involving
+  the "sc.exe" command with the "stop" parameter. This activity is significant because
+  disabling security services can undermine the organization's security posture, potentially
+  leading to unauthorized access, data exfiltration, or further attacks like malware
+  installation or privilege escalation. If confirmed malicious, this behavior could
+  compromise the endpoint and the entire network, necessitating immediate investigation
+  and response.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` values(Processes.process) as process
+  min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
+  where `process_net` OR  Processes.process_name = sc.exe Processes.process="* stop
+  *" by Processes.dest Processes.user Processes.parent_process Processes.parent_process_name
+  Processes.process_name Processes.original_file_name Processes.process Processes.process_id
+  Processes.parent_process_id | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` |lookup security_services_lookup service as
+  process OUTPUTNEW category, description | search category=security | `attempt_to_stop_security_service_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: None identified. Attempts to disable security-related services
+  should be identified and understood.
+references:
+- https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1562.001/T1562.001.md#atomic-test-14---disable-arbitrary-security-windows-service
+- https://www.microsoft.com/security/blog/2022/01/15/destructive-malware-targeting-ukrainian-organizations/
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $parent_process_name$ spawning $process_name$ was identified
+    attempting to disable security services on endpoint $dest$ by user $user$.
+  risk_objects:
+  - field: user
+    type: user
+    score: 20
+  - field: dest
+    type: system
+    score: 20
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - WhisperGate
+  - Graceful Wipe Out Attack
+  - Disabling Security Tools
+  - Data Destruction
+  - Azorult
+  - Trickbot
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1562.001
+  - T1562
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1562.001/win_defend_service_stop/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/change_default_file_association.yml
+++ b/detections/deprecated/change_default_file_association.yml
@@ -1,0 +1,82 @@
+name: Change Default File Association
+id: 462d17d8-1f71-11ec-ad07-acde48001122
+version: 5
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects suspicious registry modifications that
+  change the default file association to execute a malicious payload. It leverages
+  data from the Endpoint data model, specifically monitoring registry paths under
+  "*\\shell\\open\\command\\*" and "*HKCR\\*". This activity is significant because
+  altering default file associations can allow attackers to execute arbitrary scripts
+  or payloads when a user opens a file, leading to potential code execution. If confirmed
+  malicious, this technique can enable attackers to persist on the compromised host
+  and execute further malicious commands, posing a severe threat to the environment.
+data_source:
+- Sysmon EventID 12
+- Sysmon EventID 13
+search: '| tstats `security_content_summariesonly` count  min(_time) as firstTime
+  max(_time) as lastTime FROM datamodel=Endpoint.Registry where Registry.registry_path
+  ="*\\shell\\open\\command\\*" Registry.registry_path = "*HKCR\\*" by Registry.dest  Registry.user
+  Registry.registry_path Registry.registry_key_name Registry.registry_value_name |
+  `security_content_ctime(lastTime)` | `security_content_ctime(firstTime)` | `drop_dm_object_name(Registry)`
+  | `change_default_file_association_filter`'
+how_to_implement: To successfully implement this search, you must be ingesting data
+  that records registry activity from your hosts to populate the endpoint data model
+  in the registry node. This is typically populated via endpoint detection-and-response
+  product, such as Carbon Black or endpoint data sources, such as Sysmon. The data
+  used for this search is typically generated via logs that report reads and writes
+  to the registry.
+known_false_positives: unknown
+references:
+- https://dmcxblue.gitbook.io/red-team-notes-2-0/red-team-techniques/privilege-escalation/untitled-3/accessibility-features
+drilldown_searches:
+- name: View the detection results for - "$dest$" and "$user$"
+  search: '%original_detection_search% | search  dest = "$dest$" user = "$user$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$" and "$user$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$",
+    "$user$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Registry path $registry_path$ was modified, added, or deleted on $dest$.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 80
+  - field: user
+    type: user
+    score: 80
+  threat_objects: []
+tags:
+  analytic_story:
+  - Hermetic Wiper
+  - Windows Registry Abuse
+  - Prestige Ransomware
+  - Windows Privilege Escalation
+  - Windows Persistence Techniques
+  - Data Destruction
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1546.001
+  - T1546
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1546.001/txtfile_reg/sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/cmdline_tool_not_executed_in_cmd_shell.yml
+++ b/detections/deprecated/cmdline_tool_not_executed_in_cmd_shell.yml
@@ -1,0 +1,102 @@
+name: Cmdline Tool Not Executed In CMD Shell
+id: 6c3f7dd8-153c-11ec-ac2d-acde48001122
+version: 7
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic identifies instances where `ipconfig.exe`, `systeminfo.exe`,
+  or similar tools are executed by a non-standard parent process, excluding CMD, PowerShell,
+  or Explorer. This detection leverages Endpoint Detection and Response (EDR) telemetry
+  to monitor process creation events. Such behavior is significant as it may indicate
+  adversaries using injected processes to perform system discovery, a tactic observed
+  in FIN7's JSSLoader. If confirmed malicious, this activity could allow attackers
+  to gather critical host information, aiding in further exploitation or lateral movement
+  within the network.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where (Processes.process_name = "ipconfig.exe"
+  OR Processes.process_name = "systeminfo.exe" OR Processes.process_name = "net.exe"
+  OR Processes.process_name = "net1.exe" OR Processes.process_name = "arp.exe" OR
+  Processes.process_name = "nslookup.exe" OR Processes.process_name = "route.exe"
+  OR Processes.process_name = "netstat.exe" OR Processes.process_name = "whoami.exe")
+  AND NOT (Processes.parent_process_name = "cmd.exe" OR Processes.parent_process_name
+  = "powershell*" OR Processes.parent_process_name="pwsh.exe" OR Processes.parent_process_name
+  = "explorer.exe") by Processes.parent_process_name Processes.parent_process Processes.process_name
+  Processes.original_file_name Processes.process_id Processes.process Processes.dest
+  Processes.user | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` | `cmdline_tool_not_executed_in_cmd_shell_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: A network operator or systems administrator may utilize an
+  automated host discovery application that may generate false positives. Filter as
+  needed.
+references:
+- https://www.mandiant.com/resources/fin7-pursuing-an-enigmatic-and-evasive-global-criminal-operation
+- https://attack.mitre.org/groups/G0046/
+- https://www.microsoft.com/en-us/security/blog/2023/05/24/volt-typhoon-targets-us-critical-infrastructure-with-living-off-the-land-techniques/
+drilldown_searches:
+- name: View the detection results for - "$dest$" and "$user$"
+  search: '%original_detection_search% | search  dest = "$dest$" user = "$user$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$" and "$user$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$",
+    "$user$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: A non-standard parent process $parent_process_name$ spawned child process
+    $process_name$ to execute command-line tool on $dest$.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 56
+  - field: user
+    type: user
+    score: 56
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - Volt Typhoon
+  - Rhysida Ransomware
+  - FIN7
+  - DarkGate Malware
+  - Qakbot
+  - CISA AA22-277A
+  - CISA AA23-347A
+  - Gozi Malware
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1059
+  - T1059.007
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/fin7/jssloader/sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/create_local_admin_accounts_using_net_exe.yml
+++ b/detections/deprecated/create_local_admin_accounts_using_net_exe.yml
@@ -1,0 +1,94 @@
+name: Create local admin accounts using net exe
+id: b89919ed-fe5f-492c-b139-151bb162040e
+version: 15
+date: '2025-01-24'
+author: Bhavin Patel, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects the creation of local administrator accounts
+  using the net.exe command. It leverages Endpoint Detection and Response (EDR) data
+  to identify processes named net.exe or net1.exe with the "/add" parameter and keywords
+  related to administrator accounts. This activity is significant as it may indicate
+  an attacker attempting to gain persistent access or escalate privileges. If confirmed
+  malicious, this could lead to unauthorized access, data theft, or further system
+  compromise. Review the process details, user context, and related artifacts to determine
+  the legitimacy of the activity.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count values(Processes.user) as
+  user values(Processes.parent_process) as parent_process values(parent_process_name)
+  as parent_process_name min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
+  where `process_net` AND Processes.process=*/add* AND (Processes.process=*administrators*
+  OR Processes.process=*administratoren* OR Processes.process=*administrateurs* OR
+  Processes.process=*administrador* OR Processes.process=*amministratori* OR Processes.process=*administratorer*
+  OR Processes.process=*Rendszergazda* OR Processes.process=*Администратор* OR Processes.process=*Administratör*)
+  by Processes.process Processes.process_name Processes.parent_process_name Processes.dest
+  Processes.user| `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` | `create_local_admin_accounts_using_net_exe_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: Administrators often leverage net.exe to create admin accounts.
+references: []
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $parent_process_name$ spawning $process_name$ was identified
+    on endpoint $dest$ by user $user$ attempting to add a user to the local Administrators
+    group.
+  risk_objects:
+  - field: user
+    type: user
+    score: 30
+  - field: dest
+    type: system
+    score: 30
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - DHS Report TA18-074A
+  - Azorult
+  - CISA AA22-257A
+  - DarkGate Malware
+  - CISA AA24-241A
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1136.001
+  - T1136
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1136.001/atomic_red_team/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/deleting_of_net_users.yml
+++ b/detections/deprecated/deleting_of_net_users.yml
@@ -1,0 +1,88 @@
+name: Deleting Of Net Users
+id: 1c8c6f66-acce-11eb-aafb-acde48001122
+version: 7
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects the use of net.exe or net1.exe command-line
+  to delete a user account on a system. It leverages data from Endpoint Detection
+  and Response (EDR) agents, focusing on process and command-line execution logs.
+  This activity is significant as it may indicate an attempt to impair user accounts
+  or cover tracks during lateral movement. If confirmed malicious, this could lead
+  to unauthorized access removal, disruption of legitimate user activities, or concealment
+  of adversarial actions, complicating incident response and forensic investigations.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` values(Processes.process) as process
+  values(Processes.parent_process) as parent_process values(Processes.process_id)
+  as process_id count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
+  where `process_net` AND Processes.process="*user*" AND  Processes.process="*/delete*"
+  by  Processes.process_name Processes.original_file_name Processes.dest Processes.user
+  Processes.parent_process_name | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` | `deleting_of_net_users_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: System administrators or scripts may delete user accounts via
+  this technique. Filter as needed.
+references:
+- https://thedfirreport.com/2020/04/20/sqlserver-or-the-miner-in-the-basement/
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $parent_process_name$ spawning $process_name$ was identified
+    on endpoint $dest$ by user $user$ attempting to delete accounts.
+  risk_objects:
+  - field: user
+    type: user
+    score: 25
+  - field: dest
+    type: system
+    score: 25
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - XMRig
+  - Graceful Wipe Out Attack
+  - DarkGate Malware
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1531
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/xmrig_miner/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/detect_processes_used_for_system_network_configuration_discovery.yml
+++ b/detections/deprecated/detect_processes_used_for_system_network_configuration_discovery.yml
@@ -1,0 +1,91 @@
+name: Detect processes used for System Network Configuration Discovery
+id: a51bfe1a-94f0-48cc-b1e4-16ae10145893
+version: 7
+date: '2025-01-24'
+author: Bhavin Patel, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic identifies the rapid execution of processes used
+  for system network configuration discovery on an endpoint. It leverages data from
+  Endpoint Detection and Response (EDR) agents, focusing on process GUIDs, names,
+  parent processes, and command-line executions. This activity is significant as it
+  may indicate an attacker attempting to map the network, which is a common precursor
+  to lateral movement or further exploitation. If confirmed malicious, this behavior
+  could allow an attacker to gain insights into the network topology, identify critical
+  systems, and plan subsequent attacks, potentially leading to data exfiltration or
+  system compromise.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count values(Processes.process)
+  as process values(Processes.parent_process) as parent_process min(_time) as firstTime
+  max(_time) as lastTime from datamodel=Endpoint.Processes where NOT Processes.user
+  IN ("","unknown") by Processes.dest Processes.process_name Processes.parent_process_name
+  Processes.user _time | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  | `drop_dm_object_name(Processes)` | search `system_network_configuration_discovery_tools`
+  | transaction dest connected=false maxpause=5m |where eventcount>=5 | table firstTime
+  lastTime dest user process_name process parent_process parent_process_name eventcount
+  | `detect_processes_used_for_system_network_configuration_discovery_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: It is uncommon for normal users to execute a series of commands
+  used for network discovery. System administrators often use scripts to execute these
+  commands. These can generate false positives.
+references: []
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $parent_process_name$ spawning multiple $process_name$ was
+    identified on endpoint $dest$ by user $user$ typically not a normal behavior of
+    the process.
+  risk_objects:
+  - field: user
+    type: user
+    score: 32
+  - field: dest
+    type: system
+    score: 32
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - Unusual Processes
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1016
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1016/discovery_commands/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/detect_webshell_exploit_behavior.yml
+++ b/detections/deprecated/detect_webshell_exploit_behavior.yml
@@ -1,0 +1,104 @@
+name: Detect Webshell Exploit Behavior
+id: 22597426-6dbd-49bd-bcdc-4ec19857192f
+version: 7
+date: '2025-01-24'
+author: Steven Dick
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic identifies the execution of suspicious processes
+  typically associated with webshell activity on web servers. It detects when processes
+  like `cmd.exe`, `powershell.exe`, or `bash.exe` are spawned by web server processes
+  such as `w3wp.exe` or `nginx.exe`. This behavior is significant as it may indicate
+  an adversary exploiting a web application vulnerability to install a webshell, providing
+  persistent access and command execution capabilities. If confirmed malicious, this
+  activity could allow attackers to maintain control over the compromised server,
+  execute arbitrary commands, and potentially escalate privileges or exfiltrate sensitive
+  data.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count max(_time) as lastTime, min(_time)
+  as firstTime from datamodel=Endpoint.Processes where (Processes.process_name IN
+  ("arp.exe","at.exe","bash.exe","bitsadmin.exe","certutil.exe","cmd.exe","cscript.exe",
+  "dsget.exe","dsquery.exe","find.exe","findstr.exe","fsutil.exe","hostname.exe","ipconfig.exe","ksh.exe","nbstat.exe",
+  "net.exe","net1.exe","netdom.exe","netsh.exe","netstat.exe","nltest.exe","nslookup.exe","ntdsutil.exe","pathping.exe",
+  "ping.exe","powershell.exe","pwsh.exe","qprocess.exe","query.exe","qwinsta.exe","reg.exe","rundll32.exe","sc.exe",
+  "scrcons.exe","schtasks.exe","sh.exe","systeminfo.exe","tasklist.exe","tracert.exe","ver.exe","vssadmin.exe",
+  "wevtutil.exe","whoami.exe","wmic.exe","wscript.exe","wusa.exe","zsh.exe") AND Processes.parent_process_name
+  IN ("w3wp.exe", "http*.exe", "nginx*.exe", "php*.exe", "php-cgi*.exe","tomcat*.exe"))
+  by Processes.dest,Processes.user,Processes.parent_process,Processes.parent_process_name,Processes.process,Processes.process_name
+  | `drop_dm_object_name("Processes")` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  | `detect_webshell_exploit_behavior_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: Legitimate OS functions called by vendor applications, baseline
+  the environment and filter before enabling. Recommend throttle by dest/process_name
+references:
+- https://attack.mitre.org/techniques/T1505/003/
+- https://github.com/nsacyber/Mitigating-Web-Shells
+- https://www.hackingarticles.in/multiple-ways-to-exploit-tomcat-manager/
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Webshell Exploit Behavior - $parent_process_name$ spawned $process_name$
+    on $dest$.
+  risk_objects:
+  - field: user
+    type: user
+    score: 80
+  - field: dest
+    type: system
+    score: 80
+  threat_objects:
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - ProxyNotShell
+  - CISA AA22-257A
+  - HAFNIUM Group
+  - Citrix ShareFile RCE CVE-2023-24489
+  - ProxyShell
+  - Flax Typhoon
+  - CISA AA22-264A
+  - SysAid On-Prem Software CVE-2023-47246 Vulnerability
+  - Compromised Windows Host
+  - WS FTP Server Critical Vulnerabilities
+  - BlackByte Ransomware
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1505
+  - T1505.003
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1505.003/generic_webshell_exploit/generic_webshell_exploit.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/disabling_net_user_account.yml
+++ b/detections/deprecated/disabling_net_user_account.yml
@@ -1,0 +1,85 @@
+name: Disabling Net User Account
+id: c0325326-acd6-11eb-98c2-acde48001122
+version: 7
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects the use of the `net.exe` utility to disable
+  a user account via the command line. It leverages data from Endpoint Detection and
+  Response (EDR) agents, focusing on process execution logs and command-line arguments.
+  This activity is significant as it may indicate an adversary's attempt to disrupt
+  user availability, potentially as a precursor to further malicious actions. If confirmed
+  malicious, this could lead to denial of service for legitimate users, aiding the
+  attacker in maintaining control or covering their tracks.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` values(Processes.process) as process
+  values(Processes.parent_process) as parent_process values(Processes.process_id)
+  as process_id count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
+  where `process_net` AND Processes.process="*user*" AND Processes.process="*/active:no*"
+  by  Processes.process_name Processes.original_file_name Processes.dest Processes.user
+  Processes.parent_process_name | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` | `disabling_net_user_account_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: unknown
+references:
+- https://thedfirreport.com/2020/04/20/sqlserver-or-the-miner-in-the-basement/
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $parent_process_name$ spawning $process_name$ was identified
+    disabling a user account on endpoint $dest$ by user $user$.
+  risk_objects:
+  - field: user
+    type: user
+    score: 42
+  - field: dest
+    type: system
+    score: 42
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - XMRig
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1531
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/xmrig_miner/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/elevated_group_discovery_with_net.yml
+++ b/detections/deprecated/elevated_group_discovery_with_net.yml
@@ -1,0 +1,87 @@
+name: Elevated Group Discovery With Net
+id: a23a0e20-0b1b-4a07-82e5-ec5f70811e7a
+version: 6
+date: '2025-01-24'
+author: Mauricio Velazco, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects the execution of `net.exe` or `net1.exe`
+  with command-line arguments used to query elevated domain groups. It leverages data
+  from Endpoint Detection and Response (EDR) agents, focusing on process names and
+  command-line executions. This activity is significant as it indicates potential
+  reconnaissance efforts by adversaries to identify high-privileged users within Active
+  Directory. If confirmed malicious, this behavior could lead to further attacks aimed
+  at compromising privileged accounts, escalating privileges, or gaining unauthorized
+  access to sensitive systems and data.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where `process_net` AND (Processes.process="*group*"
+  AND Processes.process="*/do*") (Processes.process="*Domain Admins*" OR Processes.process="*Enterprise
+  Admins*" OR Processes.process="*Schema Admins*" OR Processes.process="*Account Operators*"
+  OR Processes.process="*Server Operators*" OR Processes.process="*Protected Users*"
+  OR Processes.process="*Dns Admins*") by Processes.dest Processes.user Processes.parent_process
+  Processes.process_name Processes.process Processes.process_id Processes.parent_process_id
+  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  | `elevated_group_discovery_with_net_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: Administrators or power users may use this command for troubleshooting.
+references:
+- https://attack.mitre.org/techniques/T1069/002/
+- https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/plan/security-best-practices/appendix-b--privileged-accounts-and-groups-in-active-directory
+- https://adsecurity.org/?p=3658
+- https://media.defense.gov/2023/May/24/2003229517/-1/-1/0/CSA_Living_off_the_Land.PDF
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Elevated domain group discovery enumeration on $dest$ by $user$
+  risk_objects:
+  - field: dest
+    type: system
+    score: 21
+  threat_objects: []
+tags:
+  analytic_story:
+  - Active Directory Discovery
+  - Volt Typhoon
+  - Rhysida Ransomware
+  - BlackSuit Ransomware
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1069
+  - T1069.002
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1069.002/AD_discovery/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/excessive_service_stop_attempt.yml
+++ b/detections/deprecated/excessive_service_stop_attempt.yml
@@ -1,0 +1,84 @@
+name: Excessive Service Stop Attempt
+id: ae8d3f4a-acd7-11eb-8846-acde48001122
+version: 7
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: Anomaly
+description: The following analytic has been deprecated.
+  The following analytic detects multiple attempts to stop or delete services
+  on a system using `net.exe`, `sc.exe`, or `net1.exe`. It leverages Endpoint Detection
+  and Response (EDR) telemetry, focusing on process names and command-line executions
+  within a one-minute window. This activity is significant as it may indicate an adversary
+  attempting to disable security or critical services to evade detection and further
+  their objectives. If confirmed malicious, this could lead to the attacker gaining
+  persistence, escalating privileges, or disrupting essential services, thereby compromising
+  the system's security posture.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` values(Processes.process) as process
+  values(Processes.process_id) as process_id count min(_time) as firstTime max(_time)
+  as lastTime  from datamodel=Endpoint.Processes where `process_net` OR  Processes.process_name
+  = "sc.exe" OR  Processes.process_name = "net1.exe" AND Processes.process="*stop*"
+  OR Processes.process="*delete*" by Processes.process_name Processes.original_file_name
+  Processes.parent_process_name Processes.dest Processes.user _time span=1m | where
+  count >=5 | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` | `excessive_service_stop_attempt_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: unknown
+references:
+- https://thedfirreport.com/2020/04/20/sqlserver-or-the-miner-in-the-basement/
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An excessive amount of $process_name$ was executed on $dest$ attempting
+    to disable services.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 80
+  threat_objects:
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - XMRig
+  - Ransomware
+  - BlackByte Ransomware
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1489
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/xmrig_miner/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/excessive_usage_of_net_app.yml
+++ b/detections/deprecated/excessive_usage_of_net_app.yml
@@ -1,0 +1,89 @@
+name: Excessive Usage Of Net App
+id: 45e52536-ae42-11eb-b5c6-acde48001122
+version: 6
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: Anomaly
+description: The following analytic has been deprecated.
+  The following analytic detects excessive usage of `net.exe` or `net1.exe`
+  within a one-minute interval. It leverages data from Endpoint Detection and Response
+  (EDR) agents, focusing on process names, parent processes, and command-line executions.
+  This behavior is significant as it may indicate an adversary attempting to create,
+  delete, or disable multiple user accounts rapidly, a tactic observed in Monero mining
+  incidents. If confirmed malicious, this activity could lead to unauthorized user
+  account manipulation, potentially compromising system integrity and enabling further
+  malicious actions.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` values(Processes.process) as process
+  values(Processes.process_id) as process_id count min(_time) as firstTime max(_time)
+  as lastTime  from datamodel=Endpoint.Processes where `process_net` by Processes.process_name
+  Processes.parent_process_name Processes.original_file_name Processes.dest Processes.user
+  _time span=1m | where count >=10 | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` | `excessive_usage_of_net_app_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: unknown. Filter as needed. Modify the time span as needed.
+references:
+- https://thedfirreport.com/2020/04/20/sqlserver-or-the-miner-in-the-basement/
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Excessive usage of net1.exe or net.exe within 1m, with command line $process$
+    has been detected on $dest$ by $user$
+  risk_objects:
+  - field: user
+    type: user
+    score: 28
+  - field: dest
+    type: system
+    score: 28
+  threat_objects:
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - Prestige Ransomware
+  - Graceful Wipe Out Attack
+  - XMRig
+  - Windows Post-Exploitation
+  - Azorult
+  - Ransomware
+  - Rhysida Ransomware
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1531
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/xmrig_miner/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/extraction_of_registry_hives.yml
+++ b/detections/deprecated/extraction_of_registry_hives.yml
@@ -1,0 +1,92 @@
+name: Extraction of Registry Hives
+id: 8bbb7d58-b360-11eb-ba21-acde48001122
+version: 6
+date: '2025-01-24'
+author: Michael Haag, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects the use of `reg.exe` to export Windows
+  Registry hives, which may contain sensitive credentials. This detection leverages
+  data from Endpoint Detection and Response (EDR) agents, focusing on command-line
+  executions involving `save` or `export` actions targeting the `sam`, `system`, or
+  `security` hives. This activity is significant as it indicates potential offline
+  credential access attacks, often executed from untrusted processes or scripts. If
+  confirmed malicious, attackers could gain access to credential data, enabling further
+  compromise and lateral movement within the network.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where `process_reg` (Processes.process=*save*
+  OR Processes.process=*export*) AND (Processes.process="*\sam *" OR Processes.process="*\system
+  *" OR Processes.process="*\security *") by Processes.dest Processes.user Processes.parent_process
+  Processes.process_name Processes.parent_process_name Processes.process Processes.process_id
+  Processes.parent_process_id | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` | `extraction_of_registry_hives_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: It is possible some agent based products will generate false
+  positives. Filter as needed.
+references:
+- https://www.mandiant.com/resources/shining-a-light-on-darkside-ransomware-operations
+- https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1003.002/T1003.002.md
+- https://media.defense.gov/2023/May/24/2003229517/-1/-1/0/CSA_Living_off_the_Land.PDF
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Suspicious use of `reg.exe` exporting Windows Registry hives containing
+    credentials executed on $dest$ by user $user$, with a parent process of $parent_process_id$
+  risk_objects:
+  - field: user
+    type: user
+    score: 56
+  - field: dest
+    type: system
+    score: 56
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+tags:
+  analytic_story:
+  - Volt Typhoon
+  - Credential Dumping
+  - CISA AA23-347A
+  - DarkSide Ransomware
+  - CISA AA22-257A
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1003.002
+  - T1003
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1003.002/atomic_red_team/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/linux_auditd_find_private_keys.yml
+++ b/detections/deprecated/linux_auditd_find_private_keys.yml
@@ -1,0 +1,83 @@
+name: Linux Auditd Find Private Keys
+id: 80bb9988-190b-4ee0-a3c3-509545a8f678
+version: 5
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects suspicious attempts to find private keys,
+  which may indicate an attacker's effort to access sensitive cryptographic information.
+  Private keys are crucial for securing encrypted communications and data, and unauthorized
+  access to them can lead to severe security breaches, including data decryption and
+  identity theft. By monitoring for unusual or unauthorized searches for private keys,
+  this analytic helps identify potential threats to cryptographic security, enabling
+  security teams to take swift action to protect the integrity and confidentiality
+  of encrypted information.
+data_source:
+- Linux Auditd Execve
+search: '`linux_auditd` `linux_auditd_normalized_execve_process` | rename host as
+  dest | where  (LIKE (process_exec, "%find%") OR LIKE (process_exec, "%grep%")) AND
+  (LIKE (process_exec, "%.pem%") OR LIKE (process_exec, "%.cer%") OR LIKE (process_exec,
+  "%.crt%") OR LIKE (process_exec, "%.pgp%") OR LIKE (process_exec, "%.key%") OR LIKE
+  (process_exec, "%.gpg%")OR LIKE (process_exec, "%.ppk%") OR LIKE (process_exec,
+  "%.p12%")OR LIKE (process_exec, "%.pfx%")OR LIKE (process_exec, "%.p7b%")) | stats
+  count min(_time) as firstTime max(_time) as lastTime by argc process_exec dest |
+  `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`| `linux_auditd_find_private_keys_filter`'
+how_to_implement: To implement this detection, the process begins by ingesting auditd
+  data, that consist SYSCALL, TYPE, EXECVE and PROCTITLE events, which captures command-line
+  executions and process details on Unix/Linux systems. These logs should be ingested
+  and processed using Splunk Add-on for Unix and Linux (https://splunkbase.splunk.com/app/833),
+  which is essential for correctly parsing and categorizing the data. The next step
+  involves normalizing the field names  to match the field names set by the Splunk
+  Common Information Model (CIM) to ensure consistency across different data sources
+  and enhance the efficiency of data modeling. This approach enables effective monitoring
+  and detection of linux endpoints where auditd is deployed
+known_false_positives: Administrator or network operator can use this application
+  for automation purposes. Please update the filter macros to remove false positives.
+references:
+- https://www.splunk.com/en_us/blog/security/deep-dive-on-persistence-privilege-escalation-technique-and-detection-in-linux-platform.html
+- https://github.com/peass-ng/PEASS-ng/tree/master/linPEAS
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: A [$process_exec$] event occurred on host - [$dest$] to find private keys.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 64
+  threat_objects: []
+tags:
+  analytic_story:
+  - Linux Living Off The Land
+  - Linux Privilege Escalation
+  - Linux Persistence Techniques
+  - Compromised Linux Host
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1552.004
+  - T1552
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1552.004/linux_auditd_find_gpg/linux_auditd_find_gpg.log
+    source: /var/log/audit/audit.log
+    sourcetype: linux:audit

--- a/detections/deprecated/local_account_discovery_with_net.yml
+++ b/detections/deprecated/local_account_discovery_with_net.yml
@@ -1,0 +1,58 @@
+name: Local Account Discovery with Net
+id: 5d0d4830-0133-11ec-bae3-acde48001122
+version: 6
+date: '2025-01-24'
+author: Mauricio Velazco, Splunk
+status: deprecated
+type: Hunting
+description: The following analytic has been deprecated.
+  The following analytic detects the execution of `net.exe` or `net1.exe`
+  with command-line arguments `user` or `users` to query local user accounts. It leverages
+  data from Endpoint Detection and Response (EDR) agents, focusing on process names
+  and command-line executions. This activity is significant as it indicates potential
+  reconnaissance efforts by adversaries to enumerate local users, which is a common
+  step in situational awareness and Active Directory discovery. If confirmed malicious,
+  this behavior could lead to further attacks, including privilege escalation and
+  lateral movement within the network.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where `process_net` (Processes.process=*user
+  OR Processes.process=*users) by Processes.dest Processes.user Processes.parent_process
+  Processes.process_name Processes.process Processes.process_id Processes.parent_process_id
+  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  | `local_account_discovery_with_net_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: Administrators or power users may use this command for troubleshooting.
+references:
+- https://attack.mitre.org/techniques/T1087/001/
+tags:
+  analytic_story:
+  - Active Directory Discovery
+  - Sandworm Tools
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1087
+  - T1087.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1087.001/AD_discovery/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/mshtml_module_load_in_office_product.yml
+++ b/detections/deprecated/mshtml_module_load_in_office_product.yml
@@ -1,0 +1,80 @@
+name: MSHTML Module Load in Office Product
+id: 5f1c168e-118b-11ec-84ff-acde48001122
+version: 7
+date: '2025-01-24'
+author: Michael Haag, Mauricio Velazco, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects the loading of the mshtml.dll module into
+  an Office product, which is indicative of CVE-2021-40444 exploitation. It leverages
+  Sysmon EventID 7 to monitor image loads by specific Office processes. This activity
+  is significant because it can indicate an attempt to exploit a vulnerability in
+  the MSHTML component via a malicious document. If confirmed malicious, this could
+  allow an attacker to execute arbitrary code, potentially leading to system compromise,
+  data exfiltration, or further network penetration.
+data_source:
+- Sysmon EventID 7
+search: '`sysmon` EventID=7 process_name IN ("winword.exe","excel.exe","powerpnt.exe","mspub.exe","visio.exe","wordpad.exe","wordview.exe","onenote.exe","onenotem.exe","onenoteviewer.exe","onenoteim.exe",
+  "msaccess.exe","Graph.exe","winproj.exe") loaded_file_path IN ("*\\mshtml.dll",
+  "*\\Microsoft.mshtml.dll","*\\IE.Interop.MSHTML.dll","*\\MshtmlDac.dll","*\\MshtmlDed.dll","*\\MshtmlDer.dll")
+  | stats count min(_time) as firstTime max(_time) as lastTime by user_id, dest, process_name,
+  loaded_file, loaded_file_path, original_file_name, process_guid | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` | `mshtml_module_load_in_office_product_filter`'
+how_to_implement: To successfully implement this search, you need to be ingesting
+  logs with the process names and image loads from your endpoints. If you are using
+  Sysmon, you must have at least version 6.0.4 of the Sysmon TA.
+known_false_positives: Limited false positives will be present, however, tune as necessary.
+  Some applications may legitimately load mshtml.dll.
+references:
+- https://app.any.run/tasks/36c14029-9df8-439c-bba0-45f2643b0c70/
+- https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-40444
+- https://strontic.github.io/xcyclopedia/index-dll
+- https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/trojanized-onenote-document-leads-to-formbook-malware/
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $process_name$ was identified on endpoint $dest$ loading
+    mshtml.dll.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 80
+  threat_objects:
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - Spearphishing Attachments
+  - Microsoft MSHTML Remote Code Execution CVE-2021-40444
+  - CVE-2023-36884 Office and Windows HTML RCE Vulnerability
+  asset_type: Endpoint
+  cve:
+  - CVE-2021-40444
+  mitre_attack_id:
+  - T1566
+  - T1566.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1566.001/macro/windows-sysmon_mshtml.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/network_connection_discovery_with_net.yml
+++ b/detections/deprecated/network_connection_discovery_with_net.yml
@@ -1,0 +1,58 @@
+name: Network Connection Discovery With Net
+id: 640337e5-6e41-4b7f-af06-9d9eab5e1e2d
+version: 6
+date: '2025-01-24'
+author: Mauricio Velazco, Splunk
+status: deprecated
+type: Hunting
+description: The following analytic has been deprecated.
+  The following analytic identifies the execution of `net.exe` or `net1.exe`
+  with command-line arguments used to list network connections on a compromised system.
+  It leverages data from Endpoint Detection and Response (EDR) agents, focusing on
+  process names and command-line executions. This activity is significant as it indicates
+  potential network reconnaissance by adversaries or Red Teams, aiming to gather situational
+  awareness and Active Directory information. If confirmed malicious, this behavior
+  could allow attackers to map the network, identify critical assets, and plan further
+  attacks, potentially leading to data exfiltration or lateral movement.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where `process_net` AND (Processes.process=*use*)
+  by Processes.dest Processes.user Processes.parent_process Processes.process_name
+  Processes.process Processes.process_id Processes.parent_process_id | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `network_connection_discovery_with_net_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: Administrators or power users may use this command for troubleshooting.
+references:
+- https://attack.mitre.org/techniques/T1049/
+tags:
+  analytic_story:
+  - Active Directory Discovery
+  - Azorult
+  - Windows Post-Exploitation
+  - Prestige Ransomware
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1049
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1049/AD_discovery/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/office_application_drop_executable.yml
+++ b/detections/deprecated/office_application_drop_executable.yml
@@ -1,0 +1,86 @@
+name: Office Application Drop Executable
+id: 73ce70c4-146d-11ec-9184-acde48001122
+version: 9
+date: '2025-01-24'
+author: Teoderick Contreras, Michael Haag, Splunk, TheLawsOfChaos, Github
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects Microsoft Office applications dropping
+  or creating executables or scripts on a Windows OS. It leverages process creation
+  and file system events from the Endpoint data model to identify Office applications
+  like Word or Excel generating files with extensions such as .exe, .dll, or .ps1.
+  This behavior is significant as it is often associated with spear-phishing attacks
+  where malicious files are dropped to compromise the host. If confirmed malicious,
+  this activity could lead to code execution, privilege escalation, or persistent
+  access, posing a severe threat to the environment.
+data_source:
+- Sysmon EventID 1 AND Sysmon EventID 11
+search: '| tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Processes
+  where Processes.process_name IN ("winword.exe","excel.exe","powerpnt.exe","mspub.exe","visio.exe","wordpad.exe","wordview.exe","onenote.exe","onenotem.exe","onenoteviewer.exe","onenoteim.exe","msaccess.exe")
+  by _time span=1h Processes.process_id Processes.process_name Processes.process Processes.dest
+  Processes.process_guid | `drop_dm_object_name(Processes)` |join process_guid, _time
+  [| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime FROM datamodel=Endpoint.Filesystem where Filesystem.file_name IN ("*.exe","*.dll","*.pif","*.scr","*.js","*.vbs","*.vbe","*.ps1")
+  by _time span=1h Filesystem.dest Filesystem.file_create_time Filesystem.file_name
+  Filesystem.process_guid Filesystem.file_path | `drop_dm_object_name(Filesystem)`
+  | fields _time dest file_create_time file_name file_path process_name process_path
+  process process_guid] | dedup file_create_time | table dest, process_name, process,
+  file_create_time, file_name, file_path, process_guid | `office_application_drop_executable_filter`'
+how_to_implement: To successfully implement this search, you need to be ingesting
+  logs with the process name, parent process, and command-line executions from your
+  endpoints. If you are using Sysmon, you must have at least version 6.0.4 of the
+  Sysmon TA. Tune and filter known instances where renamed rundll32.exe may be used.
+known_false_positives: office macro for automation may do this behavior
+references:
+- https://www.mandiant.com/resources/fin7-pursuing-an-enigmatic-and-evasive-global-criminal-operation
+- https://attack.mitre.org/groups/G0046/
+- https://www.joesandbox.com/analysis/702680/0/html
+- https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/trojanized-onenote-document-leads-to-formbook-malware/
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: process $process_name$ drops a file $file_name$ in host $dest$
+  risk_objects:
+  - field: dest
+    type: system
+    score: 64
+  threat_objects:
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - CVE-2023-21716 Word RTF Heap Corruption
+  - Warzone RAT
+  - FIN7
+  - Compromised Windows Host
+  - AgentTesla
+  - PlugX
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1566
+  - T1566.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/fin7/fin7_macro_js_1/sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/office_document_creating_schedule_task.yml
+++ b/detections/deprecated/office_document_creating_schedule_task.yml
@@ -1,0 +1,75 @@
+name: Office Document Creating Schedule Task
+id: cc8b7b74-9d0f-11eb-8342-acde48001122
+version: 10
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects an Office document creating a scheduled
+  task, either through a macro VBA API or by loading `taskschd.dll`. This detection
+  leverages Sysmon EventCode 7 to identify when Office applications load the `taskschd.dll`
+  file. This activity is significant as it is a common technique used by malicious
+  macro malware to establish persistence or initiate beaconing. If confirmed malicious,
+  this could allow an attacker to maintain persistence, execute arbitrary commands,
+  or schedule future malicious activities, posing a significant threat to the environment.
+data_source:
+- Sysmon EventID 7
+search: '`sysmon` EventCode=7 process_name IN ("WINWORD.EXE", "EXCEL.EXE", "POWERPNT.EXE","onenote.exe","onenotem.exe","onenoteviewer.exe","onenoteim.exe",
+  "msaccess.exe") loaded_file_path = "*\\taskschd.dll" | stats min(_time) as firstTime
+  max(_time) as lastTime count by user_id, dest, process_name,loaded_file, loaded_file_path,
+  original_file_name, process_guid | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  | `office_document_creating_schedule_task_filter`'
+how_to_implement: To successfully implement this search, you need to be ingesting
+  logs with the process name and ImageLoaded (Like sysmon EventCode 7) from your endpoints.
+  If you are using Sysmon, you must have at least version 6.0.4 of the Sysmon TA.
+  Also be sure to include those monitored dll to your own sysmon config.
+known_false_positives: False positives may occur if legitimate office documents are
+  creating scheduled tasks. Ensure to investigate the scheduled task and the command
+  to be executed. If the task is benign, add the task name to the exclusion list.
+  Some applications may legitimately load taskschd.dll.
+references:
+- https://research.checkpoint.com/2021/irans-apt34-returns-with-an-updated-arsenal/
+- https://redcanary.com/threat-detection-report/techniques/scheduled-task-job/
+- https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/trojanized-onenote-document-leads-to-formbook-malware/
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An Office document was identified creating a scheduled task on $dest$.
+    Investigate further.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 49
+  threat_objects: []
+tags:
+  analytic_story:
+  - Spearphishing Attachments
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1566
+  - T1566.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1566.001/datasets/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/office_document_executing_macro_code.yml
+++ b/detections/deprecated/office_document_executing_macro_code.yml
@@ -1,0 +1,86 @@
+name: Office Document Executing Macro Code
+id: b12c89bc-9d06-11eb-a592-acde48001122
+version: 9
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic identifies office documents executing macro code.
+  It leverages Sysmon EventCode 7 to detect when processes like WINWORD.EXE or EXCEL.EXE
+  load specific DLLs associated with macros (e.g., VBE7.DLL). This activity is significant
+  because macros are a common attack vector for delivering malicious payloads, such
+  as malware. If confirmed malicious, this could lead to unauthorized code execution,
+  data exfiltration, or further compromise of the system. Disabling macros by default
+  is recommended to mitigate this risk.
+data_source:
+- Sysmon EventID 7
+search: '`sysmon` EventCode=7 process_name IN ("WINWORD.EXE", "EXCEL.EXE", "POWERPNT.EXE","onenote.exe","onenotem.exe","onenoteviewer.exe","onenoteim.exe","msaccess.exe")
+  loaded_file_path IN ("*\\VBE7INTL.DLL","*\\VBE7.DLL", "*\\VBEUI.DLL") | stats min(_time)
+  as firstTime max(_time) as lastTime values(loaded_file) as loaded_file count by
+  dest EventCode process_name process_guid | `security_content_ctime(firstTime)` |
+  `security_content_ctime(lastTime)` | `office_document_executing_macro_code_filter`'
+how_to_implement: To successfully implement this search, you need to be ingesting
+  logs with the process name and ImageLoaded (Like sysmon EventCode 7) from your endpoints.
+  If you are using Sysmon, you must have at least version 6.0.4 of the Sysmon TA.
+  Also be sure to include those monitored dll to your own sysmon config.
+known_false_positives: False positives may occur if legitimate office documents are
+  executing macro code. Ensure to investigate the macro code and the command to be
+  executed. If the macro code is benign, add the document name to the exclusion list.
+  Some applications may legitimately load VBE7INTL.DLL, VBE7.DLL, or VBEUI.DLL.
+references:
+- https://www.joesandbox.com/analysis/386500/0/html
+- https://www.joesandbox.com/analysis/702680/0/html
+- https://bazaar.abuse.ch/sample/02cbc1ab80695fc12ff8822b926957c3a600247b9ca412a137f69cb5716c8781/
+- https://www.fortinet.com/blog/threat-research/latest-remcos-rat-phishing
+- https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/trojanized-onenote-document-leads-to-formbook-malware/
+- https://www.fortinet.com/blog/threat-research/leveraging-microsoft-office-documents-to-deliver-agent-tesla-and-njrat
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Office document executing a macro on $dest$
+  risk_objects:
+  - field: dest
+    type: system
+    score: 35
+  threat_objects: []
+tags:
+  analytic_story:
+  - Spearphishing Attachments
+  - Trickbot
+  - IcedID
+  - DarkCrystal RAT
+  - AgentTesla
+  - Qakbot
+  - Azorult
+  - Remcos
+  - PlugX
+  - NjRAT
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1566
+  - T1566.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1566.001/datasets/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/office_document_spawned_child_process_to_download.yml
+++ b/detections/deprecated/office_document_spawned_child_process_to_download.yml
@@ -1,0 +1,85 @@
+name: Office Document Spawned Child Process To Download
+id: 6fed27d2-9ec7-11eb-8fe4-aa665a019aa3
+version: 10
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic identifies Office applications spawning child
+  processes to download content via HTTP/HTTPS. It leverages data from Endpoint Detection
+  and Response (EDR) agents, focusing on process creation events where Office applications
+  like Word or Excel initiate network connections, excluding common browsers. This
+  activity is significant as it often indicates the use of malicious documents to
+  execute living-off-the-land binaries (LOLBins) for payload delivery. If confirmed
+  malicious, this behavior could lead to unauthorized code execution, data exfiltration,
+  or further malware deployment, posing a severe threat to the organization's security.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name
+  IN ("winword.exe","excel.exe","powerpnt.exe","mspub.exe","visio.exe","onenote.exe","onenotem.exe","onenoteviewer.exe","onenoteim.exe","msaccess.exe",
+  "Graph.exe","winproj.exe") Processes.process IN ("*http:*","*https:*") NOT (Processes.original_file_name
+  IN("firefox.exe", "chrome.exe","iexplore.exe","msedge.exe"))  by Processes.dest
+  Processes.user Processes.parent_process_name Processes.process_name Processes.process
+  Processes.process_id Processes.parent_process_id Processes.original_file_name |
+  `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  | `office_document_spawned_child_process_to_download_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: Default browser not in the filter list.
+references:
+- https://app.any.run/tasks/92d7ef61-bfd7-4c92-bc15-322172b4ebec/
+- https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/trojanized-onenote-document-leads-to-formbook-malware/
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Office document spawning suspicious child process on $dest$
+  risk_objects:
+  - field: dest
+    type: system
+    score: 35
+  threat_objects: []
+tags:
+  analytic_story:
+  - Spearphishing Attachments
+  - CVE-2023-36884 Office and Windows HTML RCE Vulnerability
+  - PlugX
+  - NjRAT
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1566
+  - T1566.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1566.001/datasets2/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/office_product_spawning_rundll32_with_no_dll.yml
+++ b/detections/deprecated/office_product_spawning_rundll32_with_no_dll.yml
@@ -1,0 +1,89 @@
+name: Office Product Spawning Rundll32 with no DLL
+id: c661f6be-a38c-11eb-be57-acde48001122
+version: 10
+date: '2025-01-24'
+author: Michael Haag, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects any Windows Office Product spawning `rundll32.exe`
+  without a `.dll` file extension. This behavior is identified using Endpoint Detection
+  and Response (EDR) telemetry, focusing on process and parent process relationships.
+  This activity is significant as it is a known tactic of the IcedID malware family,
+  which can lead to unauthorized code execution. If confirmed malicious, this could
+  allow attackers to execute arbitrary code, potentially leading to data exfiltration,
+  system compromise, or further malware deployment. Immediate investigation and containment
+  are recommended.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name
+  IN ("winword.exe","excel.exe","powerpnt.exe","mspub.exe","visio.exe","onenote.exe","onenotem.exe","onenoteviewer.exe","onenoteim.exe",
+  "msaccess.exe", "Graph.exe","winproj.exe") `process_rundll32` (Processes.process!=*.dll*)
+  by Processes.dest Processes.user Processes.parent_process_name Processes.parent_process
+  Processes.process_name Processes.process Processes.process_id Processes.parent_process_id
+  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)`
+  | `office_product_spawning_rundll32_with_no_dll_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: False positives should be limited, but if any are present,
+  filter as needed.
+references:
+- https://www.joesandbox.com/analysis/395471/0/html
+- https://app.any.run/tasks/cef4b8ba-023c-4b3b-b2ef-6486a44f6ed9/
+- https://any.run/malware-trends/icedid
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Office process $parent_process_name$ observed executing a suspicious child
+    process $process_name$ with process id $process_id$ and no dll commandline $process$
+    on host $dest$
+  risk_objects:
+  - field: dest
+    type: system
+    score: 63
+  threat_objects:
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - Spearphishing Attachments
+  - CVE-2023-36884 Office and Windows HTML RCE Vulnerability
+  - Compromised Windows Host
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1566
+  - T1566.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1566.001/macro/windows-sysmon_icedid.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/office_product_writing_cab_or_inf.yml
+++ b/detections/deprecated/office_product_writing_cab_or_inf.yml
@@ -1,0 +1,92 @@
+name: Office Product Writing cab or inf
+id: f48cd1d4-125a-11ec-a447-acde48001122
+version: 10
+date: '2025-01-24'
+author: Michael Haag, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects Office products writing .cab or .inf files,
+  indicative of CVE-2021-40444 exploitation. It leverages the Endpoint.Processes and
+  Endpoint.Filesystem data models to identify Office applications creating these file
+  types. This activity is significant as it may signal an attempt to load malicious
+  ActiveX controls and download remote payloads, a known attack vector. If confirmed
+  malicious, this could lead to remote code execution, allowing attackers to gain
+  control over the affected system and potentially compromise sensitive data.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+- Sysmon EventID 11
+search: '| tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Processes
+  where Processes.process_name IN ("winword.exe","excel.exe","powerpnt.exe","mspub.exe","visio.exe","wordpad.exe","wordview.exe","onenote.exe","onenotem.exe","onenoteviewer.exe","onenoteim.exe","msaccess.exe")
+  by _time span=1h Processes.process_id Processes.process_name Processes.process Processes.dest
+  Processes.process_guid | `drop_dm_object_name(Processes)` |rename process_guid as
+  proc_guid | join proc_guid, _time [ | tstats `security_content_summariesonly` count
+  min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Filesystem
+  where Filesystem.file_name IN ("*.inf","*.cab") by _time span=1h Filesystem.dest
+  Filesystem.file_create_time Filesystem.file_name Filesystem.file_path Filesystem.process_guid
+  | `drop_dm_object_name(Filesystem)` |rename process_guid as proc_guid | fields _time
+  dest file_create_time file_name file_path process_name process_path process proc_guid]
+  | dedup file_create_time | table dest, process_name, process, file_create_time,
+  file_name, file_path, proc_guid | `office_product_writing_cab_or_inf_filter`'
+how_to_implement: To successfully implement this search you need to be ingesting information
+  on process that include the name of the process responsible for the changes from
+  your endpoints into the `Endpoint` datamodel in the `Processes` node and `Filesystem`
+  node.
+known_false_positives: The query is structured in a way that `action` (read, create)
+  is not defined. Review the results of this query, filter, and tune as necessary.
+  It may be necessary to generate this query specific to your endpoint product.
+references:
+- https://twitter.com/vxunderground/status/1436326057179860992?s=20
+- https://app.any.run/tasks/36c14029-9df8-439c-bba0-45f2643b0c70/
+- https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-40444
+- https://twitter.com/RonnyTNL/status/1436334640617373699?s=20
+- https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/trojanized-onenote-document-leads-to-formbook-malware/
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $process_name$ was identified on $dest$ writing an inf or
+    cab file to this. This is not typical of $process_name$.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 80
+  threat_objects:
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - Spearphishing Attachments
+  - Microsoft MSHTML Remote Code Execution CVE-2021-40444
+  - Compromised Windows Host
+  asset_type: Endpoint
+  cve:
+  - CVE-2021-40444
+  mitre_attack_id:
+  - T1566
+  - T1566.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1566.001/macro/windows-sysmon_cabinf.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/office_spawning_control.yml
+++ b/detections/deprecated/office_spawning_control.yml
@@ -1,0 +1,94 @@
+name: Office Spawning Control
+id: 053e027c-10c7-11ec-8437-acde48001122
+version: 10
+date: '2025-01-24'
+author: Michael Haag, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic identifies instances where `control.exe` is spawned
+  by a Microsoft Office product. It leverages data from Endpoint Detection and Response
+  (EDR) agents, focusing on process and parent process relationships. This activity
+  is significant because it can indicate exploitation attempts related to CVE-2021-40444,
+  where `control.exe` is used to execute malicious .cpl or .inf files. If confirmed
+  malicious, this behavior could allow an attacker to execute arbitrary code, potentially
+  leading to system compromise, data exfiltration, or further lateral movement within
+  the network.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name
+  IN ("winword.exe","excel.exe","powerpnt.exe","mspub.exe","visio.exe","wordpad.exe","wordview.exe","onenote.exe","onenotem.exe","onenoteviewer.exe","onenoteim.exe","msaccess.exe")
+  Processes.process_name=control.exe by Processes.dest Processes.user Processes.parent_process_name
+  Processes.parent_process Processes.process_name Processes.process Processes.process_id
+  Processes.parent_process_id | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`|
+  `security_content_ctime(lastTime)`| `office_spawning_control_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: Limited false positives should be present.
+references:
+- https://strontic.github.io/xcyclopedia/library/control.exe-1F13E714A0FEA8887707DFF49287996F.html
+- https://app.any.run/tasks/36c14029-9df8-439c-bba0-45f2643b0c70/
+- https://attack.mitre.org/techniques/T1218/011/
+- https://www.echotrail.io/insights/search/control.exe/
+- https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-40444
+- https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.002/T1218.002.yaml
+- https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/trojanized-onenote-document-leads-to-formbook-malware/
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $parent_process_name$ spawning $process_name$ was identified
+    on endpoint $dest$ clicking a suspicious attachment.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 80
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - Spearphishing Attachments
+  - Microsoft MSHTML Remote Code Execution CVE-2021-40444
+  - Compromised Windows Host
+  asset_type: Endpoint
+  cve:
+  - CVE-2021-40444
+  mitre_attack_id:
+  - T1566
+  - T1566.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1566.001/macro/windows-sysmon_control.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/password_policy_discovery_with_net.yml
+++ b/detections/deprecated/password_policy_discovery_with_net.yml
@@ -1,0 +1,57 @@
+name: Password Policy Discovery with Net
+id: 09336538-065a-11ec-8665-acde48001122
+version: 7
+date: '2025-01-24'
+author: Teoderick Contreras, Mauricio Velazco, Splunk
+status: deprecated
+type: Hunting
+description: The following analytic has been deprecated.
+  The following analytic identifies the execution of `net.exe` or `net1.exe`
+  with command line arguments aimed at obtaining the domain password policy. It leverages
+  data from Endpoint Detection and Response (EDR) agents, focusing on process names
+  and command-line executions. This activity is significant as it indicates potential
+  reconnaissance efforts by adversaries to gather information about Active Directory
+  password policies. If confirmed malicious, this behavior could allow attackers to
+  understand password complexity requirements, aiding in brute-force or password-guessing
+  attacks, ultimately compromising user accounts and gaining unauthorized access to
+  the network.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where `process_net` AND Processes.process
+  = "*accounts*" AND Processes.process = "*/domain*" by Processes.dest Processes.user
+  Processes.parent_process Processes.process_name Processes.process Processes.process_id
+  Processes.parent_process_id Processes.parent_process_name | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `password_policy_discovery_with_net_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: Administrators or power users may use this command for troubleshooting.
+references:
+- https://github.com/S1ckB0y1337/Active-Directory-Exploitation-Cheat-Sheet
+tags:
+  analytic_story:
+  - Active Directory Discovery
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1201
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1201/pwd_policy_discovery/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/windows_command_shell_fetch_env_variables.yml
+++ b/detections/deprecated/windows_command_shell_fetch_env_variables.yml
@@ -1,0 +1,81 @@
+name: Windows Command Shell Fetch Env Variables
+id: 048839e4-1eaa-43ff-8a22-86d17f6fcc13
+version: 5
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic identifies a suspicious process command line fetching
+  environment variables with a non-shell parent process. It leverages data from Endpoint
+  Detection and Response (EDR) agents, focusing on command-line executions and parent
+  process names. This activity is significant as it is commonly associated with malware
+  like Qakbot, which uses this technique to gather system information. If confirmed
+  malicious, this behavior could indicate that the parent process has been compromised,
+  potentially allowing attackers to execute arbitrary commands, escalate privileges,
+  or persist within the environment.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where Processes.process = "*cmd /c
+  set" OR Processes.process = "*cmd.exe /c set" AND NOT (Processes.parent_process_name
+  = "cmd.exe" OR Processes.parent_process_name = "powershell*" OR Processes.parent_process_name="pwsh.exe"
+  OR Processes.parent_process_name = "explorer.exe") by Processes.dest Processes.user
+  Processes.parent_process_name Processes.process_name Processes.process Processes.process_id
+  Processes.parent_process_id Processes.original_file_name | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `windows_command_shell_fetch_env_variables_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: shell process that are not included in this search may cause
+  False positive. Filter is needed.
+references:
+- https://twitter.com/pr0xylife/status/1585612370441031680?s=46&t=Dc3CJi4AnM-8rNoacLbScg
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: non-shell parent process has a child process $process_name$ with a commandline
+    $process$ to fetch env variables on $dest$
+  risk_objects:
+  - field: dest
+    type: system
+    score: 56
+  threat_objects: []
+tags:
+  analytic_story:
+  - Qakbot
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1055
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/qakbot/qbot_wermgr/sysmon_wermgr.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/windows_modify_registry_reg_restore.yml
+++ b/detections/deprecated/windows_modify_registry_reg_restore.yml
@@ -1,0 +1,60 @@
+name: Windows Modify Registry Reg Restore
+id: d0072bd2-6d73-4c1b-bc77-ded6d2da3a4e
+version: 5
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: Hunting
+description: The following analytic has been deprecated.
+  The following analytic detects the execution of reg.exe with the "restore"
+  parameter, indicating an attempt to restore registry backup data on a host. This
+  detection leverages data from Endpoint Detection and Response (EDR) agents, focusing
+  on process execution logs and command-line arguments. This activity is significant
+  as it may indicate post-exploitation actions, such as those performed by tools like
+  winpeas, which use "reg save" and "reg restore" to manipulate registry settings.
+  If confirmed malicious, this could allow an attacker to revert registry changes,
+  potentially bypassing security controls and maintaining persistence.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where  `process_reg` AND Processes.process
+  = "* restore *" by Processes.process_name Processes.original_file_name Processes.process
+  Processes.process_id Processes.process_guid Processes.parent_process_name Processes.parent_process
+  Processes.parent_process_guid Processes.dest Processes.user | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `windows_modify_registry_reg_restore_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: network administrator can use this command tool to backup registry
+  before updates or modifying critical registries.
+references:
+- https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/quser
+- https://github.com/carlospolop/PEASS-ng/tree/master/winPEAS
+- https://www.microsoft.com/en-us/security/blog/2022/10/14/new-prestige-ransomware-impacts-organizations-in-ukraine-and-poland/
+tags:
+  analytic_story:
+  - Windows Post-Exploitation
+  - Prestige Ransomware
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1012
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/winpeas/sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/windows_msiexec_with_network_connections.yml
+++ b/detections/deprecated/windows_msiexec_with_network_connections.yml
@@ -1,0 +1,87 @@
+name: Windows MSIExec With Network Connections
+id: 827409a1-5393-4d8d-8da4-bbb297c262a7
+version: 6
+date: '2025-01-24'
+author: Michael Haag, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects MSIExec making network connections over
+  ports 443 or 80. This behavior is identified by correlating process creation events
+  from Endpoint Detection and Response (EDR) agents with network traffic logs. Typically,
+  MSIExec does not perform network communication to the internet, making this activity
+  unusual and potentially indicative of malicious behavior. If confirmed malicious,
+  an attacker could be using MSIExec to download or communicate with external servers,
+  potentially leading to data exfiltration, command and control (C2) communication,
+  or further malware deployment.
+data_source:
+- Sysmon EventID 1 AND Sysmon EventID 3
+search: '| tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Processes
+  where `process_msiexec` by _time Processes.user Processes.process_id Processes.process_name
+  Processes.dest Processes.process_path Processes.process Processes.parent_process_name
+  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  | join  process_id [| tstats `security_content_summariesonly` count FROM datamodel=Network_Traffic.All_Traffic
+  where All_Traffic.dest_port IN ("80","443") by All_Traffic.process_id All_Traffic.dest
+  All_Traffic.dest_port All_Traffic.dest_ip | `drop_dm_object_name(All_Traffic)` ]
+  | table _time user dest parent_process_name process_name process_path process process_id
+  dest_port dest_ip | `windows_msiexec_with_network_connections_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: False positives will be present and filtering is required.
+references:
+- https://thedfirreport.com/2022/06/06/will-the-real-msiexec-please-stand-up-exploit-leads-to-data-exfiltration/
+- https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.007/T1218.007.md
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $process_name$ was identified on endpoint $dest$ contacting
+    a remote destination $dest_ip$
+  risk_objects:
+  - field: user
+    type: user
+    score: 35
+  - field: dest
+    type: system
+    score: 35
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - Windows System Binary Proxy Execution MSIExec
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1218.007
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1218.007/atomic_red_team/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/windows_network_share_interaction_with_net.yml
+++ b/detections/deprecated/windows_network_share_interaction_with_net.yml
@@ -1,0 +1,80 @@
+name: Windows Network Share Interaction With Net
+id: 4dc3951f-b3f8-4f46-b412-76a483f72277
+version: 6
+date: '2025-01-24'
+author: Dean Luxton
+status: deprecated
+type: TTP
+data_source:
+- Sysmon EventID 1
+description: The following analytic has been deprecated.
+  This analytic detects network share discovery and collection activities
+  performed on Windows systems using the Net command. Attackers often use network
+  share discovery to identify accessible shared resources within a network, which
+  can be a precursor to privilege escalation or data exfiltration. By monitoring Windows
+  Event Logs for the usage of the Net command to list and interact with network shares,
+  this detection helps identify potential reconnaissance and collection activities.
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime values(Processes.user_category) as user_category values(Processes.user_bunit)
+  as user_bunit  FROM datamodel=Endpoint.Processes WHERE `process_net` BY Processes.user
+  Processes.dest Processes.process_exec Processes.parent_process_exec Processes.process
+  Processes.parent_process | `drop_dm_object_name(Processes)` | regex process="net[\s\.ex1]+view|net[\s\.ex1]+share|net[\s\.ex1]+use\s"
+  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `windows_network_share_interaction_with_net_filter`'
+how_to_implement: The detection is based on data originating from either Endpoint
+  Detection and Response (EDR) telemetry or EventCode 4688 with process command line
+  logging enabled. These sources provide security-related telemetry from the endpoints.
+  To implement this search, you must ingest logs that contain the process name, parent
+  process, and complete command-line executions. These logs must be mapped to the
+  Splunk Common Information Model (CIM) to normalize the field names capture the data
+  within the datamodel schema.
+known_false_positives: Unknown
+references:
+- https://attack.mitre.org/techniques/T1135/
+drilldown_searches:
+- name: View the detection results for - "$dest$" and "$user$"
+  search: '%original_detection_search% | search  dest = "$dest$" user = "$user$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$" and "$user$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$",
+    "$user$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: User $user$ leveraged net.exe on $dest$ to interact with network shares,
+    executed by parent process $parent_process$
+  risk_objects:
+  - field: dest
+    type: system
+    score: 20
+  - field: user
+    type: user
+    score: 20
+  threat_objects: []
+tags:
+  analytic_story:
+  - Active Directory Discovery
+  - Active Directory Privilege Escalation
+  - Network Discovery
+  asset_type: Endpoint
+  atomic_guid:
+  - ab39a04f-0c93-4540-9ff2-83f862c385ae
+  mitre_attack_id:
+  - T1135
+  - T1039
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1135/net_share/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/windows_office_product_spawning_msdt.yml
+++ b/detections/deprecated/windows_office_product_spawning_msdt.yml
@@ -1,0 +1,96 @@
+name: Windows Office Product Spawning MSDT
+id: 127eba64-c981-40bf-8589-1830638864a7
+version: 9
+date: '2025-01-24'
+author: Michael Haag, Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects a Microsoft Office product spawning the
+  Windows msdt.exe process. This detection leverages data from Endpoint Detection
+  and Response (EDR) agents, focusing on process creation events where Office applications
+  are the parent process. This activity is significant as it may indicate an attempt
+  to exploit protocol handlers to bypass security controls, even if macros are disabled.
+  If confirmed malicious, this behavior could allow an attacker to execute arbitrary
+  code, potentially leading to system compromise, data exfiltration, or further lateral
+  movement within the network.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name
+  IN ("winword.exe","excel.exe","powerpnt.exe","outlook.exe","mspub.exe","visio.exe","onenote.exe","onenotem.exe","onenoteviewer.exe","onenoteim.exe","msaccess.exe")
+  Processes.process_name=msdt.exe by Processes.dest Processes.user Processes.parent_process_name
+  Processes.parent_process Processes.process_name Processes.original_file_name Processes.process
+  Processes.process_id Processes.parent_process_id | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)` | `windows_office_product_spawning_msdt_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: False positives should be limited, however filter as needed.
+references:
+- https://isc.sans.edu/diary/rss/28694
+- https://doublepulsar.com/follina-a-microsoft-office-code-execution-vulnerability-1a47fce5629e
+- https://twitter.com/nao_sec/status/1530196847679401984?s=20&t=ZiXYI4dQuA-0_dzQzSUb3A
+- https://app.any.run/tasks/713f05d2-fe78-4b9d-a744-f7c133e3fafb/
+- https://www.virustotal.com/gui/file/4a24048f81afbe9fb62e7a6a49adbd1faf41f266b5f9feecdceb567aec096784/detection
+- https://strontic.github.io/xcyclopedia/library/msdt.exe-152D4C9F63EFB332CCB134C6953C0104.html
+- https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/trojanized-onenote-document-leads-to-formbook-malware/
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Office process $parent_process_name$ has spawned a child process $process_name$
+    on host $dest$.
+  risk_objects:
+  - field: user
+    type: user
+    score: 100
+  - field: dest
+    type: system
+    score: 100
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - Spearphishing Attachments
+  - Compromised Windows Host
+  - Microsoft Support Diagnostic Tool Vulnerability CVE-2022-30190
+  asset_type: Endpoint
+  cve:
+  - CVE-2022-30190
+  mitre_attack_id:
+  - T1566
+  - T1566.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1566.001/macro/msdt.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/windows_query_registry_reg_save.yml
+++ b/detections/deprecated/windows_query_registry_reg_save.yml
@@ -1,0 +1,60 @@
+name: Windows Query Registry Reg Save
+id: cbee60c1-b776-456f-83c2-faa56bdbe6c6
+version: 6
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: Hunting
+description: The following analytic has been deprecated.
+  The following analytic detects the execution of the reg.exe process with
+  the "save" parameter. This detection leverages data from Endpoint Detection and
+  Response (EDR) agents, focusing on process execution logs and command-line arguments.
+  This activity is significant because threat actors often use the "reg save" command
+  to dump credentials or test registry modification capabilities on compromised hosts.
+  If confirmed malicious, this behavior could allow attackers to escalate privileges,
+  persist in the environment, or access sensitive information stored in the registry.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where  `process_reg` AND Processes.process
+  = "* save *" by Processes.process_name Processes.original_file_name Processes.process
+  Processes.process_id Processes.process_guid Processes.parent_process_name Processes.parent_process
+  Processes.parent_process_guid Processes.dest Processes.user | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `windows_query_registry_reg_save_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: network administrator can use this command tool to backup registry
+  before updates or modifying critical registries.
+references:
+- https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/quser
+- https://github.com/carlospolop/PEASS-ng/tree/master/winPEAS
+- https://www.microsoft.com/en-us/security/blog/2022/10/14/new-prestige-ransomware-impacts-organizations-in-ukraine-and-poland/
+tags:
+  analytic_story:
+  - Windows Post-Exploitation
+  - CISA AA23-347A
+  - Prestige Ransomware
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1012
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/winpeas/sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/windows_service_stop_via_net__and_sc_application.yml
+++ b/detections/deprecated/windows_service_stop_via_net__and_sc_application.yml
@@ -1,0 +1,79 @@
+name: Windows Service Stop Via Net  and SC Application
+id: 827af04b-0d08-479b-9b84-b7d4644e4b80
+version: 5
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: Anomaly
+description: The following analytic has been deprecated.
+  The following analytic identifies attempts to stop services on a system
+  using `net.exe` or `sc.exe`. It leverages data from Endpoint Detection and Response
+  (EDR) agents, focusing on process names, GUIDs, and command-line executions. This
+  activity is significant as adversaries often terminate security or critical services
+  to evade detection and further their objectives. If confirmed malicious, this behavior
+  could allow attackers to disable security defenses, facilitate ransomware encryption,
+  or disrupt essential services, leading to potential data loss or system compromise.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime  from datamodel=Endpoint.Processes where `process_net` OR  Processes.process_name
+  = "sc.exe" OR Processes.original_file_name= "sc.exe" AND Processes.process="*stop*"
+  by  Processes.process_name Processes.original_file_name Processes.process Processes.process_id
+  Processes.process_guid Processes.parent_process_name Processes.parent_process Processes.parent_process_guid
+  Processes.dest Processes.user | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` | `windows_service_stop_via_net__and_sc_application_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: Windows OS or software may stop and restart services due to
+  some critical update.
+references:
+- https://www.microsoft.com/en-us/security/blog/2022/10/14/new-prestige-ransomware-impacts-organizations-in-ukraine-and-poland/
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: $process$ was executed on $dest$ attempting to stop service.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 49
+  threat_objects: []
+tags:
+  analytic_story:
+  - Prestige Ransomware
+  - Graceful Wipe Out Attack
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1489
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/prestige_ransomware/sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/deprecated/windows_valid_account_with_never_expires_password.yml
+++ b/detections/deprecated/windows_valid_account_with_never_expires_password.yml
@@ -1,0 +1,82 @@
+name: Windows Valid Account With Never Expires Password
+id: 73a931db-1830-48b3-8296-cd9cfa09c3c8
+version: 6
+date: '2025-01-24'
+author: Teoderick Contreras, Splunk
+status: deprecated
+type: TTP
+description: The following analytic has been deprecated.
+  The following analytic detects the use of net.exe to update user account
+  policies to set passwords as non-expiring. It leverages data from Endpoint Detection
+  and Response (EDR) agents, focusing on command-line executions involving "/maxpwage:unlimited".
+  This activity is significant as it can indicate an attempt to maintain persistence,
+  escalate privileges, evade defenses, or facilitate lateral movement. If confirmed
+  malicious, this behavior could allow an attacker to maintain long-term access to
+  compromised accounts, potentially leading to further exploitation and unauthorized
+  access to sensitive information.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: '| tstats `security_content_summariesonly` values(Processes.process) as process
+  min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
+  where `process_net` AND Processes.process="* accounts *" AND Processes.process="*
+  /maxpwage:unlimited" by Processes.dest Processes.user Processes.parent_process_name
+  Processes.process_name Processes.original_file_name Processes.process Processes.process_id
+  Processes.parent_process_id | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` | `windows_valid_account_with_never_expires_password_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: This behavior is not commonly seen in production environment
+  and not advisable, filter as needed.
+references:
+- https://app.any.run/tasks/a6f2ffe2-e6e2-4396-ae2e-04ea0143f2d8/
+- https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/net-commands-on-operating-systems
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $parent_process_name$ spawning $process_name$ was identified
+    on endpoint $dest$ attempting to make non-expiring password on host user accounts.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 100
+  threat_objects: []
+tags:
+  analytic_story:
+  - Azorult
+  - Compromised Windows Host
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1489
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: 
+      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/azorult/sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/endpoint/linux_auditd_private_keys_and_certificate_enumeration.yml
+++ b/detections/endpoint/linux_auditd_private_keys_and_certificate_enumeration.yml
@@ -1,6 +1,6 @@
 name: Linux Auditd Private Keys and Certificate Enumeration
-id: 80bb9988-190b-4ee0-a3c3-509545a8f678
-version: 4
+id: 892eb674-3344-4143-8e52-4775b1daf3f1
+version: 1
 date: '2025-01-15'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/potential_system_network_configuration_discovery_activity.yml
+++ b/detections/endpoint/potential_system_network_configuration_discovery_activity.yml
@@ -1,6 +1,6 @@
 name: Potential System Network Configuration Discovery Activity
-id: a51bfe1a-94f0-48cc-b1e4-16ae10145893
-version: 6
+id: 3f0b95e3-3195-46ac-bea3-84fb59e7fac5
+version: 1
 date: '2025-01-20'
 author: Bhavin Patel, Splunk
 status: production

--- a/detections/endpoint/powershell_loading_dotnet_into_memory_via_reflection.yml
+++ b/detections/endpoint/powershell_loading_dotnet_into_memory_via_reflection.yml
@@ -1,4 +1,4 @@
-name: PowerShell Loading DotNET Into Memory via Reflection
+name: PowerShell Loading DotNET into Memory via Reflection
 id: 85bc3f30-ca28-11eb-bd21-acde48001122
 version: 6
 date: '2025-01-16'

--- a/detections/endpoint/windows_attempt_to_stop_security_service.yml
+++ b/detections/endpoint/windows_attempt_to_stop_security_service.yml
@@ -1,6 +1,6 @@
 name: Windows Attempt To Stop Security Service
-id: c8e349c6-b97c-486e-8949-bd7bcd1f3910
-version: 8
+id: 9ed27cea-4e27-4eff-b2c6-aac9e78a7517
+version: 1
 date: '2025-01-13'
 author: Rico Valdez, Nasreddine Bencherchali, Splunk
 status: production

--- a/detections/endpoint/windows_cmdline_tool_execution_from_non_shell_process.yml
+++ b/detections/endpoint/windows_cmdline_tool_execution_from_non_shell_process.yml
@@ -1,6 +1,6 @@
 name: Windows Cmdline Tool Execution From Non-Shell Process
-id: 6c3f7dd8-153c-11ec-ac2d-acde48001122
-version: 6
+id: 2afa393f-b88d-41b7-9793-623c93a2dfde
+version: 1
 date: '2025-01-13'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_create_local_administrator_account_via_net.yml
+++ b/detections/endpoint/windows_create_local_administrator_account_via_net.yml
@@ -1,6 +1,6 @@
 name: Windows Create Local Administrator Account Via Net
-id: b89919ed-fe5f-492c-b139-151bb162040e
-version: 14
+id: 2c568c34-bb57-4b43-9d75-19c605b98e70
+version: 1
 date: '2025-01-13'
 author: Bhavin Patel, Splunk
 status: production

--- a/detections/endpoint/windows_excessive_service_stop_attempt.yml
+++ b/detections/endpoint/windows_excessive_service_stop_attempt.yml
@@ -1,6 +1,6 @@
 name: Windows Excessive Service Stop Attempt
-id: ae8d3f4a-acd7-11eb-8846-acde48001122
-version: 6
+id: 8f3a614f-6b98-4f7d-82dd-d0df38452a8b
+version: 1
 date: '2025-01-13'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_excessive_usage_of_net_app.yml
+++ b/detections/endpoint/windows_excessive_usage_of_net_app.yml
@@ -1,6 +1,6 @@
 name: Windows Excessive Usage Of Net App
-id: 45e52536-ae42-11eb-b5c6-acde48001122
-version: 5
+id: 355ba810-0a20-4215-8485-9ce3f87f2e38
+version: 1
 date: '2025-01-13'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_http_network_communication_from_msiexec.yml
+++ b/detections/endpoint/windows_http_network_communication_from_msiexec.yml
@@ -1,6 +1,6 @@
 name: Windows HTTP Network Communication From MSIExec
-id: 827409a1-5393-4d8d-8da4-bbb297c262a7
-version: 5
+id: b0fd38c7-f71a-43a2-870e-f3ca06bcdd99
+version: 1
 date: '2025-01-17'
 author: Michael Haag, Splunk
 status: production

--- a/detections/endpoint/windows_list_env_variables_via_set_command_from_uncommon_parent.yml
+++ b/detections/endpoint/windows_list_env_variables_via_set_command_from_uncommon_parent.yml
@@ -1,6 +1,6 @@
 name: Windows List ENV Variables Via SET Command From Uncommon Parent
-id: 048839e4-1eaa-43ff-8a22-86d17f6fcc13
-version: 4
+id: aec157f4-8783-4584-aca6-754c4dc7fba9
+version: 1
 date: '2025-01-17'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_network_connection_discovery_via_net.yml
+++ b/detections/endpoint/windows_network_connection_discovery_via_net.yml
@@ -1,6 +1,6 @@
 name: Windows Network Connection Discovery Via Net
-id: 640337e5-6e41-4b7f-af06-9d9eab5e1e2d
-version: 5
+id: 86a5b949-679b-4197-8d4c-9c180a818c45
+version: 1
 date: '2025-01-13'
 author: Mauricio Velazco, Splunk
 status: production

--- a/detections/endpoint/windows_network_share_interaction_via_net.yml
+++ b/detections/endpoint/windows_network_share_interaction_via_net.yml
@@ -1,6 +1,6 @@
 name: Windows Network Share Interaction Via Net
-id: 4dc3951f-b3f8-4f46-b412-76a483f72277
-version: 4
+id: e51fbdb0-0be0-474f-92ea-d289f71a695e
+version: 1
 date: '2025-01-20'
 author: Dean Luxton
 status: production

--- a/detections/endpoint/windows_new_default_file_association_value_set.yml
+++ b/detections/endpoint/windows_new_default_file_association_value_set.yml
@@ -1,6 +1,6 @@
 name: Windows New Default File Association Value Set
-id: 462d17d8-1f71-11ec-ad07-acde48001122
-version: 4
+id: 7d1f031f-f1c9-43be-8b0b-c4e3e8a8928a
+version: 1
 date: '2025-01-15'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_office_product_dropped_cab_or_inf_file.yml
+++ b/detections/endpoint/windows_office_product_dropped_cab_or_inf_file.yml
@@ -1,6 +1,6 @@
 name: Windows Office Product Dropped Cab or Inf File
-id: f48cd1d4-125a-11ec-a447-acde48001122
-version: 9
+id: dbdd251e-dd45-4ec9-a555-f5e151391746
+version: 1
 date: '2025-01-20'
 author: Michael Haag, Splunk
 status: production

--- a/detections/endpoint/windows_office_product_dropped_uncommon_file.yml
+++ b/detections/endpoint/windows_office_product_dropped_uncommon_file.yml
@@ -1,6 +1,6 @@
 name: Windows Office Product Dropped Uncommon File
-id: 73ce70c4-146d-11ec-9184-acde48001122
-version: 8
+id: 7ac0fced-9eae-4381-a748-90dcd1aa9393
+version: 1
 date: '2025-01-20'
 author: Teoderick Contreras, Michael Haag, Splunk, TheLawsOfChaos, Github
 status: production

--- a/detections/endpoint/windows_office_product_loaded_mshtml_module.yml
+++ b/detections/endpoint/windows_office_product_loaded_mshtml_module.yml
@@ -1,6 +1,6 @@
 name: Windows Office Product Loaded MSHTML Module
-id: 5f1c168e-118b-11ec-84ff-acde48001122
-version: 6
+id: 4cc015c9-687c-40d2-adcc-46350f66e10c
+version: 1
 date: '2025-01-20'
 author: Michael Haag, Mauricio Velazco, Splunk
 status: production

--- a/detections/endpoint/windows_office_product_loading_taskschd_dll.yml
+++ b/detections/endpoint/windows_office_product_loading_taskschd_dll.yml
@@ -1,6 +1,6 @@
 name: Windows Office Product Loading Taskschd DLL
-id: cc8b7b74-9d0f-11eb-8342-acde48001122
-version: 9
+id: d7297cfa-1f04-4714-bfbe-3679e0666959
+version: 1
 date: '2025-01-20'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_office_product_loading_vbe7_dll.yml
+++ b/detections/endpoint/windows_office_product_loading_vbe7_dll.yml
@@ -1,6 +1,6 @@
 name: Windows Office Product Loading VBE7 DLL
-id: b12c89bc-9d06-11eb-a592-acde48001122
-version: 8
+id: 7cfec906-2697-43f7-898b-83634a051d9a
+version: 1
 date: '2025-01-20'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_office_product_spawned_child_process_for_download.yml
+++ b/detections/endpoint/windows_office_product_spawned_child_process_for_download.yml
@@ -1,6 +1,6 @@
 name: Windows Office Product Spawned Child Process For Download
-id: 6fed27d2-9ec7-11eb-8fe4-aa665a019aa3
-version: 9
+id: f02b64b8-cbea-4f75-bf77-7a05111566b1
+version: 1
 date: '2025-01-14'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_office_product_spawned_control.yml
+++ b/detections/endpoint/windows_office_product_spawned_control.yml
@@ -1,6 +1,6 @@
 name: Windows Office Product Spawned Control
-id: 053e027c-10c7-11ec-8437-acde48001122
-version: 9
+id: 081c485d-ac8d-4bee-ad4c-525772fead4d
+version: 1
 date: '2025-01-14'
 author: Michael Haag, Splunk
 status: production

--- a/detections/endpoint/windows_office_product_spawned_msdt.yml
+++ b/detections/endpoint/windows_office_product_spawned_msdt.yml
@@ -1,6 +1,6 @@
 name: Windows Office Product Spawned MSDT
-id: 127eba64-c981-40bf-8589-1830638864a7
-version: 0
+id: a3148fad-3734-4b7f-9a71-62f08d39fab1
+version: 1
 date: '2025-01-14'
 author: Michael Haag, Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_office_product_spawned_rundll32_with_no_dll.yml
+++ b/detections/endpoint/windows_office_product_spawned_rundll32_with_no_dll.yml
@@ -1,6 +1,6 @@
 name: Windows Office Product Spawned Rundll32 With No DLL
-id: c661f6be-a38c-11eb-be57-acde48001122
-version: 9
+id: f28e787e-69ca-480e-9f98-ab970e6d4bcc
+version: 1
 date: '2025-01-14'
 author: Michael Haag, Splunk
 status: production

--- a/detections/endpoint/windows_password_policy_discovery_with_net.yml
+++ b/detections/endpoint/windows_password_policy_discovery_with_net.yml
@@ -1,6 +1,6 @@
 name: Windows Password Policy Discovery with Net
-id: 09336538-065a-11ec-8665-acde48001122
-version: 6
+id: e52f7865-be78-46bf-b7ed-150fbe447613
+version: 1
 date: '2025-01-13'
 author: Teoderick Contreras, Mauricio Velazco, Nasreddine Bencherchali, Splunk
 status: production

--- a/detections/endpoint/windows_registry_entries_exported_via_reg.yml
+++ b/detections/endpoint/windows_registry_entries_exported_via_reg.yml
@@ -1,6 +1,6 @@
 name: Windows Registry Entries Exported Via Reg
-id: cbee60c1-b776-456f-83c2-faa56bdbe6c6
-version: 4
+id: 466379bc-0f47-476c-8202-16ef38112e0d
+version: 1
 date: '2025-01-15'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_registry_entries_restored_via_reg.yml
+++ b/detections/endpoint/windows_registry_entries_restored_via_reg.yml
@@ -1,6 +1,6 @@
 name: Windows Registry Entries Restored Via Reg
-id: d0072bd2-6d73-4c1b-bc77-ded6d2da3a4e
-version: 4
+id: a17af481-e2ad-494c-9da6-afb4d243a019
+version: 1
 date: '2025-01-14'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_sensitive_group_discovery_with_net.yml
+++ b/detections/endpoint/windows_sensitive_group_discovery_with_net.yml
@@ -1,6 +1,6 @@
 name: Windows Sensitive Group Discovery With Net
-id: a23a0e20-0b1b-4a07-82e5-ec5f70811e7a
-version: 5
+id: d9eb7cda-5622-4722-bc88-7f2442f4b5af
+version: 1
 date: '2025-01-13'
 author: Mauricio Velazco, Splunk
 status: production

--- a/detections/endpoint/windows_sensitive_registry_hive_dump_via_commandline.yml
+++ b/detections/endpoint/windows_sensitive_registry_hive_dump_via_commandline.yml
@@ -1,6 +1,6 @@
 name: Windows Sensitive Registry Hive Dump Via CommandLine
-id: 8bbb7d58-b360-11eb-ba21-acde48001122
-version: 5
+id: 5aaff29d-0cce-405b-9ee8-5d06b49d045e
+version: 1
 date: '2025-01-15'
 author: Michael Haag, Patrick Bareiss, Nasreddine Bencherchali, Splunk
 status: production

--- a/detections/endpoint/windows_service_stop_attempt.yml
+++ b/detections/endpoint/windows_service_stop_attempt.yml
@@ -1,6 +1,6 @@
 name: Windows Service Stop Attempt
-id: 827af04b-0d08-479b-9b84-b7d4644e4b80
-version: 4
+id: dd0f07ea-f08f-4d88-96e5-cb58156e82b6
+version: 1
 date: '2025-01-13'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_set_account_password_policy_to_unlimited_via_net.yml
+++ b/detections/endpoint/windows_set_account_password_policy_to_unlimited_via_net.yml
@@ -1,6 +1,6 @@
 name: Windows Set Account Password Policy To Unlimited Via Net
-id: 73a931db-1830-48b3-8296-cd9cfa09c3c8
-version: 5
+id: 11f93009-8083-43fd-82a7-821fcbdc8342
+version: 1
 date: '2025-01-13'
 author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production

--- a/detections/endpoint/windows_suspicious_child_process_spawned_from_webserver.yml
+++ b/detections/endpoint/windows_suspicious_child_process_spawned_from_webserver.yml
@@ -1,6 +1,6 @@
 name: Windows Suspicious Child Process Spawned From WebServer
-id: 22597426-6dbd-49bd-bcdc-4ec19857192f
-version: '6'
+id: 2d4470ef-7158-4b47-b68b-1f7f16382156
+version: 1
 date: '2025-01-13'
 author: Steven Dick
 status: production

--- a/detections/endpoint/windows_user_deletion_via_net.yml
+++ b/detections/endpoint/windows_user_deletion_via_net.yml
@@ -1,6 +1,6 @@
 name: Windows User Deletion Via Net
-id: 1c8c6f66-acce-11eb-aafb-acde48001122
-version: 6
+id: b0b6fd2c-8953-4d1b-8f7b-56075ea6ab3e
+version: 1
 date: '2025-01-13'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_user_disabled_via_net.yml
+++ b/detections/endpoint/windows_user_disabled_via_net.yml
@@ -1,6 +1,6 @@
 name: Windows User Disabled Via Net
-id: c0325326-acd6-11eb-98c2-acde48001122
-version: 6
+id: b0359e05-c87b-4354-83d8-aee0d890243f
+version: 1
 date: '2025-01-13'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_user_discovery_via_net.yml
+++ b/detections/endpoint/windows_user_discovery_via_net.yml
@@ -1,6 +1,6 @@
 name: Windows User Discovery Via Net
-id: 5d0d4830-0133-11ec-bae3-acde48001122
-version: 5
+id: 7742987e-88c1-476b-a626-a869e088ab72
+version: 1
 date: '2025-01-13'
 author: Mauricio Velazco, Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production


### PR DESCRIPTION
This PR restores the deleted analytics in #3271 and restore them to the deprecated folder. It also generates new ids for their replacements and revert their versioning to 1