### PR TITLE
Removing duplicate creation of user

### DIFF
--- a/detections/endpoint/first_time_seen_child_process_of_zoom.yml
+++ b/detections/endpoint/first_time_seen_child_process_of_zoom.yml
@@ -26,7 +26,7 @@ search: '| tstats `security_content_summariesonly` min(_time) as firstTime max(_
   as process_exec values(Processes.process_guid) as process_guid values(Processes.process_hash)
   as process_hash values(Processes.process_integrity_level) as process_integrity_level
   values(Processes.process_name) as process_name values(Processes.process_path) as
-  process_path values(Processes.user) as user  values(Processes.user_id) as user_id
+  process_path  values(Processes.user_id) as user_id
   values(Processes.vendor_product) as vendor_product from datamodel=Endpoint.Processes
   where (Processes.parent_process_name=zoom.exe OR Processes.parent_process_name=zoom.us)
   by Processes.process_id Processes.dest | `drop_dm_object_name(Processes)` | lookup

--- a/detections/endpoint/first_time_seen_child_process_of_zoom.yml
+++ b/detections/endpoint/first_time_seen_child_process_of_zoom.yml
@@ -1,7 +1,7 @@
 name: First Time Seen Child Process of Zoom
 id: e91bd102-d630-4e76-ab73-7e3ba22c5961
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-05-15'
 author: David Dorsey, Splunk
 status: experimental
 type: Anomaly


### PR DESCRIPTION
### Details

Per feedback received via email, removing this duplicate field

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://docs.splunk.com/Documentation/SplunkCloud/8.2.2203/Admin/PrivateApps#Manage_lookups_in_Splunk_Cloud_Platform) but the short version is that any changes to lookup files need to bump the the date and version in the associated YAML file.