### PR TITLE
Remove duplicate filter macro

### DIFF
--- a/detections/endpoint/windows_adfind_exe.yml
+++ b/detections/endpoint/windows_adfind_exe.yml
@@ -1,7 +1,7 @@
 name: Windows AdFind Exe
 id: bd3b0187-189b-46c0-be45-f52da2bae67f
-version: 8
-date: '2024-11-13'
+version: 9
+date: '2025-04-24'
 author: Jose Hernandez, Bhavin Patel, Splunk
 status: production
 type: TTP

--- a/detections/endpoint/windows_adfind_exe.yml
+++ b/detections/endpoint/windows_adfind_exe.yml
@@ -5,7 +5,8 @@ date: '2024-11-13'
 author: Jose Hernandez, Bhavin Patel, Splunk
 status: production
 type: TTP
-description: The following analytic identifies the execution of `adfind.exe` with
+description:
+  The following analytic identifies the execution of `adfind.exe` with
   specific command-line arguments related to Active Directory queries. It leverages
   data from Endpoint Detection and Response (EDR) agents, focusing on process names,
   command-line arguments, and parent processes. This activity is significant because
@@ -14,10 +15,11 @@ description: The following analytic identifies the execution of `adfind.exe` wit
   allow attackers to map the AD environment, facilitating further attacks such as
   privilege escalation or lateral movement.
 data_source:
-- Sysmon EventID 1
-- Windows Event Log Security 4688
-- CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  - Sysmon EventID 1
+  - Windows Event Log Security 4688
+  - CrowdStrike ProcessRollup2
+search:
+  '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where ((Processes.process="* -f *"
   OR Processes.process="* -b *") AND (Processes.process=*objectcategory* OR Processes.process="*-gcb
   *" OR Processes.process="* -sc *" )) OR ((Processes.process="*trustdmp*" OR Processes.process="*dclist*"))
@@ -27,8 +29,9 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
   Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `windows_adfind_exe_filter`| `windows_adfind_exe_filter`'
-how_to_implement: The detection is based on data that originates from Endpoint Detection
+  | `windows_adfind_exe_filter`'
+how_to_implement:
+  The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
   you must ingest logs that contain the process GUID, process name, and parent process.
@@ -37,61 +40,64 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: ADfind is a command-line tool for AD administration and management
+known_false_positives:
+  ADfind is a command-line tool for AD administration and management
   that is seen to be leveraged by various adversaries. Filter out legitimate administrator
   usage using the filter macro.
 references:
-- https://www.volexity.com/blog/2020/12/14/dark-halo-leverages-solarwinds-compromise-to-breach-organizations/
-- https://www.mandiant.com/resources/a-nasty-trick-from-credential-theft-malware-to-business-disruption
-- https://www.joeware.net/freetools/tools/adfind/index.htm
-- https://thedfirreport.com/2023/05/22/icedid-macro-ends-in-nokoyawa-ransomware/
+  - https://www.volexity.com/blog/2020/12/14/dark-halo-leverages-solarwinds-compromise-to-breach-organizations/
+  - https://www.mandiant.com/resources/a-nasty-trick-from-credential-theft-malware-to-business-disruption
+  - https://www.joeware.net/freetools/tools/adfind/index.htm
+  - https://thedfirreport.com/2023/05/22/icedid-macro-ends-in-nokoyawa-ransomware/
 drilldown_searches:
-- name: View the detection results for - "$user$"
-  search: '%original_detection_search% | search  user = "$user$"'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$user$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$")
-    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
-    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
-    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
-    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
-    | `security_content_ctime(lastTime)`'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
+  - name: View the detection results for - "$user$"
+    search: '%original_detection_search% | search  user = "$user$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$user$"
+    search:
+      '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$")
+      starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+      values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+      as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+      as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+      | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
 rba:
-  message: Windows AdFind Exe detected with command-line arguments associated with
+  message:
+    Windows AdFind Exe detected with command-line arguments associated with
     Active Directory queries on machine - [dest]
   risk_objects:
-  - field: user
-    type: user
-    score: 25
+    - field: user
+      type: user
+      score: 25
   threat_objects: []
 tags:
   analytic_story:
-  - Domain Trust Discovery
-  - IcedID
-  - NOBELIUM Group
-  - Graceful Wipe Out Attack
-  - BlackSuit Ransomware
+    - Domain Trust Discovery
+    - IcedID
+    - NOBELIUM Group
+    - Graceful Wipe Out Attack
+    - BlackSuit Ransomware
   asset_type: Endpoint
   atomic_guid:
-  - 736b4f53-f400-4c22-855d-1a6b5a551600
-  - b95fd967-4e62-4109-b48d-265edfd28c3a
-  - e1ec8d20-509a-4b9a-b820-06c9b2da8eb7
-  - 5e2938fb-f919-47b6-8b29-2f6a1f718e99
-  - abf00f6c-9983-4d9a-afbc-6b1c6c6448e1
-  - 51a98f96-0269-4e09-a10f-e307779a8b05
+    - 736b4f53-f400-4c22-855d-1a6b5a551600
+    - b95fd967-4e62-4109-b48d-265edfd28c3a
+    - e1ec8d20-509a-4b9a-b820-06c9b2da8eb7
+    - 5e2938fb-f919-47b6-8b29-2f6a1f718e99
+    - abf00f6c-9983-4d9a-afbc-6b1c6c6448e1
+    - 51a98f96-0269-4e09-a10f-e307779a8b05
   mitre_attack_id:
-  - T1018
+    - T1018
   product:
-  - Splunk Enterprise
-  - Splunk Enterprise Security
-  - Splunk Cloud
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
   security_domain: endpoint
 tests:
-- name: True Positive Test
-  attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1018/atomic_red_team/windows-sysmon.log
-    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    sourcetype: XmlWinEventLog
+  - name: True Positive Test
+    attack_data:
+      - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1018/atomic_red_team/windows-sysmon.log
+        source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+        sourcetype: XmlWinEventLog


### PR DESCRIPTION
### Details

[Initial Report](https://splunkcommunity.slack.com/archives/C78NT6CQ7/p1745508615610199)

"ESCU - Windows AdFind Exe - Rule" has a duplicate filter macro in the search. 


### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://docs.splunk.com/Documentation/SplunkCloud/8.2.2203/Admin/PrivateApps#Manage_lookups_in_Splunk_Cloud_Platform) but the short version is that any changes to lookup files need to bump the the date and version in the associated YAML file.