### PR TITLE
Remove Incompatible 4688 Data Sources

### DIFF
--- a/detections/endpoint/chcp_command_execution.yml
+++ b/detections/endpoint/chcp_command_execution.yml
@@ -1,7 +1,7 @@
 name: CHCP Command Execution
 id: 21d236ec-eec1-11eb-b23e-acde48001122
-version: 4
-date: '2024-11-13'
+version: 5
+date: '2025-02-19'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
@@ -15,7 +15,6 @@ description: The following analytic detects the execution of the chcp.exe applic
   system compromise and data exfiltration.
 data_source:
 - Sysmon EventID 1
-- Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.process_name=chcp.com

--- a/detections/endpoint/jscript_execution_using_cscript_app.yml
+++ b/detections/endpoint/jscript_execution_using_cscript_app.yml
@@ -1,7 +1,7 @@
 name: Jscript Execution Using Cscript App
 id: 002f1e24-146e-11ec-a470-acde48001122
-version: 5
-date: '2025-02-10'
+version: 6
+date: '2025-02-19'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
@@ -14,7 +14,6 @@ description: The following analytic detects the execution of JScript using the c
   scripts, leading to code execution, data exfiltration, or further system compromise.
 data_source:
 - Sysmon EventID 1
-- Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where (Processes.parent_process_name

--- a/detections/endpoint/ping_sleep_batch_command.yml
+++ b/detections/endpoint/ping_sleep_batch_command.yml
@@ -1,7 +1,7 @@
 name: Ping Sleep Batch Command
 id: ce058d6c-79f2-11ec-b476-acde48001122
-version: 6
-date: '2025-02-10'
+version: 7
+date: '2025-02-19'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly
@@ -15,7 +15,6 @@ description: The following analytic identifies the execution of ping sleep batch
   exfiltration.
 data_source:
 - Sysmon EventID 1
-- Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where `process_ping` (Processes.parent_process

--- a/detections/endpoint/vbscript_execution_using_wscript_app.yml
+++ b/detections/endpoint/vbscript_execution_using_wscript_app.yml
@@ -1,7 +1,7 @@
 name: Vbscript Execution Using Wscript App
 id: 35159940-228f-11ec-8a49-acde48001122
-version: 5
-date: '2025-02-10'
+version: 6
+date: '2025-02-19'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
@@ -15,7 +15,6 @@ description: The following analytic detects the execution of VBScript using the 
   data exfiltration, or further lateral movement within the network.
 data_source:
 - Sysmon EventID 1
-- Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where (Processes.parent_process_name

--- a/detections/endpoint/windows_command_shell_dcrat_forkbomb_payload.yml
+++ b/detections/endpoint/windows_command_shell_dcrat_forkbomb_payload.yml
@@ -1,7 +1,7 @@
 name: Windows Command Shell DCRat ForkBomb Payload
 id: 2bb1a362-7aa8-444a-92ed-1987e8da83e1
-version: 6
-date: '2025-02-10'
+version: 7
+date: '2025-02-19'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
@@ -15,7 +15,6 @@ description: The following analytic detects the execution of a DCRat "forkbomb" 
   disruption of services.
 data_source:
 - Sysmon EventID 1
-- Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` values(Processes.process) as process
   values(Processes.parent_process) as parent_process values(Processes.parent_process_id)

--- a/detections/endpoint/windows_indirect_command_execution_via_forfiles.yml
+++ b/detections/endpoint/windows_indirect_command_execution_via_forfiles.yml
@@ -1,7 +1,7 @@
 name: Windows Indirect Command Execution Via forfiles
 id: 1fdf31c9-ff4d-4c48-b799-0e8666e08787
-version: 4
-date: '2024-11-13'
+version: 5
+date: '2025-02-19'
 author: Eric McGinnis, Splunk
 status: production
 type: TTP
@@ -16,7 +16,6 @@ description: The following analytic detects the execution of programs initiated 
   compromise.
 data_source:
 - Sysmon EventID 1
-- Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.parent_process="*forfiles*

--- a/detections/endpoint/windows_indirect_command_execution_via_pcalua.yml
+++ b/detections/endpoint/windows_indirect_command_execution_via_pcalua.yml
@@ -1,7 +1,7 @@
 name: Windows Indirect Command Execution Via pcalua
 id: 3428ac18-a410-4823-816c-ce697d26f7a8
-version: 4
-date: '2024-11-13'
+version: 5
+date: '2025-02-19'
 author: Eric McGinnis, Splunk
 status: production
 type: TTP
@@ -15,7 +15,6 @@ description: The following analytic detects programs initiated by pcalua.exe, th
   environment.
 data_source:
 - Sysmon EventID 1
-- Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.parent_process="*pcalua*

--- a/detections/endpoint/windows_scheduled_task_service_spawned_shell.yml
+++ b/detections/endpoint/windows_scheduled_task_service_spawned_shell.yml
@@ -1,7 +1,7 @@
 name: Windows Scheduled Task Service Spawned Shell
 id: d8120352-3b62-4e3c-8cb6-7b47584dd5e8
-version: 4
-date: '2024-11-13'
+version: 5
+date: '2025-02-19'
 author: Steven Dick
 status: production
 type: TTP
@@ -15,7 +15,6 @@ description: The following analytic detects when the Task Scheduler service ("sv
   persistence, or escalate privileges within the environment.
 data_source:
 - Sysmon EventID 1
-- Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.parent_process="*\\system32\\svchost.exe*"

--- a/detections/endpoint/windows_time_based_evasion.yml
+++ b/detections/endpoint/windows_time_based_evasion.yml
@@ -1,13 +1,12 @@
 name: Windows Time Based Evasion
 id: 34502357-deb1-499a-8261-ffe144abf561
-version: 5
-date: '2025-02-10'
+version: 6
+date: '2025-02-19'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
 data_source:
 - Sysmon EventID 1
-- Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 description: The following analytic detects potentially malicious processes that initiate
   a ping delay using an invalid IP address. It leverages data from Endpoint Detection


### PR DESCRIPTION
This PR removes the 4688 data source from analytics that leverage `Processes.parent_process` since EventID 4688 does not have a `ParentCommandLine` field.