### PR TITLE
[chore] update AWS TA -> 7.9.1

### DIFF
--- a/contentctl.yml
+++ b/contentctl.yml
@@ -143,9 +143,9 @@ apps:
 - uid: 1876
   title: Splunk Add-on for AWS
   appid: Splunk_TA_aws
-  version: 7.9.0
+  version: 7.9.1
   description: description of app
-  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-amazon-web-services-aws_790.tgz
+  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-amazon-web-services-aws_791.tgz
 - uid: 3088
   title: Splunk Add-on for Google Cloud Platform
   appid: SPLUNK_ADD_ON_FOR_GOOGLE_CLOUD_PLATFORM

--- a/data_sources/asl_aws_cloudtrail.yml
+++ b/data_sources/asl_aws_cloudtrail.yml
@@ -10,4 +10,4 @@ separator: api.operation
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1

--- a/data_sources/aws_cloudfront.yml
+++ b/data_sources/aws_cloudfront.yml
@@ -9,7 +9,7 @@ sourcetype: aws:cloudfront:accesslogs
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail.yml
+++ b/data_sources/aws_cloudtrail.yml
@@ -10,4 +10,4 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1

--- a/data_sources/aws_cloudtrail_assumerolewithsaml.yml
+++ b/data_sources/aws_cloudtrail_assumerolewithsaml.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_consolelogin.yml
+++ b/data_sources/aws_cloudtrail_consolelogin.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_copyobject.yml
+++ b/data_sources/aws_cloudtrail_copyobject.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - additionalEventData.AuthenticationMethod

--- a/data_sources/aws_cloudtrail_createaccesskey.yml
+++ b/data_sources/aws_cloudtrail_createaccesskey.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_createkey.yml
+++ b/data_sources/aws_cloudtrail_createkey.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_createloginprofile.yml
+++ b/data_sources/aws_cloudtrail_createloginprofile.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_createnetworkaclentry.yml
+++ b/data_sources/aws_cloudtrail_createnetworkaclentry.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_createpolicyversion.yml
+++ b/data_sources/aws_cloudtrail_createpolicyversion.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_createsnapshot.yml
+++ b/data_sources/aws_cloudtrail_createsnapshot.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_createtask.yml
+++ b/data_sources/aws_cloudtrail_createtask.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_createvirtualmfadevice.yml
+++ b/data_sources/aws_cloudtrail_createvirtualmfadevice.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deactivatemfadevice.yml
+++ b/data_sources/aws_cloudtrail_deactivatemfadevice.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deleteaccountpasswordpolicy.yml
+++ b/data_sources/aws_cloudtrail_deleteaccountpasswordpolicy.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletealarms.yml
+++ b/data_sources/aws_cloudtrail_deletealarms.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletedetector.yml
+++ b/data_sources/aws_cloudtrail_deletedetector.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_deletegroup.yml
+++ b/data_sources/aws_cloudtrail_deletegroup.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deleteipset.yml
+++ b/data_sources/aws_cloudtrail_deleteipset.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_deleteloggroup.yml
+++ b/data_sources/aws_cloudtrail_deleteloggroup.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - apiVersion

--- a/data_sources/aws_cloudtrail_deletelogstream.yml
+++ b/data_sources/aws_cloudtrail_deletelogstream.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - apiVersion

--- a/data_sources/aws_cloudtrail_deletenetworkaclentry.yml
+++ b/data_sources/aws_cloudtrail_deletenetworkaclentry.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletepolicy.yml
+++ b/data_sources/aws_cloudtrail_deletepolicy.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deleterule.yml
+++ b/data_sources/aws_cloudtrail_deleterule.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - apiVersion

--- a/data_sources/aws_cloudtrail_deletesnapshot.yml
+++ b/data_sources/aws_cloudtrail_deletesnapshot.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletetrail.yml
+++ b/data_sources/aws_cloudtrail_deletetrail.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_deletevirtualmfadevice.yml
+++ b/data_sources/aws_cloudtrail_deletevirtualmfadevice.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletewebacl.yml
+++ b/data_sources/aws_cloudtrail_deletewebacl.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - apiVersion

--- a/data_sources/aws_cloudtrail_describeeventaggregates.yml
+++ b/data_sources/aws_cloudtrail_describeeventaggregates.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_describeimagescanfindings.yml
+++ b/data_sources/aws_cloudtrail_describeimagescanfindings.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_getaccountpasswordpolicy.yml
+++ b/data_sources/aws_cloudtrail_getaccountpasswordpolicy.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_getobject.yml
+++ b/data_sources/aws_cloudtrail_getobject.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - additionalEventData.AuthenticationMethod

--- a/data_sources/aws_cloudtrail_getpassworddata.yml
+++ b/data_sources/aws_cloudtrail_getpassworddata.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_jobcreated.yml
+++ b/data_sources/aws_cloudtrail_jobcreated.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_modifydbinstance.yml
+++ b/data_sources/aws_cloudtrail_modifydbinstance.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_modifyimageattribute.yml
+++ b/data_sources/aws_cloudtrail_modifyimageattribute.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_modifysnapshotattribute.yml
+++ b/data_sources/aws_cloudtrail_modifysnapshotattribute.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_putbucketacl.yml
+++ b/data_sources/aws_cloudtrail_putbucketacl.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_putbucketlifecycle.yml
+++ b/data_sources/aws_cloudtrail_putbucketlifecycle.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - additionalEventData.AuthenticationMethod

--- a/data_sources/aws_cloudtrail_putbucketreplication.yml
+++ b/data_sources/aws_cloudtrail_putbucketreplication.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - additionalEventData.AuthenticationMethod

--- a/data_sources/aws_cloudtrail_putbucketversioning.yml
+++ b/data_sources/aws_cloudtrail_putbucketversioning.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - additionalEventData.AuthenticationMethod

--- a/data_sources/aws_cloudtrail_putimage.yml
+++ b/data_sources/aws_cloudtrail_putimage.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_putkeypolicy.yml
+++ b/data_sources/aws_cloudtrail_putkeypolicy.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_replacenetworkaclentry.yml
+++ b/data_sources/aws_cloudtrail_replacenetworkaclentry.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_setdefaultpolicyversion.yml
+++ b/data_sources/aws_cloudtrail_setdefaultpolicyversion.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_stoplogging.yml
+++ b/data_sources/aws_cloudtrail_stoplogging.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_updateaccountpasswordpolicy.yml
+++ b/data_sources/aws_cloudtrail_updateaccountpasswordpolicy.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_updateloginprofile.yml
+++ b/data_sources/aws_cloudtrail_updateloginprofile.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_updatesamlprovider.yml
+++ b/data_sources/aws_cloudtrail_updatesamlprovider.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_updatetrail.yml
+++ b/data_sources/aws_cloudtrail_updatetrail.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudwatchlogs_vpcflow.yml
+++ b/data_sources/aws_cloudwatchlogs_vpcflow.yml
@@ -9,7 +9,7 @@ sourcetype: aws:cloudwatchlogs:vpcflow
 separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
-  version: 7.9.0
+  version: 7.9.1
   url: https://splunkbase.splunk.com/app/1876
 fields:
 - _raw

--- a/data_sources/aws_security_hub.yml
+++ b/data_sources/aws_security_hub.yml
@@ -9,7 +9,7 @@ sourcetype: aws:securityhub:finding
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 7.9.0
+  version: 7.9.1
 fields:
 - _time
 - AwsAccountId


### PR DESCRIPTION
### Details

Breaks the AWS TA update out of #3360 & #3361 both of which can be closed from this, as they're currently still failing due to the *nix TA changes.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://docs.splunk.com/Documentation/SplunkCloud/8.2.2203/Admin/PrivateApps#Manage_lookups_in_Splunk_Cloud_Platform) but the short version is that any changes to lookup files need to bump the datestamp in the lookup CSV filename, and the reference to it in the YAML needs to be updated.