### PR TITLE
Deprecate CLI updates

### DIFF
--- a/.github/workflows/appinspect.yml
+++ b/.github/workflows/appinspect.yml
@@ -34,7 +34,7 @@ jobs:
           APPINSPECTPASSWORD: "${{ secrets.APPINSPECTPASSWORD }}"
         run: |
           echo $APPINSPECTUSERNAME
-          contentctl inspect --splunk-api-username "$APPINSPECTUSERNAME" --splunk-api-password "$APPINSPECTPASSWORD" --enrichments --enable-metadata-validation --suppress-missing-content-exceptions
+          contentctl inspect --splunk-api-username "$APPINSPECTUSERNAME" --splunk-api-password "$APPINSPECTPASSWORD" --enrichments --enable-metadata-validation --suppress-missing-content-exceptions --enforce-deprecation-mapping-requirement
           echo "done appinspect"
           mkdir -p artifacts/app_inspect_report
           cp -r dist/*.html artifacts/app_inspect_report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       
       - name: Running build with enrichments
         run: |
-          contentctl build --enrichments
+          contentctl build --enrichments --enforce_deprecation_mapping_requirement
           mkdir artifacts
           mv dist/DA-ESS-ContentUpdate-latest.tar.gz artifacts/
 

--- a/removed/baselines/previously_seen_aws_cross_account_activity.yml
+++ b/removed/baselines/previously_seen_aws_cross_account_activity.yml
@@ -1,10 +1,10 @@
 name: Previously Seen AWS Cross Account Activity
 id: 1cc22b09-c867-416e-a511-cb36ac44aee2
-version: 1
-date: '2018-06-04'
+version: 2
+date: '2025-04-18'
 author: David Dorsey, Splunk
 type: Baseline
-status: production
+status: removed
 description: This search looks for **AssumeRole** events where the requesting account
   differs from the requested account, then writes these relationships to a lookup
   file.

--- a/removed/deprecation_mapping.YML
+++ b/removed/deprecation_mapping.YML
@@ -760,6 +760,9 @@ detections:
     removed_in_version: 5.2.0
     reason: Detection deprecated as it no longer effectively identifies the intended malicious activity
 baselines:
+  - content: Previously Seen AWS Cross Account Activity
+    removed_in_version: 5.4.0
+    reason: 'All detection(s) which leverage this baseline have been deprecated. As such, this baseline has been deprecated as well.'
   - content: Previously Seen AWS Cross Account Activity - Initial
     removed_in_version: 5.4.0
     reason: 'All detection(s) which leverage this baseline have been deprecated. As such, this baseline has been deprecated as well.'

--- a/removed/deprecation_mapping.YML
+++ b/removed/deprecation_mapping.YML
@@ -967,6 +967,9 @@ stories:
     reason: Analytic Story has been replaced by a new analytic story with a more specific name
     replacement_content:
     - Salt Typhoon
+  - content: AWS Cross Account Activity
+    removed_in_version: 5.4.0
+    reason: All associated detections with this story have been deprecated
   - content: AWS Cryptomining
     removed_in_version: 5.2.0
     reason: Analytic Story deprecated as it no longer effectively identifies the intended malicious activity

--- a/removed/stories/aws_cross_account_activity.yml
+++ b/removed/stories/aws_cross_account_activity.yml
@@ -1,9 +1,9 @@
 name: AWS Cross Account Activity
 id: 2f2f610a-d64d-48c2-b57c-967a2b49ab5a
-version: 1
-date: '2018-06-04'
+version: 2
+date: '2025-04-18'
 author: David Dorsey, Splunk
-status: production
+status: removed
 description: Track when a user assumes an IAM role in another AWS account to obtain
   cross-account access to services and resources in that account. Accessing new roles
   could be an indication of malicious activity.


### PR DESCRIPTION
- updated CLI for deprecation enforcement
- deprecate AWS Cross Account Activity story as all asssociated detections have been deprecated