### PR TITLE
Deprecation CI update

### DIFF
--- a/.github/workflows/appinspect.yml
+++ b/.github/workflows/appinspect.yml
@@ -34,7 +34,7 @@ jobs:
           APPINSPECTPASSWORD: "${{ secrets.APPINSPECTPASSWORD }}"
         run: |
           echo $APPINSPECTUSERNAME
-          contentctl inspect --splunk-api-username "$APPINSPECTUSERNAME" --splunk-api-password "$APPINSPECTPASSWORD" --enrichments --enable-metadata-validation --suppress-missing-content-exceptions
+          contentctl inspect --splunk-api-username "$APPINSPECTUSERNAME" --splunk-api-password "$APPINSPECTPASSWORD" --enrichments --enable-metadata-validation --suppress-missing-content-exceptions --enforce-deprecation-mapping-requirement
           echo "done appinspect"
           mkdir -p artifacts/app_inspect_report
           cp -r dist/*.html artifacts/app_inspect_report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       
       - name: Running build with enrichments
         run: |
-          contentctl build --enrichments
+          contentctl build --enrichments --enforce_deprecation_mapping_requirement
           mkdir artifacts
           mv dist/DA-ESS-ContentUpdate-latest.tar.gz artifacts/
 

--- a/baselines/previously_seen_aws_cross_account_activity___initial.yml
+++ b/baselines/previously_seen_aws_cross_account_activity___initial.yml
@@ -4,7 +4,7 @@ version: 1
 date: '2020-08-15'
 author: Rico Valdez, Splunk
 type: Baseline
-status: removed
+status: production
 description: This search looks for **AssumeRole** events where the requesting account
   differs from the requested account, then writes these relationships to a lookup
   file.
@@ -24,7 +24,7 @@ known_false_positives: none
 references: []
 tags:
   analytic_story:
-  - Suspicious Cloud Authentication Activities
+  - AWS Cross Account Activity
   detections:
   - AWS Cross Account Activity From Previously Unseen Account
   product:

--- a/baselines/previously_seen_aws_cross_account_activity___update.yml
+++ b/baselines/previously_seen_aws_cross_account_activity___update.yml
@@ -4,7 +4,7 @@ version: 1
 date: '2020-08-15'
 author: Rico Valdez, Splunk
 type: Baseline
-status: removed
+status: production
 description: This search looks for **AssumeRole** events where the requesting account
   differs from the requested account, then writes these relationships to a lookup
   file.
@@ -24,7 +24,7 @@ known_false_positives: none
 references: []
 tags:
   analytic_story:
-  - Suspicious Cloud Authentication Activities
+  - AWS Cross Account Activity
   detections:
   - AWS Cross Account Activity From Previously Unseen Account
   product:

--- a/detections/cloud/aws_cross_account_activity_from_previously_unseen_account.yml
+++ b/detections/cloud/aws_cross_account_activity_from_previously_unseen_account.yml
@@ -1,6 +1,6 @@
 name: AWS Cross Account Activity From Previously Unseen Account
 id: 21193641-cb96-4a2c-a707-d9b9a7f7792b
-version: 5
+version: 6  
 date: '2024-11-14'
 author: Rico Valdez, Splunk
 status: production

--- a/detections/cloud/aws_cross_account_activity_from_previously_unseen_account.yml
+++ b/detections/cloud/aws_cross_account_activity_from_previously_unseen_account.yml
@@ -3,7 +3,7 @@ id: 21193641-cb96-4a2c-a707-d9b9a7f7792b
 version: 5
 date: '2024-11-14'
 author: Rico Valdez, Splunk
-status: removed
+status: production
 type: Anomaly
 description: The following analytic identifies AssumeRole events where an IAM role
   in a different AWS account is accessed for the first time. It detects this activity
@@ -36,6 +36,20 @@ known_false_positives: Using multiple AWS accounts and roles is perfectly valid 
   It's suspicious when an account requests privileges of an account it hasn't before.
   You should validate with the account owner that this is a legitimate request.
 references: []
+drilldown_searches:
+- name: View the detection results for - "$user$"
+  search: '%original_detection_search% | search  user = "$user$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
 rba:
   message: AWS account $requestingAccountId$ is trying to access resource from some
     other account $requestedAccountId$, for the first time.
@@ -46,7 +60,7 @@ rba:
   threat_objects: []
 tags:
   analytic_story:
-  - Suspicious Cloud Authentication Activities
+  - AWS Cross Account Activity
   asset_type: AWS Instance
   product:
   - Splunk Enterprise

--- a/removed/deprecation_mapping.YML
+++ b/removed/deprecation_mapping.YML
@@ -53,9 +53,6 @@ detections:
     reason: Detection deprecated as it no longer effectively identifies the intended malicious activity
     replacement_content:
     - Windows Suspicious Process File Path
-  - content: AWS Cross Account Activity From Previously Unseen Account
-    removed_in_version: 5.4.0
-    reason: Detection deprecated as it no longer effectively identifies the intended malicious activity
   - content: aws detect attach to role policy
     removed_in_version: 5.4.0
     reason: Detection deprecated as it no longer effectively identifies the intended malicious activity
@@ -760,12 +757,6 @@ detections:
     removed_in_version: 5.2.0
     reason: Detection deprecated as it no longer effectively identifies the intended malicious activity
 baselines:
-  - content: Previously Seen AWS Cross Account Activity - Initial
-    removed_in_version: 5.4.0
-    reason: 'All detection(s) which leverage this baseline have been deprecated. As such, this baseline has been deprecated as well.'
-  - content: Previously Seen AWS Cross Account Activity - Update
-    removed_in_version: 5.4.0
-    reason: 'All detection(s) which leverage this baseline have been deprecated. As such, this baseline has been deprecated as well.'
   - content: Add Prohibited Processes to Enterprise Security
     removed_in_version: 5.2.0
     reason: 'All detection(s) which leverage this baseline have been deprecated. As such, this baseline has been deprecated as well.'


### PR DESCRIPTION
- update CI for `--enforce_deprecation_mapping_requirement` during build to create an updated deprecated_info.csv

- move an incorrectly updated removed back to production 
