### PR TITLE
switches pull_request_target

### DIFF
--- a/.github/workflows/appinspect.yml
+++ b/.github/workflows/appinspect.yml
@@ -2,6 +2,9 @@ name: appinspect
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - develop
 jobs:
   appinspect:
     runs-on: ubuntu-latest

--- a/.github/workflows/appinspect.yml
+++ b/.github/workflows/appinspect.yml
@@ -1,6 +1,6 @@
 name: appinspect
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 jobs:
   appinspect:


### PR DESCRIPTION
to pull_request for appinspect.
We still allow the labeler to
be pull_request_target to
properly label incoming PRs.
