### PR TITLE
Updating to manual test

### DIFF
--- a/detections/endpoint/windows_sql_server_critical_procedures_enabled.yml
+++ b/detections/endpoint/windows_sql_server_critical_procedures_enabled.yml
@@ -71,6 +71,7 @@ tags:
   - Splunk Enterprise Security
   - Splunk Cloud
   security_domain: endpoint
+  manual_test: The risk message is dynamically generated in the SPL and it needs to be manually tested for integration testing. 
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/endpoint/windows_sql_server_startup_procedure.yml
+++ b/detections/endpoint/windows_sql_server_startup_procedure.yml
@@ -60,6 +60,7 @@ tags:
   - Splunk Enterprise Security
   - Splunk Cloud
   security_domain: endpoint
+  manual_test: The risk message is dynamically generated in the SPL and it needs to be manually tested for integration testing. 
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/endpoint/windows_sql_server_xp_cmdshell_config_change.yml
+++ b/detections/endpoint/windows_sql_server_xp_cmdshell_config_change.yml
@@ -72,6 +72,7 @@ tags:
     - Splunk Enterprise Security
     - Splunk Cloud
     security_domain: endpoint
+    manual_test: The risk message is dynamically generated in the SPL and it needs to be manually tested for integration testing. 
 tests:
   - name: True Positive Test
     attack_data:


### PR DESCRIPTION
The risk message is dynamically generated in the SPL and it needs to be manually tested for integration testing.