### PR TITLE
fix more typo'd data source names

### DIFF
--- a/detections/endpoint/windows_compatibility_telemetry_suspicious_child_process.yml
+++ b/detections/endpoint/windows_compatibility_telemetry_suspicious_child_process.yml
@@ -8,7 +8,7 @@ type: TTP
 description: The following analytic detects the execution of CompatTelRunner.exe with parameters indicative of a process not part of the normal "Microsoft Compatibility Appraiser" telemetry collection. It leverages data from Endpoint Detection and Response (EDR) agents, focusing on process names, parent processes, and command-line arguments. This activity is significant because CompatTelRunner.exe and the "Microsoft Compatibility Appraiser" task always run as System and can be used to elevate privileges or establish a highly privileged persistence mechanism. If confirmed malicious, this could enable unauthorized code execution, privilege escalation, or persistent access to the compromised system.
 data_source: 
 - Windows Security Event ID 4688
-- Sysmon Event ID 1
+- Sysmon EventID 1
 - CrowdStrike ProcessRollup2
 search: |-
   |  tstats `security_content_summariesonly` values(Processes.parent_process) as Processes.parent_process, values(Processes.process) as Processes.process values(Processes.process_current_directory) AS process_current_directory, values(Processes.process_id) as Processes.process_id, values(Processes.process_guid) as Processes.process_guid, count min(_time) AS firstTime, max(_time) AS lastTime FROM datamodel=Endpoint.Processes where Processes.parent_process_name = "CompatTelRunner.exe" AND Processes.process="* -cv:*" NOT Processes.process IN ("* -m:*") BY _time span=1h Processes.user Processes.dest Processes.parent_process_name Processes.process_name

--- a/detections/endpoint/windows_compatibility_telemetry_tampering_through_registry.yml
+++ b/detections/endpoint/windows_compatibility_telemetry_tampering_through_registry.yml
@@ -7,7 +7,7 @@ status: production
 type: TTP
 description: This detection identifies suspicious modifications to the Windows Compatibility Telemetry registry settings, specifically within the "TelemetryController" registry key and "Command" registry value. It leverages data from the Endpoint.Registry data model, focusing on registry paths and values indicative of such changes. This activity is significant because CompatTelRunner.exe and the "Microsoft Compatibility Appraiser" task always run as System and can be used to elevate privileges or establish a highly privileged persistence mechanism. If confirmed malicious, this could enable unauthorized code execution, privilege escalation, or persistent access to the compromised system.
 data_source: 
-- Sysmon Event ID 13
+- Sysmon EventID 13
 search: |-
   | tstats `security_content_summariesonly` min(_time) as firstTime, max(_time) as lastTime, count FROM datamodel=Endpoint.Registry WHERE (Registry.registry_path = "*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\TelemetryController*" AND Registry.registry_value_name="Command" NOT Registry.registry_value_data IN ("(empty)")) BY Registry.dest Registry.user Registry.registry_path Registry.registry_key_name Registry.registry_value_name Registry.registry_value_data Registry.process_guid
   | `drop_dm_object_name(Registry)`

--- a/detections/endpoint/windows_powershell_process_with_malicious_string.yml
+++ b/detections/endpoint/windows_powershell_process_with_malicious_string.yml
@@ -8,7 +8,7 @@ type: TTP
 description: The following analytic detects the execution of multiple offensive toolkits and commands through the process execution datamodel. This method captures commands given directly to powershell.exe, allowing for the identification of suspicious activities including several well-known tools used for credential theft, lateral movement, and persistence. If confirmed malicious, this could lead to unauthorized access, privilege escalation, and potential compromise of sensitive information within the environment.
 data_source: 
 - Windows Security Event ID 4688
-- Sysmon Event ID 1
+- Sysmon EventID 1
 - CrowdStrike ProcessRollup2
 search: |-
   | tstats `security_content_summariesonly` count values(Processes.original_file_name) as original_file_name values(Processes.process) as process values(Processes.parent_process) as parent_process min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where `process_powershell` by Processes.user Processes.dest Processes.process_name Processes.parent_process_name Processes.process 


### PR DESCRIPTION
Fix typos in the names of data_sources.

Unsure if it will make it into the upcoming release, so I have NOT updated the versions (yet).
If this goes into 5.2, we will need to bump the versions.