### PR TITLE
Update Exchange Macro

### DIFF
--- a/detections/endpoint/exchange_powershell_abuse_via_ssrf.yml
+++ b/detections/endpoint/exchange_powershell_abuse_via_ssrf.yml
@@ -1,7 +1,7 @@
 name: Exchange PowerShell Abuse via SSRF
 id: 29228ab4-0762-11ec-94aa-acde48001122
-version: 5
-date: '2024-11-13'
+version: 6
+date: '2025-02-19'
 author: Michael Haag, Splunk
 status: experimental
 type: TTP
@@ -14,7 +14,7 @@ description: The following analytic detects suspicious behavior indicative of Pr
   If confirmed malicious, this could lead to unauthorized access, privilege escalation,
   or persistent control over the Exchange environment.
 data_source: []
-search: '`exchange` c_uri="*//autodiscover*" cs_uri_query="*PowerShell*" cs_method="POST"
+search: '`windows_exchange_iis` c_uri="*//autodiscover*" cs_uri_query="*PowerShell*" cs_method="POST"
   | stats count min(_time) as firstTime max(_time) as lastTime by dest, cs_uri_query,
   cs_method, c_uri | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
   | `exchange_powershell_abuse_via_ssrf_filter`'

--- a/macros/exchange.yml
+++ b/macros/exchange.yml
@@ -1,4 +1,0 @@
-definition: sourcetype="MSWindows:IIS"
-description: customer specific splunk configurations(eg- index, source, sourcetype).
-  Replace the macro definition with configurations for your Splunk Environment.
-name: exchange

--- a/macros/windows_exchange_iis.yml
+++ b/macros/windows_exchange_iis.yml
@@ -1,0 +1,4 @@
+definition: (sourcetype="MSWindows:2003:IIS" OR sourcetype="MSWindows:2008R2:IIS" OR sourcetype="MSWindows:2010EWS:IIS" OR sourcetype="MSWindows:2012:IIS" OR sourcetype="MSWindows:2013EWS:IIS")
+description: customer specific splunk configurations(eg- index, source, sourcetype).
+  Replace the macro definition with configurations for your Splunk Environment.
+name: windows_exchange_iis


### PR DESCRIPTION
This PR updates the Exchange macro to the actual sourcetype defined by the TA https://splunkbase.splunk.com/app/3225 specifically the `TA-Windows-Exchange-IIS`

@inspired was the one to notice this during XS24, so kudos to him.

Since there is only one analytic currently using. I took the liberty to rename the macro to a more accurate name. I do not think this will affect anyone in a major way, but please keep me honest. If needed i could revert the rename.

![image](https://github.com/user-attachments/assets/3f528553-3268-4e7e-8ea4-147b39437be8)
![image](https://github.com/user-attachments/assets/20ab6d27-cafc-4138-9a10-8ed88ae91c4b)


