### PR TITLE
0xC0FFEEEE - Windows Process Injection into Notepad Improvements

### DIFF
--- a/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
+++ b/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
@@ -9,13 +9,13 @@ data_source:
 - Sysmon EventID 10
 description: The following analytic detects process injection into executables that are commonly abused using
   Sysmon EventCode 10. It identifies suspicious GrantedAccess requests (0x40 and 0x1fffff)
-  to notepad.exe, wordpad.exe, calc.exe and mspaint.exe, excluding common system paths like System32, Syswow64, and Program
+  to processes such as notepad.exe, wordpad.exe and calc.exe, excluding common system paths like System32, Syswow64, and Program
   Files. This behavior is often associated with the SliverC2 framework by BishopFox.
   Monitoring this activity is crucial as it may indicate an initial payload attempting
   to execute malicious code. If confirmed malicious, this could
   allow attackers to execute arbitrary code, potentially leading to privilege escalation
   or persistent access within the environment.
-search: '`sysmon` EventCode=10 TargetImage IN ("*\\notepad.exe", "*\\wordpad.exe", "*\\calc.exe", "*\\mspaint.exe") NOT (SourceImage IN ("*\\system32\\*","*\\syswow64\\*","*\\Program Files\\*")) GrantedAccess IN ("0x40","0x1fffff") 
+search: '`sysmon` EventCode=10 TargetImage IN ("*\\notepad.exe", "*\\wordpad.exe", "*\\calc.exe", "*\\mspaint.exe", "*\\lsass.exe", "*\\svchost.exe", "*\\backgroundtaskhost.exe", "*\\dllhost.exe", "*\\regsvr32.exe", "*\\searchprotocolhost.exe", "*\\werfault.exe", "*\\wuauclt.exe", "*\\spoolsv.exe") NOT (SourceImage IN ("*\\system32\\*","*\\syswow64\\*","*\\Program Files\\*", "*\\Program Files (x86)\\*")) GrantedAccess IN ("0x40","0x1fffff") 
   | stats count min(_time) as firstTime max(_time) as lastTime by dest SourceImage TargetImage GrantedAccess CallTrace 
   | eval CallTrace=split(CallTrace, "|")
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
+++ b/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
@@ -31,6 +31,7 @@ known_false_positives: False positives may be present based on SourceImage paths
 references:
 - https://dominicbreuker.com/post/learning_sliver_c2_08_implant_basics/
 - https://www.cybereason.com/blog/sliver-c2-leveraged-by-many-threat-actors
+- https://redcanary.com/threat-detection-report/techniques/process-injection/
 drilldown_searches:
 - name: View the detection results for - "$dest$"
   search: '%original_detection_search% | search  dest = "$dest$"'

--- a/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
+++ b/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
@@ -25,7 +25,7 @@ how_to_implement: To successfully implement this search, you need to be ingestin
   logs with the process name, parent process, and command-line executions from your
   endpoints. If you are using Sysmon, you must have at least version 6.0.4 of the
   Sysmon TA.
-known_false_positives: False positives may be present based on SourceImage paths.
+known_false_positives: False positives may be present based on SourceImage paths, particularly those with a legitimate reason for accessing lsass.exe or regsvr32.exe.
   If removing the paths is important, realize svchost and many native binaries inject
   into processes consistently. Restrict or tune as needed.
 references:

--- a/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
+++ b/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
@@ -20,7 +20,7 @@ search: '`sysmon` EventCode=10 TargetImage IN ("*\\notepad.exe", "*\\wordpad.exe
   | eval CallTrace=split(CallTrace, "|")
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 
-  | `windows_process_injection_into_notepad_filter`'
+  | `windows_process_injection_into_commonly_abused_process_filter`'
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the process name, parent process, and command-line executions from your
   endpoints. If you are using Sysmon, you must have at least version 6.0.4 of the

--- a/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
+++ b/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
@@ -15,7 +15,7 @@ description: The following analytic detects process injection into executables t
   to execute malicious code. If confirmed malicious, this could
   allow attackers to execute arbitrary code, potentially leading to privilege escalation
   or persistent access within the environment.
-search: '`sysmon` EventCode=10 TargetImage IN ("*\\notepad.exe", "*\\wordpad.exe", "*\\calc.exe", "*\\mspaint.exe", "*\\lsass.exe", "*\\svchost.exe", "*\\backgroundtaskhost.exe", "*\\dllhost.exe", "*\\regsvr32.exe", "*\\searchprotocolhost.exe", "*\\werfault.exe", "*\\wuauclt.exe", "*\\spoolsv.exe", "*\\chrome.exe", "*\\edge.exe", "*\\firefox.exe") NOT (SourceImage IN ("*\\system32\\*","*\\syswow64\\*","*\\Program Files\\*", "*\\Program Files (x86)\\*")) GrantedAccess IN ("0x40","0x1fffff") 
+search: '`sysmon` EventCode=10 TargetImage IN ("*\\notepad.exe", "*\\wordpad.exe", "*\\calc.exe", "*\\mspaint.exe", "*\\lsass.exe", "*\\svchost.exe", "*\\backgroundtaskhost.exe", "*\\dllhost.exe", "*\\regsvr32.exe", "*\\searchprotocolhost.exe", "*\\werfault.exe", "*\\wuauclt.exe", "*\\spoolsv.exe", "*\\chrome.exe", "*\\edge.exe", "*\\firefox.exe") NOT (SourceImage IN ("*\\system32\\*","*\\syswow64\\*","*\\Program Files\\*", "*\\Program Files (x86)\\*")) GrantedAccess IN ("0x40","0x1fffff", "0x1f3fff") 
   | stats values(user) as user, min(_time) as firstTime, max(_time) as lastTime, count by dest SourceImage TargetImage GrantedAccess CallTrace 
   | eval CallTrace=split(CallTrace, "|")
   | `security_content_ctime(firstTime)` 

--- a/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
+++ b/detections/endpoint/windows_process_injection_into_commonly_abused_process.yml
@@ -15,11 +15,12 @@ description: The following analytic detects process injection into executables t
   to execute malicious code. If confirmed malicious, this could
   allow attackers to execute arbitrary code, potentially leading to privilege escalation
   or persistent access within the environment.
-search: '`sysmon` EventCode=10 TargetImage IN ("*\\notepad.exe", "*\\wordpad.exe", "*\\calc.exe", "*\\mspaint.exe", "*\\lsass.exe", "*\\svchost.exe", "*\\backgroundtaskhost.exe", "*\\dllhost.exe", "*\\regsvr32.exe", "*\\searchprotocolhost.exe", "*\\werfault.exe", "*\\wuauclt.exe", "*\\spoolsv.exe") NOT (SourceImage IN ("*\\system32\\*","*\\syswow64\\*","*\\Program Files\\*", "*\\Program Files (x86)\\*")) GrantedAccess IN ("0x40","0x1fffff") 
-  | stats count min(_time) as firstTime max(_time) as lastTime by dest SourceImage TargetImage GrantedAccess CallTrace 
+search: '`sysmon` EventCode=10 TargetImage IN ("*\\notepad.exe", "*\\wordpad.exe", "*\\calc.exe", "*\\mspaint.exe", "*\\lsass.exe", "*\\svchost.exe", "*\\backgroundtaskhost.exe", "*\\dllhost.exe", "*\\regsvr32.exe", "*\\searchprotocolhost.exe", "*\\werfault.exe", "*\\wuauclt.exe", "*\\spoolsv.exe", "*\\chrome.exe", "*\\edge.exe", "*\\firefox.exe") NOT (SourceImage IN ("*\\system32\\*","*\\syswow64\\*","*\\Program Files\\*", "*\\Program Files (x86)\\*")) GrantedAccess IN ("0x40","0x1fffff") 
+  | stats values(user) as user, min(_time) as firstTime, max(_time) as lastTime, count by dest SourceImage TargetImage GrantedAccess CallTrace 
   | eval CallTrace=split(CallTrace, "|")
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 
+  | table firstTime lastTime dest user SourceImage TargetImage GrantedAccess CallTrace count
   | `windows_process_injection_into_commonly_abused_process_filter`'
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the process name, parent process, and command-line executions from your

--- a/detections/endpoint/windows_process_injection_into_notepad.yml
+++ b/detections/endpoint/windows_process_injection_into_notepad.yml
@@ -1,24 +1,25 @@
-name: Windows Process Injection into Notepad
+name: Windows Process Injection into Commonly Abused Process
 id: b8340d0f-ba48-4391-bea7-9e793c5aae36
-version: 6
-date: '2025-02-10'
-author: Michael Haag, Splunk
+version: 7
+date: '2025-03-12'
+author: Michael Haag, Splunk, 0xC0FFEEEE, Github Community
 type: Anomaly
 status: production
 data_source:
 - Sysmon EventID 10
-description: The following analytic detects process injection into Notepad.exe using
+description: The following analytic detects process injection into executables that are commonly abused using
   Sysmon EventCode 10. It identifies suspicious GrantedAccess requests (0x40 and 0x1fffff)
-  to Notepad.exe, excluding common system paths like System32, Syswow64, and Program
+  to notepad.exe, wordpad.exe, calc.exe and mspaint.exe, excluding common system paths like System32, Syswow64, and Program
   Files. This behavior is often associated with the SliverC2 framework by BishopFox.
   Monitoring this activity is crucial as it may indicate an initial payload attempting
-  to execute malicious code within Notepad.exe. If confirmed malicious, this could
+  to execute malicious code. If confirmed malicious, this could
   allow attackers to execute arbitrary code, potentially leading to privilege escalation
   or persistent access within the environment.
-search: '`sysmon` EventCode=10 TargetImage IN (*\\notepad.exe) NOT (SourceImage IN
-  ("*\\system32\\*","*\\syswow64\\*","*\\Program Files\\*")) GrantedAccess IN ("0x40","0x1fffff")
-  | stats count min(_time) as firstTime max(_time) as lastTime by dest SourceImage
-  TargetImage GrantedAccess CallTrace | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+search: '`sysmon` EventCode=10 TargetImage IN ("*\\notepad.exe", "*\\wordpad.exe", "*\\calc.exe", "*\\mspaint.exe") NOT (SourceImage IN ("*\\system32\\*","*\\syswow64\\*","*\\Program Files\\*")) GrantedAccess IN ("0x40","0x1fffff") 
+  | stats count min(_time) as firstTime max(_time) as lastTime by dest SourceImage TargetImage GrantedAccess CallTrace 
+  | eval CallTrace=split(CallTrace, "|")
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)` 
   | `windows_process_injection_into_notepad_filter`'
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the process name, parent process, and command-line executions from your
@@ -26,7 +27,7 @@ how_to_implement: To successfully implement this search, you need to be ingestin
   Sysmon TA.
 known_false_positives: False positives may be present based on SourceImage paths.
   If removing the paths is important, realize svchost and many native binaries inject
-  into notepad consistently. Restrict or tune as needed.
+  into processes consistently. Restrict or tune as needed.
 references:
 - https://dominicbreuker.com/post/learning_sliver_c2_08_implant_basics/
 - https://www.cybereason.com/blog/sliver-c2-leveraged-by-many-threat-actors


### PR DESCRIPTION
### Details

Increase detection coverage through inclusion of additional target processes. Detection renamed to `Windows Process Injection into Commonly Abused Process` as a result of this change.

This change increased the efficacy of the detection by 2x when testing with a BAS tool.

Additionally, split `CallTrace` values to increase readability. This preserves the order.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.
