### PR TITLE
Updating dcsync detection due to false positive

### DIFF
--- a/detections/endpoint/windows_ad_replication_request_initiated_by_user_account.yml
+++ b/detections/endpoint/windows_ad_replication_request_initiated_by_user_account.yml
@@ -14,21 +14,18 @@ description: The following analytic detects a user account initiating an Active 
   sufficient privileges to request password hashes for any or all users within the
   domain. If confirmed malicious, this could lead to unauthorized access, privilege
   escalation, and potential compromise of the entire domain.
-search: '`wineventlog_security` EventCode=4662 ObjectType IN ("%{19195a5b-6da0-11d0-afd3-00c04fd930c9}",
-  "domainDNS") AND Properties IN ("*Replicating Directory Changes All*", "*{1131f6ad-9c07-11d1-f79f-00c04fc2dcd2}*",
-  "*{9923a32a-3607-11d2-b9be-0000f87a36b2}*","*{1131f6ac-9c07-11d1-f79f-00c04fc2dcd2}*")
-  AND AccessMask="0x100" AND NOT (SubjectUserSid="NT AUT*" OR SubjectUserSid="S-1-5-18"
-  OR SubjectDomainName="Window Manager" OR SubjectUserName="*$") | stats min(_time)
-  as _time, count by SubjectDomainName, SubjectUserName, Computer, Logon_ID, ObjectName,
-  ObjectServer, ObjectType, OperationType, status | rename SubjectDomainName as Target_Domain,
-  SubjectUserName as user, Logon_ID as TargetLogonId, _time as attack_time | appendpipe
-  [| map search="search `wineventlog_security` EventCode=4624 TargetLogonId=$TargetLogonId$"]
-  | table attack_time, AuthenticationPackageName, LogonProcessName, LogonType, TargetUserSid,
-  Target_Domain, user, Computer, TargetLogonId, status, src_ip, src_category, ObjectName,
-  ObjectServer, ObjectType, OperationType | stats min(attack_time) as _time values(TargetUserSid)
-  as TargetUserSid, values(Target_Domain) as Target_Domain, values(user) as user,
-  values(Computer) as Computer, values(status) as status, values(src_category) as
-  src_category, values(src_ip) as src_ip by TargetLogonId | `windows_ad_replication_request_initiated_by_user_account_filter`'
+search: >-
+  `wineventlog_security` EventCode=4662 ObjectType IN ("%{19195a5b-6da0-11d0-afd3-00c04fd930c9}","domainDNS") 
+      AND Properties IN ("*Replicating Directory Changes All*", "*{1131f6ad-9c07-11d1-f79f-00c04fc2dcd2}*","*{9923a32a-3607-11d2-b9be-0000f87a36b2}*","*{1131f6ac-9c07-11d1-f79f-00c04fc2dcd2}*")
+      AND AccessMask="0x100" AND NOT (SubjectUserSid="NT AUT*" OR SubjectUserSid="S-1-5-18" OR SubjectDomainName="Window Manager" OR SubjectUserName="*$") 
+  | stats min(_time) as _time, count by SubjectDomainName, SubjectUserName, Computer, Logon_ID, ObjectName, ObjectServer, ObjectType, OperationType, status 
+  | rename SubjectDomainName as Target_Domain, SubjectUserName as user, Logon_ID as TargetLogonId, _time as attack_time 
+  | appendpipe 
+      [| map search="search `wineventlog_security` EventCode=4624 TargetLogonId=$TargetLogonId$" | fields - status] 
+  | table attack_time, AuthenticationPackageName, LogonProcessName, LogonType, TargetUserSid, Target_Domain, user, Computer, TargetLogonId, status, src_ip, src_category, ObjectName, ObjectServer, ObjectType, OperationType 
+  | stats min(attack_time) as _time values(TargetUserSid) as TargetUserSid, values(Target_Domain) as Target_Domain, values(user) as user, values(Computer) as Computer, values(status) as status, values(src_category) as
+      src_category, values(src_ip) as src_ip by TargetLogonId 
+  | `windows_ad_replication_request_initiated_by_user_account_filter`
 how_to_implement: To successfully implement this search, you need to be ingesting
   eventcode `4662`. The Advanced Security Audit policy settings `Audit Directory Services
   Access` within `DS Access` needs to be enabled, as well as the following SACLs applied
@@ -36,7 +33,7 @@ how_to_implement: To successfully implement this search, you need to be ingestin
   Computers`, and  `Domain Controllers` auditing the permissions `Replicating Directory
   Changes`, `Replicating Directory Changes All`, and `Replicating Directory Changes
   In Filtered Set`
-known_false_positives: Azure AD Connect syncing operations.
+known_false_positives: Azure AD Connect syncing operations and the dcdiag.exe /Test:Replications command. 
 references:
 - https://adsecurity.org/?p=1729
 - https://www.linkedin.com/pulse/mimikatz-dcsync-event-log-detections-john-dwyer

--- a/detections/endpoint/windows_ad_replication_request_initiated_by_user_account.yml
+++ b/detections/endpoint/windows_ad_replication_request_initiated_by_user_account.yml
@@ -1,6 +1,6 @@
 name: Windows AD Replication Request Initiated by User Account
 id: 51307514-1236-49f6-8686-d46d93cc2821
-version: 7
+version: 8
 date: '2025-02-10'
 author: Dean Luxton
 type: TTP
@@ -54,14 +54,15 @@ drilldown_searches:
   latest_offset: $info_max_time$
 rba:
   message: Windows Active Directory Replication Request Initiated by User Account
-    $user$ at $src_ip$
+    $user$ from $src_ip$
   risk_objects:
   - field: user
     type: user
     score: 100
-  threat_objects:
   - field: src_ip
-    type: ip_address
+    type: system
+    score: 100
+  threat_objects: []
 tags:
   analytic_story:
   - Compromised Windows Host

--- a/detections/endpoint/windows_ad_replication_request_initiated_from_unsanctioned_location.yml
+++ b/detections/endpoint/windows_ad_replication_request_initiated_from_unsanctioned_location.yml
@@ -1,6 +1,6 @@
 name: Windows AD Replication Request Initiated from Unsanctioned Location
 id: 50998483-bb15-457b-a870-965080d9e3d3
-version: 8
+version: 9
 date: '2025-02-10'
 author: Dean Luxton
 type: TTP

--- a/detections/endpoint/windows_ad_replication_request_initiated_from_unsanctioned_location.yml
+++ b/detections/endpoint/windows_ad_replication_request_initiated_from_unsanctioned_location.yml
@@ -66,9 +66,10 @@ rba:
   - field: user
     type: user
     score: 100
-  threat_objects:
   - field: src_ip
-    type: ip_address
+    type: system
+    score: 100
+  threat_objects: []
 tags:
   analytic_story:
   - Compromised Windows Host


### PR DESCRIPTION
A customer found this detection can be triggered using the following command. 
dcdiag.exe /Test:Replications /s:DCNAMEHERE

This is still a replication event initiated by a user, but its not a dcsync attack.  
Updating the search to remove the logon status & adding details to the known false positives. 