### PR TITLE
Update Network CIM Analytics With FTD Data

### DIFF
--- a/data_sources/cisco_secure_firewall_threat_defense_connection_event.yml
+++ b/data_sources/cisco_secure_firewall_threat_defense_connection_event.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall Threat Defense Connection Event
 id: 18878597-8f8a-4bca-a805-bfbe35e00032
-version: 1
-date: '2025-04-01'
+version: 2
+date: '2025-05-22'
 author: Nasreddine Bencherchali, Splunk
 description: Data source object for raw connection events from Cisco Secure Firewall
   Threat Defense
@@ -114,7 +114,6 @@ output_fields:
 - dest_port
 - transport
 - rule
-- url
 - action
 example_log: '{"EventType":"ConnectionEvent", "FirstPacketSecond":1743500734, "DeviceUUID":"11bc8e94-f604-11ef-bcfe-eeb1de9c8a63",
   "InstanceID":1, "ConnectionID":259, "AC_RuleAction":"Block", "InitiatorIP":"172.16.3.110",

--- a/detections/network/cisco_secure_firewall___remote_access_software_usage_traffic.yml
+++ b/detections/network/cisco_secure_firewall___remote_access_software_usage_traffic.yml
@@ -75,6 +75,7 @@ tags:
   - Command And Control
   - Ransomware
   - Remote Monitoring and Management Software
+  - Cisco Secure Firewall Threat Defense Analytics
   asset_type: Network
   mitre_attack_id:
   - T1219

--- a/detections/network/cisco_secure_firewall___remote_access_software_usage_traffic.yml
+++ b/detections/network/cisco_secure_firewall___remote_access_software_usage_traffic.yml
@@ -1,0 +1,95 @@
+name: Cisco Secure Firewall - Remote Access Software Usage Traffic
+id: ac54d39e-a75d-4f42-971d-006db3a0423a
+version: 1
+date: '2025-05-02'
+author: Nasreddine Bencherchali, Splunk
+status: production
+type: Anomaly
+description: |
+  The following analytic detects network traffic associated with known remote access software applications
+  that are covered by Cisco Secure Firewall Application Detectors, such as AnyDesk, GoToMyPC, LogMeIn, and TeamViewer.
+  It leverages Cisco Secure Firewall Threat Defense Connection Event.
+  This activity is significant because adversaries often use remote access tools to maintain unauthorized access to compromised environments.
+  If confirmed malicious, this activity could allow attackers to control systems remotely, exfiltrate
+  data, or deploy additional malware, posing a severe threat to the organization's security.
+data_source:
+- Cisco Secure Firewall Threat Defense Connection Event
+search: |
+  `cisco_secure_firewall` EventType=ConnectionEvent
+  | stats min(_time) as firstTime max(_time) as lastTime 
+        values(dest_port) as dest_port
+        values(dest) as dest
+        values(transport) as transport
+        values(url) as url
+        values(rule) as rule
+        count by src_ip ClientApplication action
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | lookup cisco_secure_firewall_appid_remote_mgmt_and_desktop_tools appName AS ClientApplication OUTPUT category, appDescription as Description
+  | search category IN ("remote administration", "remote desktop control")
+  | `remote_access_software_usage_exceptions`
+  | `cisco_secure_firewall___remote_access_software_usage_traffic_filter`
+how_to_implement: |
+  This search requires Cisco Secure Firewall Threat Defense Logs, which
+  includes the ConnectionEvent EventType. This search uses an input macro named `cisco_secure_firewall`.
+  We strongly recommend that you specify your environment-specific configurations
+  (index, source, sourcetype, etc.) for Cisco Secure Firewall Threat Defense logs. Replace the macro definition
+  with configurations for your Splunk environment. The search also uses a post-filter
+  macro designed to filter out known false positives.
+  The logs are to be ingested using the Splunk Add-on for Cisco Security Cloud (https://splunkbase.splunk.com/app/7404).
+  The access policy must also enable logging.
+  The "exceptions" macro leverages both an Assets and Identities lookup, as well as a KVStore collection called "remote_software_exceptions"
+  that lets you track and maintain device- based exceptions for this set of detections.
+known_false_positives: |
+  It is possible that legitimate remote access software is used within the environment. Known false positives can be added to the remote_access_software_usage_exception.csv lookup to globally suppress these situations across all remote access content
+references:
+- https://attack.mitre.org/techniques/T1219/
+- https://thedfirreport.com/2022/08/08/bumblebee-roasts-its-way-to-domain-admin/
+- https://thedfirreport.com/2022/11/28/emotet-strikes-again-lnk-file-leads-to-domain-wide-ransomware/
+drilldown_searches:
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Traffic to known remote access software [$ClientApplication$] was detected from $src$.
+  risk_objects:
+  - field: src
+    type: system
+    score: 25
+  - field: user
+    type: user
+    score: 25
+  threat_objects:
+  - field: ClientApplication
+    type: signature
+tags:
+  analytic_story:
+  - Insider Threat
+  - Command And Control
+  - Ransomware
+  - Remote Monitoring and Management Software
+  asset_type: Network
+  mitre_attack_id:
+  - T1219
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: network
+  manual_test: This detection uses A&I lookups from Enterprise Security.
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/connection_event/connection_events.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/cisco_secure_firewall___remote_access_software_usage_traffic.yml
+++ b/detections/network/cisco_secure_firewall___remote_access_software_usage_traffic.yml
@@ -47,12 +47,12 @@ references:
 - https://thedfirreport.com/2022/08/08/bumblebee-roasts-its-way-to-domain-admin/
 - https://thedfirreport.com/2022/11/28/emotet-strikes-again-lnk-file-leads-to-domain-wide-ransomware/
 drilldown_searches:
-- name: View the detection results for - "$src$"
-  search: '%original_detection_search% | search  src = "$src$"'
+- name: View the detection results for - "$src_ip$"
+  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$")
+- name: View risk events for the last 7 days for - "$src_ip$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$")
     starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
     values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
     as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
@@ -61,13 +61,10 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Traffic to known remote access software [$ClientApplication$] was detected from $src$.
+  message: Traffic to known remote access software [$ClientApplication$] was detected from $src_ip$.
   risk_objects:
-  - field: src
+  - field: src_ip
     type: system
-    score: 25
-  - field: user
-    type: user
     score: 25
   threat_objects:
   - field: ClientApplication

--- a/detections/network/detect_outbound_ldap_traffic.yml
+++ b/detections/network/detect_outbound_ldap_traffic.yml
@@ -22,7 +22,7 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   by All_Traffic.action All_Traffic.app All_Traffic.bytes All_Traffic.bytes_in All_Traffic.bytes_out
   All_Traffic.dest All_Traffic.dest_ip All_Traffic.dest_port All_Traffic.dvc All_Traffic.protocol
   All_Traffic.protocol_version All_Traffic.src All_Traffic.src_ip All_Traffic.src_port
-  All_Traffic.transport All_Traffic.user All_Traffic.vendor_product |`drop_dm_object_name("All_Traffic")`
+  All_Traffic.transport All_Traffic.user All_Traffic.vendor_product All_Traffic.rule |`drop_dm_object_name("All_Traffic")`
   | where src_ip != dest_ip | `security_content_ctime(firstTime)`  | `security_content_ctime(lastTime)`
   |`detect_outbound_ldap_traffic_filter`'
 how_to_implement: In order to properly run this search, Splunk needs to ingest data

--- a/detections/network/detect_outbound_ldap_traffic.yml
+++ b/detections/network/detect_outbound_ldap_traffic.yml
@@ -37,6 +37,7 @@ references:
 tags:
   analytic_story:
   - Log4Shell CVE-2021-44228
+  - Cisco Secure Firewall Threat Defense Analytics
   asset_type: Endpoint
   cve:
   - CVE-2021-44228

--- a/detections/network/detect_outbound_ldap_traffic.yml
+++ b/detections/network/detect_outbound_ldap_traffic.yml
@@ -26,9 +26,9 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   | where src_ip != dest_ip | `security_content_ctime(firstTime)`  | `security_content_ctime(lastTime)`
   |`detect_outbound_ldap_traffic_filter`'
 how_to_implement: In order to properly run this search, Splunk needs to ingest data
-  from Next Generation Firewalls like Palo Alto Networks Firewalls or other network
-  control devices that mediate the traffic allowed into an environment. The search
-  requires the Network_Traffic data model to be populated.
+  from Next Generation Firewalls like, Cisco Secure Firewall Threat Defense, Palo Alto Networks Firewalls
+  or other network control devices that mediate the traffic allowed into an environment.
+  The search requires the Network_Traffic data model to be populated.
 known_false_positives: Unknown at this moment. Outbound LDAP traffic should not be
   allowed outbound through your perimeter firewall. Please check those servers to
   verify if the activity is legitimate.

--- a/detections/network/detect_outbound_ldap_traffic.yml
+++ b/detections/network/detect_outbound_ldap_traffic.yml
@@ -1,7 +1,7 @@
 name: Detect Outbound LDAP Traffic
 id: 5e06e262-d7cd-4216-b2f8-27b437e18458
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-05-22'
 author: Bhavin Patel, Johan Bjerke, Splunk
 status: production
 type: Hunting
@@ -14,6 +14,7 @@ description: The following analytic identifies outbound LDAP traffic to external
   network compromise.
 data_source:
 - Palo Alto Network Traffic
+- Cisco Secure Firewall Threat Defense Connection Event
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime values(All_Traffic.dest_ip) as dest_ip from datamodel=Network_Traffic.All_Traffic
   where All_Traffic.dest_port = 389 OR All_Traffic.dest_port = 636 AND NOT (All_Traffic.dest_ip
@@ -48,8 +49,13 @@ tags:
   - Splunk Cloud
   security_domain: network
 tests:
-- name: True Positive Test
+- name: Palo Alto True Positive Test
   attack_data:
   - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1059/log4shell_ldap_traffic/pantraffic.log
     sourcetype: pan:traffic
     source: pan:traffic
+- name: Cisco Secure Firewall True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/connection_event/connection_events.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/detect_outbound_smb_traffic.yml
+++ b/detections/network/detect_outbound_smb_traffic.yml
@@ -53,6 +53,7 @@ tags:
   - Hidden Cobra Malware
   - DHS Report TA18-074A
   - NOBELIUM Group
+  - Cisco Secure Firewall Threat Defense Analytics
   asset_type: Endpoint
   mitre_attack_id:
   - T1071.002

--- a/detections/network/detect_outbound_smb_traffic.yml
+++ b/detections/network/detect_outbound_smb_traffic.yml
@@ -1,7 +1,7 @@
 name: Detect Outbound SMB Traffic
 id: 1bed7774-304a-4e8f-9d72-d80e45ff492b
-version: 10
-date: '2025-05-02'
+version: 11
+date: '2025-05-22'
 author: Bhavin Patel, Stuart Hopkins, Patrick Bareiss
 status: experimental
 type: TTP
@@ -15,6 +15,7 @@ description: The following analytic detects outbound SMB (Server Message Block) 
   full system compromise.
 data_source:
 - Zeek Conn
+- Cisco Secure Firewall Threat Defense Connection Event
 search: '| tstats `security_content_summariesonly` earliest(_time) as start_time latest(_time)
   as end_time values(All_Traffic.action) as action values(All_Traffic.app) as app
   values(sourcetype) as sourcetype count from datamodel=Network_Traffic where (All_Traffic.action=allowed
@@ -61,8 +62,13 @@ tags:
   - Splunk Cloud
   security_domain: network
 tests:
-- name: True Positive Test
+- name: Zeek True Positive Test
   attack_data:
   - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1071.002/outbound_smb_traffic/zeek_conn.log
     sourcetype: bro:conn:json
     source: conn.log
+- name: Cisco Secure Firewall True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/connection_event/connection_events.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/detect_outbound_smb_traffic.yml
+++ b/detections/network/detect_outbound_smb_traffic.yml
@@ -28,8 +28,8 @@ search: '| tstats `security_content_summariesonly` earliest(_time) as start_time
   All_Traffic.transport All_Traffic.user All_Traffic.vendor_product All_Traffic.rule | `drop_dm_object_name("All_Traffic")`  |
   `security_content_ctime(start_time)`  | `security_content_ctime(end_time)`  | iplocation
   dest_ip | `detect_outbound_smb_traffic_filter`'
-how_to_implement: This search also requires you to be ingesting your network traffic
-  and populating the Network_Traffic data model
+how_to_implement: This search requires you to be ingesting your network traffic
+  and populating the Network_Traffic data model.
 known_false_positives: It is likely that the outbound Server Message Block (SMB) traffic
   is legitimate, if the company's internal networks are not well-defined in the Assets
   and Identity Framework. Categorize the internal CIDR blocks as `internal` in the

--- a/detections/network/detect_outbound_smb_traffic.yml
+++ b/detections/network/detect_outbound_smb_traffic.yml
@@ -23,9 +23,9 @@ search: '| tstats `security_content_summariesonly` earliest(_time) as start_time
   AND All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16") AND NOT
   All_Traffic.dest_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16","100.64.0.0/10")
   by All_Traffic.action All_Traffic.app All_Traffic.bytes All_Traffic.bytes_in All_Traffic.bytes_out
-  All_Traffic.dest  All_Traffic.dest_ip All_Traffic.dest_port All_Traffic.dvc All_Traffic.protocol
+  All_Traffic.dest All_Traffic.dest_ip All_Traffic.dest_port All_Traffic.dvc All_Traffic.protocol
   All_Traffic.protocol_version All_Traffic.src All_Traffic.src_ip All_Traffic.src_port
-  All_Traffic.transport All_Traffic.user All_Traffic.vendor_product | `drop_dm_object_name("All_Traffic")`  |
+  All_Traffic.transport All_Traffic.user All_Traffic.vendor_product All_Traffic.rule | `drop_dm_object_name("All_Traffic")`  |
   `security_content_ctime(start_time)`  | `security_content_ctime(end_time)`  | iplocation
   dest_ip | `detect_outbound_smb_traffic_filter`'
 how_to_implement: This search also requires you to be ingesting your network traffic

--- a/detections/network/internal_horizontal_port_scan.yml
+++ b/detections/network/internal_horizontal_port_scan.yml
@@ -18,7 +18,7 @@ search: '| tstats `security_content_summariesonly` values(All_Traffic.action) as
   values(All_Traffic.src_category) as src_category values(All_Traffic.dest_zone) as
   dest_zone values(All_Traffic.src_zone) as src_zone values(All_Traffic.src_port)
   as src_port count from datamodel=Network_Traffic where All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16")
-  by All_Traffic.src_ip All_Traffic.dest_port All_Traffic.dest_ip span=1s _time All_Traffic.transport All_Traffic.rule
+  by All_Traffic.src_ip All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.transport All_Traffic.rule span=1s _time
   | `drop_dm_object_name("All_Traffic")` | eval gtime=_time | bin span=1h gtime |
   stats min(_time) as _time values(action) as action dc(dest_ip) as totalDestIPCount
   values(src_category) as src_category values(dest_zone) as dest_zone values(src_zone)

--- a/detections/network/internal_horizontal_port_scan.yml
+++ b/detections/network/internal_horizontal_port_scan.yml
@@ -1,12 +1,13 @@
 name: Internal Horizontal Port Scan
 id: 1ff9eb9a-7d72-4993-a55e-59a839e607f1
-version: 6
-date: '2025-05-02'
+version: 7
+date: '2025-05-22'
 author: Dean Luxton
 status: production
 type: TTP
 data_source:
 - AWS CloudWatchLogs VPCflow
+- Cisco Secure Firewall Threat Defense Connection Event
 description: This analytic identifies instances where an internal host has attempted
   to communicate with 250 or more destination IP addresses using the same port and
   protocol. Horizontal port scans from internal hosts can indicate reconnaissance
@@ -65,8 +66,13 @@ tags:
   - Splunk Cloud
   security_domain: network
 tests:
-- name: True Positive Test
+- name: AWS CloudWatch True Positive Test
   attack_data:
   - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1046/nmap/horizontal.log
     source: aws:cloudwatchlogs:vpcflow
     sourcetype: aws:cloudwatchlogs:vpcflow
+- name: Cisco Secure Firewall True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/connection_event/connection_events.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/internal_horizontal_port_scan.yml
+++ b/detections/network/internal_horizontal_port_scan.yml
@@ -50,7 +50,7 @@ rba:
   message: $src_ip$ has scanned for ports $dest_ports$ across $totalDestIPCount$ destination
     IPs
   risk_objects:
-  - field: dest_port
+  - field: dest_ports
     type: system
     score: 64
   threat_objects:

--- a/detections/network/internal_horizontal_port_scan.yml
+++ b/detections/network/internal_horizontal_port_scan.yml
@@ -50,13 +50,16 @@ rba:
   message: $src_ip$ has scanned for ports $dest_ports$ across $totalDestIPCount$ destination
     IPs
   risk_objects:
-  - field: src_ip
+  - field: dest_port
     type: system
     score: 64
-  threat_objects: []
+  threat_objects:
+  - field: src_ip
+    type: ip_address
 tags:
   analytic_story:
   - Network Discovery
+  - Cisco Secure Firewall Threat Defense Analytics
   asset_type: Endpoint
   mitre_attack_id:
   - T1046

--- a/detections/network/internal_horizontal_port_scan.yml
+++ b/detections/network/internal_horizontal_port_scan.yml
@@ -18,7 +18,7 @@ search: '| tstats `security_content_summariesonly` values(All_Traffic.action) as
   values(All_Traffic.src_category) as src_category values(All_Traffic.dest_zone) as
   dest_zone values(All_Traffic.src_zone) as src_zone values(All_Traffic.src_port)
   as src_port count from datamodel=Network_Traffic where All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16")
-  by All_Traffic.src_ip All_Traffic.dest_port All_Traffic.dest_ip span=1s _time All_Traffic.transport
+  by All_Traffic.src_ip All_Traffic.dest_port All_Traffic.dest_ip span=1s _time All_Traffic.transport All_Traffic.rule
   | `drop_dm_object_name("All_Traffic")` | eval gtime=_time | bin span=1h gtime |
   stats min(_time) as _time values(action) as action dc(dest_ip) as totalDestIPCount
   values(src_category) as src_category values(dest_zone) as dest_zone values(src_zone)

--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -1,12 +1,13 @@
 name: Internal Horizontal Port Scan NMAP Top 20
 id: 3141a041-4f57-4277-9faa-9305ca1f8e5b
-version: 4
-date: '2025-05-02'
+version: 5
+date: '2025-05-22'
 author: Dean Luxton
 status: production
 type: TTP
 data_source:
 - AWS CloudWatchLogs VPCflow
+- Cisco Secure Firewall Threat Defense Connection Event
 description: This analytic identifies instances where an internal host has attempted
   to communicate with 250 or more destination IP addresses using on of the NMAP top
   20 ports. Horizontal port scans from internal hosts can indicate reconnaissance
@@ -67,8 +68,13 @@ tags:
   - Splunk Cloud
   security_domain: network
 tests:
-- name: True Positive Test
+- name: AWS CloudWatch True Positive Test
   attack_data:
   - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1046/nmap/horizontal.log
     source: aws:cloudwatchlogs:vpcflow
     sourcetype: aws:cloudwatchlogs:vpcflow
+- name: Cisco Secure Firewall True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/connection_event/connection_events.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -52,13 +52,16 @@ rba:
   message: $src_ip$ has scanned for ports $dest_ports$ across $totalDestIPCount$ destination
     IPs
   risk_objects:
-  - field: src_ip
+  - field: dest_zone
     type: system
     score: 72
-  threat_objects: []
+  threat_objects:
+  - field: src_ip
+    type: ip_address
 tags:
   analytic_story:
   - Network Discovery
+  - Cisco Secure Firewall Threat Defense Analytics
   asset_type: Endpoint
   mitre_attack_id:
   - T1046

--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -20,7 +20,7 @@ search: '| tstats `security_content_summariesonly` values(All_Traffic.action) as
   as src_port count from datamodel=Network_Traffic where All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16")
   AND All_Traffic.dest_port IN (21, 22, 23, 25, 53, 80, 110, 111, 135, 139, 143, 443,
   445, 993, 995, 1723, 3306, 3389, 5900, 8080) by All_Traffic.src_ip All_Traffic.src
-  All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.dest span=1s _time All_Traffic.transport  |
+  All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.dest span=1s _time All_Traffic.transport All_Traffic.rule |
   `drop_dm_object_name("All_Traffic")`  | eval gtime=_time  | bin span=1h gtime  |
   stats min(_time) as _time values(action) as action dc(dest_ip) as totalDestIPCount
   values(src_category) as src_category values(dest_zone)  as dest_zone values(src_zone)

--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -23,14 +23,14 @@ search: '| tstats `security_content_summariesonly` values(All_Traffic.action) as
   All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.dest All_Traffic.transport All_Traffic.rule span=1s _time |
   `drop_dm_object_name("All_Traffic")`  | eval gtime=_time  | bin span=1h gtime  |
   stats min(_time) as _time values(action) as action dc(dest_ip) as totalDestIPCount
-  values(src_category) as src_category values(dest_zone)  as dest_zone values(src_zone)
+  values(src_category) as src_category values(dest_zone) as dest_zone values(src_zone)
   as src_zone by src_ip dest_port gtime transport  | where totalDestIPCount>=250  |
   eval dest_port=transport + "/" + dest_port  | stats min(_time) as _time values(action)
   as action sum(totalDestIPCount) as totalDestIPCount values(src_category) as src_category
   values(dest_port) as dest_ports values(dest_zone) as dest_zone values(src_zone)
   as src_zone by src_ip gtime  | fields - gtime  | `internal_horizontal_port_scan_nmap_top_20_filter`'
 how_to_implement: To properly run this search, Splunk needs to ingest data from networking
-  telemetry sources such as firewalls, NetFlow, or host-based networking events. Ensure
+  telemetry sources such as firewalls like Cisco Secure Firewall, NetFlow, or host-based networking events. Ensure
   that the Network_Traffic data model is populated to enable this search effectively.
 known_false_positives: Unknown
 references: []

--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -52,7 +52,7 @@ rba:
   message: $src_ip$ has scanned for ports $dest_ports$ across $totalDestIPCount$ destination
     IPs
   risk_objects:
-  - field: dest_zone
+  - field: dest_ports
     type: system
     score: 72
   threat_objects:

--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -20,7 +20,7 @@ search: '| tstats `security_content_summariesonly` values(All_Traffic.action) as
   as src_port count from datamodel=Network_Traffic where All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16")
   AND All_Traffic.dest_port IN (21, 22, 23, 25, 53, 80, 110, 111, 135, 139, 143, 443,
   445, 993, 995, 1723, 3306, 3389, 5900, 8080) by All_Traffic.src_ip All_Traffic.src
-  All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.dest span=1s _time All_Traffic.transport All_Traffic.rule |
+  All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.dest All_Traffic.transport All_Traffic.rule span=1s _time |
   `drop_dm_object_name("All_Traffic")`  | eval gtime=_time  | bin span=1h gtime  |
   stats min(_time) as _time values(action) as action dc(dest_ip) as totalDestIPCount
   values(src_category) as src_category values(dest_zone)  as dest_zone values(src_zone)

--- a/detections/network/internal_vertical_port_scan.yml
+++ b/detections/network/internal_vertical_port_scan.yml
@@ -50,13 +50,16 @@ drilldown_searches:
 rba:
   message: $src_ip$ has scanned $totalDestPortCount$ ports on $dest_ip$
   risk_objects:
-  - field: src_ip
+  - field: dest_ip
     type: system
-    score: 64
-  threat_objects: []
+    score: 60
+  threat_objects:
+  - field: src_ip
+    type: ip_address
 tags:
   analytic_story:
   - Network Discovery
+  - Cisco Secure Firewall Threat Defense Analytics
   asset_type: Endpoint
   mitre_attack_id:
   - T1046

--- a/detections/network/internal_vertical_port_scan.yml
+++ b/detections/network/internal_vertical_port_scan.yml
@@ -18,7 +18,7 @@ search: '| tstats `security_content_summariesonly` values(All_Traffic.action) as
   values(All_Traffic.src_category) as src_category values(All_Traffic.dest_zone) as
   dest_zone values(All_Traffic.src_zone) as src_zone values(All_Traffic.src_port)
   as src_port count from datamodel=Network_Traffic where All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16")
-  by All_Traffic.src_ip All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.transport
+  by All_Traffic.src_ip All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.transport All_Traffic.rule
   span=1s _time | `drop_dm_object_name("All_Traffic")` | eval gtime=_time | bin span=1h
   gtime | stats min(_time) as _time values(action) as action dc(eval(if(dest_port<1024
   AND transport="tcp",dest_port,null))) as privilegedDestTcpPortCount dc(eval(if(transport="tcp",dest_port,null)))

--- a/detections/network/internal_vertical_port_scan.yml
+++ b/detections/network/internal_vertical_port_scan.yml
@@ -1,12 +1,13 @@
 name: Internal Vertical Port Scan
 id: 40d2dc41-9bbf-421a-a34b-8611271a6770
-version: 5
-date: '2025-05-02'
+version: 6
+date: '2025-05-22'
 author: Dean Luxton
 status: production
 type: TTP
 data_source:
 - AWS CloudWatchLogs VPCflow
+- Cisco Secure Firewall Threat Defense Connection Event
 description: This analytic detects instances where an internal host attempts to communicate
   with over 500 ports on a single destination IP address. It includes filtering criteria
   to exclude applications performing scans over ephemeral port ranges, focusing on
@@ -65,8 +66,13 @@ tags:
   - Splunk Cloud
   security_domain: network
 tests:
-- name: True Positive Test
+- name: AWS CloudWatch True Positive Test
   attack_data:
   - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1046/nmap/vertical.log
     source: aws:cloudwatchlogs:vpcflow
     sourcetype: aws:cloudwatchlogs:vpcflow
+- name: Cisco Secure Firewall True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/connection_event/connection_events.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/prohibited_network_traffic_allowed.yml
+++ b/detections/network/prohibited_network_traffic_allowed.yml
@@ -58,6 +58,7 @@ tags:
   - Prohibited Traffic Allowed or Protocol Mismatch
   - Ransomware
   - Command And Control
+  - Cisco Secure Firewall Threat Defense Analytics
   asset_type: Endpoint
   mitre_attack_id:
   - T1048

--- a/detections/network/prohibited_network_traffic_allowed.yml
+++ b/detections/network/prohibited_network_traffic_allowed.yml
@@ -1,7 +1,7 @@
 name: Prohibited Network Traffic Allowed
 id: ce5a0962-849f-4720-a678-753fe6674479
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-05-27'
 author: Rico Valdez, Splunk
 status: production
 type: TTP
@@ -15,10 +15,11 @@ description: The following analytic detects instances where network traffic, ide
   compromising the organization's security posture.
 data_source:
 - Zeek Conn
+- Cisco Secure Firewall Threat Defense Connection Event
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Network_Traffic where All_Traffic.action = allowed by
+  as lastTime from datamodel=Network_Traffic where All_Traffic.action IN ("allowed", "allow") by
   All_Traffic.src_ip All_Traffic.dest_ip All_Traffic.dest_port All_Traffic.action
-  All_Traffic.dvc All_Traffic.src_port All_Traffic.vendor_product | lookup update=true
+  All_Traffic.dvc All_Traffic.src_port All_Traffic.vendor_product  All_Traffic.rule | lookup update=true
   interesting_ports_lookup dest_port as All_Traffic.dest_port OUTPUT app is_prohibited
   note transport | search is_prohibited=true | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)` | `drop_dm_object_name("All_Traffic")` | `prohibited_network_traffic_allowed_filter`'
@@ -67,8 +68,13 @@ tags:
   security_domain: network
   manual_test: This detection uses builtin lookup from Enterprise Security.
 tests:
-- name: True Positive Test
+- name: Zeek Conn True Positive Test
   attack_data:
   - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1048/ftp_connection/zeek_conn.log
     sourcetype: bro:conn:json
     source: conn.log
+- name: Cisco Secure Firewall True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/connection_event/connection_events.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/protocol_or_port_mismatch.yml
+++ b/detections/network/protocol_or_port_mismatch.yml
@@ -24,8 +24,8 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   All_Traffic.dest_port All_Traffic.transport All_Traffic.action All_Traffic.rule |`security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
   | `drop_dm_object_name("All_Traffic")` | `protocol_or_port_mismatch_filter`'
 how_to_implement: Running this search properly requires a technology that can inspect
-  network traffic and identify common protocols. Technologies such as Bro and Palo
-  Alto Networks firewalls are two examples that will identify protocols via inspection,
+  network traffic and identify common protocols. Technologies such as Zeek, Cisco Secure Firewall or Palo
+  Alto Networks firewalls are examples that will identify protocols via inspection,
   and not just assume a specific protocol based on the transport protocol and ports.
 known_false_positives: Some false positive could occur with some applications that change their default communication port for an added layer of obscurity.
 references: []

--- a/detections/network/protocol_or_port_mismatch.yml
+++ b/detections/network/protocol_or_port_mismatch.yml
@@ -56,6 +56,7 @@ tags:
   analytic_story:
   - Prohibited Traffic Allowed or Protocol Mismatch
   - Command And Control
+  - Cisco Secure Firewall Threat Defense Analytics
   asset_type: Endpoint
   mitre_attack_id:
   - T1048.003

--- a/detections/network/protocol_or_port_mismatch.yml
+++ b/detections/network/protocol_or_port_mismatch.yml
@@ -46,10 +46,12 @@ drilldown_searches:
 rba:
   message: Port or Protocol Traffic Mismatch
   risk_objects:
-  - field: dest
+  - field: src_ip
     type: system
     score: 25
-  threat_objects: []
+  threat_objects:
+  - field: dest_ip
+    type: ip_address
 tags:
   analytic_story:
   - Prohibited Traffic Allowed or Protocol Mismatch

--- a/detections/network/protocol_or_port_mismatch.yml
+++ b/detections/network/protocol_or_port_mismatch.yml
@@ -21,7 +21,7 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   OR All_Traffic.dest_port=8080 OR All_Traffic.dest_port=8000)) OR (All_Traffic.app=ssl
   NOT (All_Traffic.dest_port=443 OR All_Traffic.dest_port=8443)) OR (All_Traffic.app=smtp
   NOT All_Traffic.dest_port=25) by All_Traffic.src_ip, All_Traffic.dest_ip, All_Traffic.app,
-  All_Traffic.dest_port All_Traffic.rule |`security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  All_Traffic.dest_port All_Traffic.transport All_Traffic.action All_Traffic.rule |`security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
   | `drop_dm_object_name("All_Traffic")` | `protocol_or_port_mismatch_filter`'
 how_to_implement: Running this search properly requires a technology that can inspect
   network traffic and identify common protocols. Technologies such as Bro and Palo

--- a/detections/network/protocol_or_port_mismatch.yml
+++ b/detections/network/protocol_or_port_mismatch.yml
@@ -1,9 +1,9 @@
 name: Protocol or Port Mismatch
 id: 54dc1265-2f74-4b6d-b30d-49eb506a31b3
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-05-27'
 author: Rico Valdez, Splunk
-status: experimental
+status: production
 type: Anomaly
 description: The following analytic identifies network traffic where the higher layer
   protocol does not match the expected port, such as non-HTTP traffic on TCP port
@@ -13,20 +13,21 @@ description: The following analytic identifies network traffic where the higher 
   malicious, this behavior could allow attackers to evade detection, maintain persistence,
   or exfiltrate data through commonly allowed ports, posing a significant threat to
   network security.
-data_source: []
+data_source:
+- Cisco Secure Firewall Threat Defense Connection Event
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Network_Traffic where (All_Traffic.app=dns NOT All_Traffic.dest_port=53)
   OR ((All_Traffic.app=web-browsing OR All_Traffic.app=http) NOT (All_Traffic.dest_port=80
   OR All_Traffic.dest_port=8080 OR All_Traffic.dest_port=8000)) OR (All_Traffic.app=ssl
   NOT (All_Traffic.dest_port=443 OR All_Traffic.dest_port=8443)) OR (All_Traffic.app=smtp
   NOT All_Traffic.dest_port=25) by All_Traffic.src_ip, All_Traffic.dest_ip, All_Traffic.app,
-  All_Traffic.dest_port |`security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  All_Traffic.dest_port All_Traffic.rule |`security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
   | `drop_dm_object_name("All_Traffic")` | `protocol_or_port_mismatch_filter`'
 how_to_implement: Running this search properly requires a technology that can inspect
   network traffic and identify common protocols. Technologies such as Bro and Palo
   Alto Networks firewalls are two examples that will identify protocols via inspection,
   and not just assume a specific protocol based on the transport protocol and ports.
-known_false_positives: None identified
+known_false_positives: Some false positive could occur with some applications that change their default communication port for an added layer of obscurity.
 references: []
 rba:
   message: Port or Protocol Traffic Mismatch
@@ -47,3 +48,9 @@ tags:
   - Splunk Enterprise Security
   - Splunk Cloud
   security_domain: network
+tests:
+- name: Cisco Secure Firewall True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/connection_event/connection_events.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/protocol_or_port_mismatch.yml
+++ b/detections/network/protocol_or_port_mismatch.yml
@@ -29,6 +29,20 @@ how_to_implement: Running this search properly requires a technology that can in
   and not just assume a specific protocol based on the transport protocol and ports.
 known_false_positives: Some false positive could occur with some applications that change their default communication port for an added layer of obscurity.
 references: []
+drilldown_searches:
+- name: View the detection results for - "$src_ip$"
+  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$src_ip$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
 rba:
   message: Port or Protocol Traffic Mismatch
   risk_objects:

--- a/detections/network/protocols_passing_authentication_in_cleartext.yml
+++ b/detections/network/protocols_passing_authentication_in_cleartext.yml
@@ -45,7 +45,7 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Potential Authentication in cleartext
+  message: Allowed Traffic from $src_ip$ to $dest_ip$ over port $dest_port$. Which might indicate a potential authentication attempts over a  cleartext protocol.
   risk_objects:
   - field: user
     type: user
@@ -59,6 +59,7 @@ rba:
 tags:
   analytic_story:
   - Use of Cleartext Protocols
+  - Cisco Secure Firewall Threat Defense Analytics
   asset_type: Endpoint
   product:
   - Splunk Enterprise

--- a/detections/network/protocols_passing_authentication_in_cleartext.yml
+++ b/detections/network/protocols_passing_authentication_in_cleartext.yml
@@ -54,7 +54,7 @@ rba:
     type: system
     score: 25
   threat_objects:
-  - field: dest_ip
+  - field: dest
     type: ip_address
 tags:
   analytic_story:

--- a/detections/network/protocols_passing_authentication_in_cleartext.yml
+++ b/detections/network/protocols_passing_authentication_in_cleartext.yml
@@ -1,9 +1,9 @@
 name: Protocols passing authentication in cleartext
 id: 6923cd64-17a0-453c-b945-81ac2d8c6db9
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-05-27'
 author: Rico Valdez, Splunk
-status: experimental
+status: production
 type: Anomaly
 description: The following analytic identifies the use of cleartext protocols that
   risk leaking sensitive information. It detects network traffic on legacy protocols
@@ -13,19 +13,20 @@ description: The following analytic identifies the use of cleartext protocols th
   and other sensitive data to interception. If confirmed malicious, attackers could
   capture authentication details, leading to unauthorized access and potential data
   breaches.
-data_source: []
+data_source:
+- Cisco Secure Firewall Threat Defense Connection Event
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Network_Traffic where All_Traffic.action!=blocked AND
+  as lastTime from datamodel=Network_Traffic where All_Traffic.action NOT IN ("blocked", "block") AND
   All_Traffic.transport="tcp" AND (All_Traffic.dest_port="23" OR All_Traffic.dest_port="143"
   OR All_Traffic.dest_port="110" OR (All_Traffic.dest_port="21" AND All_Traffic.user
-  != "anonymous")) by All_Traffic.user All_Traffic.src All_Traffic.dest All_Traffic.dest_port
+  != "anonymous")) by All_Traffic.user All_Traffic.src All_Traffic.dest All_Traffic.dest_port All_Traffic.rule
   | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `drop_dm_object_name("All_Traffic")`
   | `protocols_passing_authentication_in_cleartext_filter`'
 how_to_implement: This search requires you to be ingesting your network traffic, and
   populating the Network_Traffic data model. For more accurate result it's better
   to limit destination to organization private and public IP range, like All_Traffic.dest
   IN(192.168.0.0/16,172.16.0.0/12,10.0.0.0/8, x.x.x.x/22)
-known_false_positives: Some networks may use kerberos, FTP or telnet servers, however, this is rare.
+known_false_positives: Some networks may use leverage clear text protocols such as kerberos, FTP or telnet servers. Apply the necessary exclusions where needed.
 references:
 - https://www.rackaid.com/blog/secure-your-email-and-file-transfers/
 - https://www.infosecmatter.com/capture-passwords-using-wireshark/
@@ -48,3 +49,9 @@ tags:
   - Splunk Enterprise Security
   - Splunk Cloud
   security_domain: network
+tests:
+- name: Cisco Secure Firewall True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/connection_event/connection_events.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/protocols_passing_authentication_in_cleartext.yml
+++ b/detections/network/protocols_passing_authentication_in_cleartext.yml
@@ -45,7 +45,7 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Allowed Traffic from $src_ip$ to $dest_ip$ over port $dest_port$. Which might indicate a potential authentication attempts over a  cleartext protocol.
+  message: Allowed Traffic from $src_ip$ to $dest$ over port $dest_port$. Which might indicate a potential authentication attempts over a  cleartext protocol.
   risk_objects:
   - field: user
     type: user

--- a/detections/network/protocols_passing_authentication_in_cleartext.yml
+++ b/detections/network/protocols_passing_authentication_in_cleartext.yml
@@ -16,7 +16,7 @@ description: The following analytic identifies the use of cleartext protocols th
 data_source:
 - Cisco Secure Firewall Threat Defense Connection Event
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Network_Traffic where All_Traffic.action NOT IN ("blocked", "block") AND
+  as lastTime from datamodel=Network_Traffic where NOT All_Traffic.action IN ("blocked", "block") AND
   All_Traffic.transport="tcp" AND (All_Traffic.dest_port="23" OR All_Traffic.dest_port="143"
   OR All_Traffic.dest_port="110" OR (All_Traffic.dest_port="21" AND All_Traffic.user
   != "anonymous")) by All_Traffic.user All_Traffic.src_ip All_Traffic.dest All_Traffic.dest_port All_Traffic.rule
@@ -53,7 +53,9 @@ rba:
   - field: dest
     type: system
     score: 25
-  threat_objects: []
+  threat_objects:
+  - field: dest_ip
+    type: ip_address
 tags:
   analytic_story:
   - Use of Cleartext Protocols

--- a/detections/network/protocols_passing_authentication_in_cleartext.yml
+++ b/detections/network/protocols_passing_authentication_in_cleartext.yml
@@ -19,7 +19,7 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   as lastTime from datamodel=Network_Traffic where All_Traffic.action NOT IN ("blocked", "block") AND
   All_Traffic.transport="tcp" AND (All_Traffic.dest_port="23" OR All_Traffic.dest_port="143"
   OR All_Traffic.dest_port="110" OR (All_Traffic.dest_port="21" AND All_Traffic.user
-  != "anonymous")) by All_Traffic.user All_Traffic.src All_Traffic.dest All_Traffic.dest_port All_Traffic.rule
+  != "anonymous")) by All_Traffic.user All_Traffic.src_ip All_Traffic.dest All_Traffic.dest_port All_Traffic.rule
   | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `drop_dm_object_name("All_Traffic")`
   | `protocols_passing_authentication_in_cleartext_filter`'
 how_to_implement: This search requires you to be ingesting your network traffic, and

--- a/detections/network/protocols_passing_authentication_in_cleartext.yml
+++ b/detections/network/protocols_passing_authentication_in_cleartext.yml
@@ -30,6 +30,20 @@ known_false_positives: Some networks may use leverage clear text protocols such 
 references:
 - https://www.rackaid.com/blog/secure-your-email-and-file-transfers/
 - https://www.infosecmatter.com/capture-passwords-using-wireshark/
+drilldown_searches:
+- name: View the detection results for - "$src_ip$"
+  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$src_ip$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
 rba:
   message: Potential Authentication in cleartext
   risk_objects:

--- a/detections/network/tor_traffic.yml
+++ b/detections/network/tor_traffic.yml
@@ -24,10 +24,10 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   All_Traffic.transport All_Traffic.user All_Traffic.vendor_product All_Traffic.rule | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)` | `drop_dm_object_name("All_Traffic")` | `tor_traffic_filter`'
 how_to_implement: In order to properly run this search, Splunk needs to ingest data
-  from Next Generation Firewalls like Palo Alto Networks Firewalls or other network
-  control devices that mediate the traffic allowed into an environment. This is necessary
-  so that the search can identify an 'action' taken on the traffic of interest. The
-  search requires the Network_Traffic data model to be populated.
+  from Next Generation Firewalls like, Cisco Secure Firewall Threat Defense, Palo Alto Networks Firewalls 
+  or other network control devices that mediate the traffic allowed into an environment. This is necessary
+  so that the search can identify an 'action' taken on the traffic of interest.
+  The search requires the Network_Traffic data model to be populated.
 known_false_positives: None at this time
 references:
 - https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA10g000000ClRtCAK

--- a/detections/network/tor_traffic.yml
+++ b/detections/network/tor_traffic.yml
@@ -1,7 +1,7 @@
 name: TOR Traffic
 id: ea688274-9c06-4473-b951-e4cb7a5d7a45
-version: 9
-date: '2025-05-02'
+version: 10
+date: '2025-05-27'
 author: David Dorsey, Bhavin Patel, Splunk
 status: production
 type: TTP
@@ -15,12 +15,13 @@ description: The following analytic identifies allowed network traffic to The On
   violations, compromising the integrity and security of the network.
 data_source:
 - Palo Alto Network Traffic
+- Cisco Secure Firewall Threat Defense Connection Event
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Network_Traffic where All_Traffic.app=tor AND All_Traffic.action=allowed
   by All_Traffic.action All_Traffic.app All_Traffic.bytes All_Traffic.bytes_in All_Traffic.bytes_out
   All_Traffic.dest All_Traffic.dest_ip All_Traffic.dest_port All_Traffic.dvc All_Traffic.protocol
   All_Traffic.protocol_version All_Traffic.src All_Traffic.src_ip All_Traffic.src_port
-  All_Traffic.transport All_Traffic.user All_Traffic.vendor_product | `security_content_ctime(firstTime)`
+  All_Traffic.transport All_Traffic.user All_Traffic.vendor_product All_Traffic.rule | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)` | `drop_dm_object_name("All_Traffic")` | `tor_traffic_filter`'
 how_to_implement: In order to properly run this search, Splunk needs to ingest data
   from Next Generation Firewalls like Palo Alto Networks Firewalls or other network
@@ -68,8 +69,13 @@ tags:
   - Splunk Cloud
   security_domain: network
 tests:
-- name: True Positive Test
+- name: Palo Alto True Positive Test
   attack_data:
   - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1090.003/pan_tor_allowed/pan_tor_allowed.log
     source: pan_tor_allowed
     sourcetype: pan:traffic
+- name: Cisco Secure Firewall True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/connection_event/connection_events.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/tor_traffic.yml
+++ b/detections/network/tor_traffic.yml
@@ -60,6 +60,7 @@ tags:
   - Ransomware
   - NOBELIUM Group
   - Command And Control
+  - Cisco Secure Firewall Threat Defense Analytics
   asset_type: Endpoint
   mitre_attack_id:
   - T1090.003

--- a/detections/network/tor_traffic.yml
+++ b/detections/network/tor_traffic.yml
@@ -17,7 +17,7 @@ data_source:
 - Palo Alto Network Traffic
 - Cisco Secure Firewall Threat Defense Connection Event
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Network_Traffic where All_Traffic.app=tor AND All_Traffic.action=allowed
+  as lastTime from datamodel=Network_Traffic where All_Traffic.app=tor AND All_Traffic.action IN ("allowed", "allow")
   by All_Traffic.action All_Traffic.app All_Traffic.bytes All_Traffic.bytes_in All_Traffic.bytes_out
   All_Traffic.dest All_Traffic.dest_ip All_Traffic.dest_port All_Traffic.dvc All_Traffic.protocol
   All_Traffic.protocol_version All_Traffic.src All_Traffic.src_ip All_Traffic.src_port

--- a/lookups/cisco_secure_firewall_appid_remote_mgmt_and_desktop_tools.csv
+++ b/lookups/cisco_secure_firewall_appid_remote_mgmt_and_desktop_tools.csv
@@ -1,0 +1,320 @@
+appName,appName1,appDescription,category
+AirDroid,AirDroid,Android device managment solutions provider.,remote administration
+Airsoft Powerburst,Airsoft Powerburst,A remote access accelerator that caches client sessions on the remote server. IANA tcp/udp 485.,remote administration
+AMMYY,AMMYY,Remote access software.,remote administration
+AnyDesk,AnyDesk,Remote Desktop Access Software.,remote administration
+Apache ZooKeeper,Apache ZooKeeper,A centralized service for providing configuration information; naming; synchronization and group services over large clusters in distributed systems.,remote administration
+Apple Remote Desktop,Apple Remote Desktop,VNC on Mac OSX.,remote desktop control
+AweSun,AweSun,Remote desktop software.,remote administration
+Blast,Blast,VMWare Blast Protocol.,remote administration
+Bomgar,Bomgar,Remote desktop control and file transfer software.,remote administration
+Chrome Remote Desktop,Chrome Remote Desktop,Chrome Remote Desktop is a remote desktop software tool that allows a user to remotely control another computer's desktop.,remote desktop control
+Cisco Meraki,Cisco Meraki,Secure cloud solution that allows users to manage Meraki network devices in a single platform.,remote administration
+Citrix CGP,Citrix CGP,Citrix Common Gateway Protocol.,remote administration
+Citrix IMA,Citrix IMA,Independent Management Architeture protocol. Used for licensing and server load updates.,remote administration
+Citrix Licensing,Citrix Licensing,Citrix Licensing traffic. Registered with IANA on port 7279 tcp/udp.,remote administration
+Citrix RTMP,Citrix RTMP,Registered with IANA on port 2897 tcp/udp.,remote administration
+Citrix SLG,Citrix SLG,Storage Link Gateway. Discovery and access to various storage services.,remote administration
+Citrix WANScaler,Citrix WANScaler,Citrix WAN optimization traffic.,remote administration
+CrossLoop,CrossLoop,Desktop sharing / remote access site.,remote administration
+Dameware,Dameware,Remote desktop software suite.,remote administration
+DLMS-COSEM Get Request,DLMS-COSEM Get Request,A DLMS-COSEM service request to get the value(s) of one or all attributes.,remote administration
+DLMS-COSEM Get Response,DLMS-COSEM Get Response,A DLMS-COSEM service to send a response to a previously received GET indication primitive.,remote administration
+DLMS-COSEM Initiate Request High-Level Authentication,DLMS-COSEM Initiate Request High-Level Authentication,A DLMS-COSEM service request for User-Information exchange with High-Level Authentication.,remote administration
+DLMS-COSEM Initiate Request Low-Level Authentication,DLMS-COSEM Initiate Request Low-Level Authentication,A DLMS-COSEM service request for User-Information exchange with Low-Level Authentication.,remote administration
+DLMS-COSEM Initiate Request No Authentication,DLMS-COSEM Initiate Request No Authentication,A DLMS-COSEM service request for User-Information exchange with No Authentication.,remote administration
+DLMS-COSEM Initiate Response,DLMS-COSEM Initiate Response,A DLMS-COSEM service response for User-Information exchange.,remote administration
+DLMS-COSEM Set Request,DLMS-COSEM Set Request,A DLMS-COSEM service request to set the value of one or more attributes.,remote administration
+DLMS-COSEM Set Response,DLMS-COSEM Set Response,A DLMS-COSEM service to send a response to a previously received SET indication primitive.,remote administration
+DNP3 Abort File,DNP3 Abort File,Distributed Network Protocol "Abort File" PDU.,remote administration
+DNP3 Assign Class,DNP3 Assign Class,Distributed Network Protocol "Assign Class" PDU.,remote administration
+DNP3 Authenticate File,DNP3 Authenticate File,Distributed Network Protocol "Authenticate File" PDU.,remote administration
+DNP3 Close File,DNP3 Close File,Distributed Network Protocol "Close File" PDU.,remote administration
+DNP3 Cold Restart,DNP3 Cold Restart,Distributed Network Protocol "Cold Restart" PDU.,remote administration
+DNP3 Confirm,DNP3 Confirm,Distributed Network Protocol "Confirm" PDU.,remote administration
+DNP3 Delay Measurement,DNP3 Delay Measurement,Distributed Network Protocol "Delay Measurement" PDU.,remote administration
+DNP3 Delete File,DNP3 Delete File,Distributed Network Protocol "Delete File" PDU.,remote administration
+DNP3 Dir Operate,DNP3 Dir Operate,Distributed Network Protocol "Dir Operate" PDU.,remote administration
+DNP3 Dir Operate No Resp,DNP3 Dir Operate No Resp,Distributed Network Protocol "Dir Operate No Resp" PDU.,remote administration
+DNP3 Disable Unsolicited,DNP3 Disable Unsolicited,Distributed Network Protocol "Disable Unsolicited" PDU.,remote administration
+DNP3 Enable Unsolicited,DNP3 Enable Unsolicited,Distributed Network Protocol "Enable Unsolicited" PDU.,remote administration
+DNP3 Freeze,DNP3 Freeze,Distributed Network Protocol "Freeze" PDU.,remote administration
+DNP3 Freeze At Time,DNP3 Freeze At Time,Distributed Network Protocol "Freeze At Time" PDU.,remote administration
+DNP3 Freeze At Time No Resp,DNP3 Freeze At Time No Resp,Distributed Network Protocol "Freeze At Time No Resp" PDU.,remote administration
+DNP3 Freeze Clear,DNP3 Freeze Clear,Distributed Network Protocol "Freeze Clear" PDU.,remote administration
+DNP3 Freeze Clear No Resp,DNP3 Freeze Clear No Resp,Distributed Network Protocol "Freeze Clear No Resp" PDU.,remote administration
+DNP3 Freeze No Resp,DNP3 Freeze No Resp,Distributed Network Protocol "Freeze No Resp" PDU.,remote administration
+DNP3 Get File Information,DNP3 Get File Information,Distributed Network Protocol "Get File Information" PDU.,remote administration
+DNP3 Initialize Application,DNP3 Initialize Application,Distributed Network Protocol "Initialize Application" PDU.,remote administration
+DNP3 Initialize Data,DNP3 Initialize Data,Distributed Network Protocol "Initialize Data" PDU.,remote administration
+DNP3 Link Status,DNP3 Link Status,Distributed Network Protocol "Link Status" data frame.,remote administration
+DNP3 Open File,DNP3 Open File,Distributed Network Protocol "Open File" PDU.,remote administration
+DNP3 Operate,DNP3 Operate,Distributed Network Protocol "Operate" PDU.,remote administration
+DNP3 Read,DNP3 Read,Distributed Network Protocol "Read" PDU.,remote administration
+DNP3 Record Current Time,DNP3 Record Current Time,Distributed Network Protocol "Record Current Time" PDU.,remote administration
+DNP3 Request Link Status,DNP3 Request Link Status,Distributed Network Protocol "Request Link Status" data frame.,remote administration
+DNP3 Response,DNP3 Response,Distributed Network Protocol "Response" PDU.,remote administration
+DNP3 Save Configuration,DNP3 Save Configuration,Distributed Network Protocol "Save Configuration" PDU.,remote administration
+DNP3 Select,DNP3 Select,Distributed Network Protocol "Select" PDU.,remote administration
+DNP3 Start Application,DNP3 Start Application,Distributed Network Protocol "Start Application" PDU.,remote administration
+DNP3 Stop Application,DNP3 Stop Application,Distributed Network Protocol "Stop Application" PDU.,remote administration
+DNP3 Unsolicited Response,DNP3 Unsolicited Response,Distributed Network Protocol "Unsolicited Response" PDU.,remote administration
+DNP3 Warm Restart,DNP3 Warm Restart,Distributed Network Protocol "Warm Restart" PDU.,remote administration
+DNP3 Write,DNP3 Write,Distributed Network Protocol "Write" PDU.,remote administration
+Dropbear,Dropbear,SSH client.,remote administration
+DynGate,DynGate,A firewall that allows TeamViewer traffic to tunnel over HTTP.,remote desktop control
+eRoom,eRoom,Collaborative software site.,remote administration
+ERPC,ERPC,Encore Expedited Remote Procedure Call.,remote administration
+exec,exec,Unix utility that provides remote execution of software.,remote desktop control
+FastViewer,FastViewer,Online meeting and remote control software.,remote administration
+Ganglia,Ganglia,Monitors distributed computing systems.,remote administration
+Gbridge,Gbridge,Google extension to access other computer remotely.,remote administration
+Getscreen.me,Getscreen.me,Remote Desktop Access. Cloud-based software for administration; technical support and remote work.,remote desktop control
+Google ChromeOS VM Monitor,Google ChromeOS VM Monitor,Chrome virtual machine monitor is Linux based KVM hypervisor focusing on security and speed.,remote desktop control
+Google::Google Remote Desktop,#NAME?,Online desktop sharing service.,remote administration
+GoToMyPC,GoToMyPC,PC remote control software.,remote desktop control
+HP VMM,HP VMM,HP Virtual Machine Manager.,remote administration
+ICA Browser,ICA Browser,Remote desktop service.,remote administration
+IEC 104 Ack File Ack Section,IEC 104 Ack File Ack Section,An IEC 104 Type ID; F_AF_NA_1. Act file; Act section in file transfer.,remote administration
+IEC 104 Bitstring 32 bit Command with Long Time,IEC 104 Bitstring 32 bit Command with Long Time,An IEC 104 Type ID; C_BO_TA_1. Command telegrams of Bit string 32 bit with time tag CP56Time2a.,remote administration
+IEC 104 Bitstring 32 bit with Long Time,IEC 104 Bitstring 32 bit with Long Time,An IEC 104 Type ID; M_BO_TB_1. Process telegrams of Bit string of 32 bit with time tag CP56Time2a.,remote administration
+IEC 104 Call directory Select File,IEC 104 Call directory Select File,An IEC 104 Type ID; F_SC_NA_1. Call directory; select file; call file; call section.,remote administration
+IEC 104 Clock Synchronization Command,IEC 104 Clock Synchronization Command,An IEC 104 Type ID; C_CS_NA_1. System information in control direction of Clock synchronization command.,remote administration
+IEC 104 Control Bitstring 32 bits,IEC 104 Control Bitstring 32 bits,An IEC 104 Type ID; C_BO_NA_1. Process Information in control direction of Bit string 32 bit.,remote administration
+IEC 104 Counter Interrogation Command,IEC 104 Counter Interrogation Command,An IEC 104 Type ID; C_CI_NA_1. System information in control direction of Counter interrogation command.,remote administration
+IEC 104 Double Command,IEC 104 Double Command,An IEC 104 Type ID; C_DC_NA_1. Process Information in control direction of Double command.,remote administration
+IEC 104 Double Command with Long Time,IEC 104 Double Command with Long Time,An IEC 104 Type ID; C_DC_TA_1. Command telegrams of Double command with time tag CP56Time2a.,remote administration
+IEC 104 Double Point Info,IEC 104 Double Point Info,An IEC 104 Type ID; M_DP_NA_1. Process information in monitor direction of Double point information.,remote administration
+IEC 104 Double Point Info with Long Time,IEC 104 Double Point Info with Long Time,An IEC 104 Type ID; M_DP_TB_1. Process telegrams of Double point information with time tag CP56Time2a.,remote administration
+IEC 104 End of Initialization,IEC 104 End of Initialization,An IEC 104 Type ID; M_EI_NA_1. System information in monitor direction of End of initialization.,remote administration
+IEC 104 Event of Protection with Long Time,IEC 104 Event of Protection with Long Time,An IEC 104 Type ID; M_EP_TD_1. Process telegrams of Event of protection equipment with time tag CP56Time2a.,remote administration
+IEC 104 File Ready,IEC 104 File Ready,An IEC 104 Type ID; F_FR_NA_1. File ready in file transfer.,remote administration
+IEC 104 Integrated Totals,IEC 104 Integrated Totals,An IEC 104 Type ID; M_IT_NA_1. Process information in monitor direction of Integrated totals.,remote administration
+IEC 104 Integrated Totals with Long Time,IEC 104 Integrated Totals with Long Time,An IEC 104 Type ID; M_IT_TB_1. Process telegrams of Integrated totals with time tag CP56Time2a.,remote administration
+IEC 104 Interrogation Command,IEC 104 Interrogation Command,An IEC 104 Type ID; C_IC_NA_1. System Information in control direction of General Interrogation command.,remote administration
+IEC 104 Last Section Last Segment,IEC 104 Last Section Last Segment,An IEC 104 Type ID; F_LS_NA_1. Last section; last segment in file transfer.,remote administration
+IEC 104 List Directory,IEC 104 List Directory,An IEC 104 Type ID; F_DR_TA_1. List Directory in file transfer.,remote administration
+IEC 104 List Segment,IEC 104 List Segment,An IEC 104 Type ID; F_SG_NA_1. List Segment in file transfer.,remote administration
+IEC 104 Measured Normalized,IEC 104 Measured Normalized,An IEC 104 Type ID; M_ME_NA_1. Process information in monitor direction of Measured value; normalized value.,remote administration
+IEC 104 Measured Normalized with Long Time,IEC 104 Measured Normalized with Long Time,An IEC 104 Type ID; M_ME_TD_1. Process telegrams of Measured value; normalized value with time tag CP56Time2a.,remote administration
+IEC 104 Measured Normalized without Quality Descriptor,IEC 104 Measured Normalized without Quality Descriptor,An IEC 104 Type ID; M_ME_ND_1. Process information in monitor direction of Measured value; normalized value without quality descriptor.,remote administration
+IEC 104 Measured Scaled,IEC 104 Measured Scaled,An IEC 104 Type ID; M_ME_NB_1. Process information in monitor direction of Measured value; scaled value.,remote administration
+IEC 104 Measured Scaled with Long Time,IEC 104 Measured Scaled with Long Time,An IEC 104 Type ID; M_ME_TE_1. Process telegrams of Measured value; scaled value with time tag CP56Time2a.,remote administration
+IEC 104 Measured Short Float,IEC 104 Measured Short Float,An IEC 104 Type ID; M_ME_NC_1. Process information in monitor direction of Measured value; short floating point value.,remote administration
+IEC 104 Measured Short Float with Long Time,IEC 104 Measured Short Float with Long Time,An IEC 104 Type ID; M_ME_TF_1. Process telegrams of Measured value; short floating point value with time tag CP56Time2a.,remote administration
+IEC 104 Monitor Bitstring 32 bit,IEC 104 Monitor Bitstring 32 bit,An IEC 104 Type ID; M_BO_NA_1. Process information in monitor direction of Bit string of 32 bit.,remote administration
+IEC 104 Packed Output Circuit Info with Long Time,IEC 104 Packed Output Circuit Info with Long Time,An IEC 104 Type ID; M_EP_TF_1. Process telegrams of Packed output circuit information of protection equipment with time tag CP56Time2a.,remote administration
+IEC 104 Packed Single Point,IEC 104 Packed Single Point,An IEC 104 Type ID; M_PS_NA_1. Process information in monitor direction of Packed single-point information with status change detection.,remote administration
+IEC 104 Packed Start Event with Long Time,IEC 104 Packed Start Event with Long Time,An IEC 104 Type ID; M_EP_TE_1. Process telegrams of Packed start events of protection equipment with time tag CP56Time2a.,remote administration
+IEC 104 Parameter Activation,IEC 104 Parameter Activation,An IEC 104 Type ID; P_AC_NA_1. Parameter in control direction of Parameter activation.,remote administration
+IEC 104 Parameter of Measured Normalized,IEC 104 Parameter of Measured Normalized,An IEC 104 Type ID; P_ME_NA_1. Parameter in control direction of measured value; normalized value.,remote administration
+IEC 104 Parameter of Measured Scaled,IEC 104 Parameter of Measured Scaled,An IEC 104 Type ID; P_ME_NB_1. Parameter in control direction of measured value; scaled value.,remote administration
+IEC 104 Parameter of Measured Short Float,IEC 104 Parameter of Measured Short Float,An IEC 104 Type ID; P_ME_NC_1. Parameter in control direction of measured value; short floating point value.,remote administration
+IEC 104 Query Log,IEC 104 Query Log,An IEC 104 Type ID; F_SC_NB_1. Query Log in file transfer.,remote administration
+IEC 104 Read Command,IEC 104 Read Command,An IEC 104 Type ID; C_RD_NA_1. System information in control direction of Read command.,remote administration
+IEC 104 Regulating Step Command,IEC 104 Regulating Step Command,An IEC 104 Type ID; C_RC_NA_1. Process information in control direction of Regulating step command.,remote administration
+IEC 104 Regulating Step Command with Long Time,IEC 104 Regulating Step Command with Long Time,An IEC 104 Type ID; C_RC_TA_1. Command telegrams of Regulating step command with time tag CP56Time2a.,remote administration
+IEC 104 Reset Process Command,IEC 104 Reset Process Command,An IEC 104 Type ID; C_RP_NC_1. System information in control direction of Reset process command.,remote administration
+IEC 104 Section Ready,IEC 104 Section Ready,An IEC 104 Type ID; F_SR_NA_1. Section ready in file transfer.,remote administration
+IEC 104 Setpoint Command Normalized,IEC 104 Setpoint Command Normalized,An IEC 104 Type ID; C_SE_NA_1. Process information in control direction of Setpoint command; normalized value.,remote administration
+IEC 104 Setpoint Command Normalized with Long Time,IEC 104 Setpoint Command Normalized with Long Time,An IEC 104 Type ID; C_SE_TA_1. Command telegrams of Setpoint command; normalized value with time tag CP56Time2a.,remote administration
+IEC 104 Setpoint Command Scaled,IEC 104 Setpoint Command Scaled,An IEC 104 Type ID; C_SE_NB_1. Process information in control direction of Setpoint command; scaled value.,remote administration
+IEC 104 Setpoint Command Scaled with Long Time,IEC 104 Setpoint Command Scaled with Long Time,An IEC 104 Type ID; C_SE_TB_1. Command telegrams of Setpoint command; scaled value with time tag CP56Time2a.,remote administration
+IEC 104 Setpoint Command Short Float,IEC 104 Setpoint Command Short Float,An IEC 104 Type ID; C_SE_NC_1. Process information in control direction of Setpoint command; short floating point value.,remote administration
+IEC 104 Setpoint Command Short Float with Long Time,IEC 104 Setpoint Command Short Float with Long Time,An IEC 104 Type ID; C_SE_TC_1. Command telegrams of Setpoint command; short floating point value with time tag CP56Time2a.,remote administration
+IEC 104 Single Command,IEC 104 Single Command,An IEC 104 Type ID; C_SC_NA_1. Process information in control direction of Single command.,remote administration
+IEC 104 Single Command with Long Time,IEC 104 Single Command with Long Time,An IEC 104 Type ID; C_SC_TA_1. Command telegrams of Single command with time tag CP56Time2a.,remote administration
+IEC 104 Single Point Info,IEC 104 Single Point Info,An IEC 104 Type ID; M_SP_NA_1. Process information in monitor direction of Single point information.,remote administration
+IEC 104 Single Point Info with Long Time,IEC 104 Single Point Info with Long Time,An IEC 104 Type ID; M_SP_TB_1. Process telegrams of Single point information with time tag CP56Time2a.,remote administration
+IEC 104 STARTDT ACT,IEC 104 STARTDT ACT,An IEC 104 Function of Start Data Transfer Activation.,remote administration
+IEC 104 STARTDT CON,IEC 104 STARTDT CON,An IEC 104 Function of Start Data Transfer Confirmation.,remote administration
+IEC 104 Step Position Info,IEC 104 Step Position Info,An IEC 104 Type ID; M_ST_NA_1. Process information in monitor direction of Step position information.,remote administration
+IEC 104 Step Position Info with Long Time,IEC 104 Step Position Info with Long Time,An IEC 104 Type ID; M_ST_TB_1. Process telegrams of Step position information with time tag CP56Time2a.,remote administration
+IEC 104 Test Command with Long Time,IEC 104 Test Command with Long Time,An IEC 104 Type ID; C_TS_TA_1. System information in control direction of Test command with time tag CP56Time2a.,remote administration
+IEC 104 TESTFR ACT,IEC 104 TESTFR ACT,An IEC 104 Function of Test Frame Activation.,remote administration
+IEC 104 TESTFR CON,IEC 104 TESTFR CON,An IEC 104 Function of Test Frame Confirmation.,remote administration
+IEEE C37.118 Command DT Off Frame,IEEE C37.118 Command DT Off Frame,An IEEE C37.118 Protocol Synchrophasor Command Data Transmission Off Frame Packet.,remote administration
+IEEE C37.118 Command DT On Frame,IEEE C37.118 Command DT On Frame,An IEEE C37.118 Protocol Synchrophasor Command Data Transmission On Frame Packet.,remote administration
+IEEE C37.118 Command Extended Frame,IEEE C37.118 Command Extended Frame,An IEEE C37.118 Protocol Synchrophasor Command Extended Frame Packet.,remote administration
+IEEE C37.118 Command Send Configuration 1 Frame,IEEE C37.118 Command Send Configuration 1 Frame,An IEEE C37.118 Protocol Synchrophasor Command Send Configuration 1 Frame Packet.,remote administration
+IEEE C37.118 Command Send Configuration 2 Frame,IEEE C37.118 Command Send Configuration 2 Frame,An IEEE C37.118 Protocol Synchrophasor Command Send Configuration 2 Frame Packet.,remote administration
+IEEE C37.118 Command Send Configuration 3 Frame,IEEE C37.118 Command Send Configuration 3 Frame,An IEEE C37.118 Protocol Synchrophasor Command Send Configuration 3 Frame Packet.,remote administration
+IEEE C37.118 Command Send Header Frame,IEEE C37.118 Command Send Header Frame,An IEEE C37.118 Protocol Synchrophasor Command Send Header Frame Packet.,remote administration
+IEEE C37.118 Configuration Frame 1,IEEE C37.118 Configuration Frame 1,An IEEE C37.118 Protocol Synchrophasor Configuration Frame 1 Packet.,remote administration
+IEEE C37.118 Configuration Frame 2,IEEE C37.118 Configuration Frame 2,An IEEE C37.118 Protocol Synchrophasor Configuration Frame 2 Packet.,remote administration
+IEEE C37.118 Configuration Frame 3,IEEE C37.118 Configuration Frame 3,An IEEE C37.118 Protocol Synchrophasor Configuration Frame 3 Packet.,remote administration
+IEEE C37.118 Data Frame,IEEE C37.118 Data Frame,An IEEE C37.118 Protocol Synchrophasor Data Frame Packet.,remote administration
+IEEE C37.118 Header Frame,IEEE C37.118 Header Frame,An IEEE C37.118 Protocol Synchrophasor Header Frame Packet.,remote administration
+IEEE C37.118 Synchrophasor,IEEE C37.118 Synchrophasor,IEEE C37.118 Synchrophasor Data Transfer Protocol is an IEEE standard which defines a method for exchange of synchronized phasor measurement data between power system equipment.,remote administration
+JBoss Remoting,JBoss Remoting,Framework for communication over the network.,remote administration
+KNETCMP,KNETCMP,KNET/VM Command/Message Protocol.,remote desktop control
+Ktelnet,Ktelnet,Telnet with Kerberos authentication and encryption.,remote administration
+KVM,KVM,KVM (Keyboard/Video/Mouse) over IP Management Service.,remote administration
+KVM,KVM,KVM (Keyboard/Video/Mouse) over IP Management Service.,remote desktop control
+KWDB,KWDB,Remote Kernel debugger communication.,remote administration
+libssh2,libssh2,A client-side C library implementing the SSH2 protocol.,remote administration
+Linuxconf,Linuxconf,Linux system configurator.,remote administration
+LogMeIn,LogMeIn,Remote access and PC desktop control.,remote administration
+LogMeIn Rescue,LogMeIn Rescue,A remote desktop support tool.,remote administration
+LogMeIn Rescue,LogMeIn Rescue,A remote desktop support tool.,remote desktop control
+lsh,lsh,Freeware SSH implementation.,remote administration
+Microsoft WSMan,Microsoft WSMan,Microsoft Web Services for Management tools.,remote administration
+Mikogo,Mikogo,Desktop sharing application.,remote administration
+MMS ackEventNotificaton,MMS ackEventNotificaton,An MMS Command of Acknowledge Event Notification request.,remote administration
+MMS alterEventConditionMonitoring,MMS alterEventConditionMonitoring,An MMS Command of Alter Event Condition Monitoring request.,remote administration
+MMS alterEventEnrollment,MMS alterEventEnrollment,An MMS Command of Alter Event Enrollment request.,remote administration
+MMS confirmedErrorPDU,MMS confirmedErrorPDU,An MMS Confirmed Error PDU message.,remote administration
+MMS confirmedResponsePDU,MMS confirmedResponsePDU,An MMS Confirmed Response PDU message.,remote administration
+MMS createJournal,MMS createJournal,An MMS Command of Create Journal request.,remote administration
+MMS createProgramInvocation,MMS createProgramInvocation,An MMS Command of Create Program Invocation request.,remote administration
+MMS defineEventAction,MMS defineEventAction,An MMS Command of Define Event Action request.,remote administration
+MMS defineEventCondition,MMS defineEventCondition,An MMS Command of Define Event Condition request.,remote administration
+MMS defineEventEnrollment,MMS defineEventEnrollment,An MMS Command of Define Event Enrollment request.,remote administration
+MMS defineNamedType,MMS defineNamedType,An MMS Command of Define Named Type request.,remote administration
+MMS defineNamedVariable,MMS defineNamedVariable,An MMS Command of Define Named Variable request.,remote administration
+MMS defineNamedVariableList,MMS defineNamedVariableList,An MMS Command of Define Named Variable List request.,remote administration
+MMS defineScatteredAccess,MMS defineScatteredAccess,An MMS Command of Define Scattered Access request.,remote administration
+MMS defineSemaphore,MMS defineSemaphore,An MMS Command of Define Semaphore request.,remote administration
+MMS deleteDomain,MMS deleteDomain,An MMS Command of Delete Domain request.,remote administration
+MMS deleteEventAction,MMS deleteEventAction,An MMS Command of Delete Event Action request.,remote administration
+MMS deleteEventCondition,MMS deleteEventCondition,An MMS Command of Delete Event Condition request.,remote administration
+MMS deleteEventEnrollment,MMS deleteEventEnrollment,An MMS Command of Delete Event Enrollment request.,remote administration
+MMS deleteJournal,MMS deleteJournal,An MMS Command of Delete Journal request.,remote administration
+MMS deleteNamedType,MMS deleteNamedType,An MMS Command of Delete Named Type request.,remote administration
+MMS deleteNamedVariableList,MMS deleteNamedVariableList,An MMS Command of Delete Named Variable List request.,remote administration
+MMS deleteProgramInvocation,MMS deleteProgramInvocation,An MMS Command of Delete Program Invocation request.,remote administration
+MMS deleteSemaphore,MMS deleteSemaphore,An MMS Command of Delete Semaphore request.,remote administration
+MMS deleteVariableAccess,MMS deleteVariableAccess,An MMS Command of Delete Variable Access request.,remote administration
+MMS domainDownload,MMS domainDownload,An MMS Command of Request Domain Download.,remote administration
+MMS domainUpload,MMS domainUpload,An MMS Command of Request Domain Upload.,remote administration
+MMS downloadSegment,MMS downloadSegment,An MMS Command of Download Segment request.,remote administration
+MMS fileClose,MMS fileClose,An MMS Command of File Close request.,remote administration
+MMS fileDelete,MMS fileDelete,An MMS Command of File Delete request.,remote administration
+MMS fileDirectory,MMS fileDirectory,An MMS Command of File Directory request.,remote administration
+MMS fileOpen,MMS fileOpen,An MMS Command of File Open request.,remote administration
+MMS fileRead,MMS fileRead,An MMS Command of File Read request.,remote administration
+MMS fileRename,MMS fileRename,An MMS Command of File Rename request.,remote administration
+MMS getAlarmEnrollmentSummary,MMS getAlarmEnrollmentSummary,An MMS Command of Get Alarm Enrollment Summary request.,remote administration
+MMS getAlarmSummary,MMS getAlarmSummary,An MMS Command of Get Alarm Summary request.,remote administration
+MMS getCapabilityList,MMS getCapabilityList,An MMS Command of Get Capability List request.,remote administration
+MMS getDomainAttributes,MMS getDomainAttributes,An MMS Command of Get Domain Attributes request.,remote administration
+MMS getEventActionAttr,MMS getEventActionAttr,An MMS Command of Get Event Action Attributes request.,remote administration
+MMS getEventConditionAttr,MMS getEventConditionAttr,An MMS Command of Get Event Condition Attributes request.,remote administration
+MMS getEventEnrollmentAttr,MMS getEventEnrollmentAttr,An MMS Command of Get Event Enrollment Attributes request.,remote administration
+MMS getNamedTypeAttr,MMS getNamedTypeAttr,An MMS Command of Get Named Type Attributes request.,remote administration
+MMS getNamedVariableListAttr,MMS getNamedVariableListAttr,An MMS Command of Get Named Variable List Attributes request.,remote administration
+MMS getNameList,MMS getNameList,An MMS command of Get Name List request.,remote administration
+MMS getProgramInvocationAttr,MMS getProgramInvocationAttr,An MMS Command of Get Program Invocation Attributes request.,remote administration
+MMS getScatteredAccessAttr,MMS getScatteredAccessAttr,An MMS Command of Get Scattered Access Attributes request.,remote administration
+MMS getVariableAccAttr,MMS getVariableAccAttr,An MMS Command of Get Variable Access Attributes request.,remote administration
+MMS identify,MMS identify,An MMS Command of Identify request.,remote administration
+MMS initializeJournal,MMS initializeJournal,An MMS Command of Initialize Journal request.,remote administration
+MMS initiateDownloadSequence,MMS initiateDownloadSequence,An MMS Command of Initiate Download Sequence request.,remote administration
+MMS initiateUploadSequence,MMS initiateUploadSequence,An MMS Command of Initiate Upload Sequence request.,remote administration
+MMS input,MMS input,An MMS Command of Input request.,remote administration
+MMS kill,MMS kill,An MMS Command of Kill request.,remote administration
+MMS loadDomainContent,MMS loadDomainContent,An MMS Command of Load Domain Content request.,remote administration
+MMS obtainFile,MMS obtainFile,An MMS Command of Obtain File request.,remote administration
+MMS output,MMS output,An MMS Command of Output request.,remote administration
+MMS read,MMS read,An MMS Command of Read request.,remote administration
+MMS readJournal,MMS readJournal,An MMS Command of Read Journal request.,remote administration
+MMS relinquishControl,MMS relinquishControl,An MMS Command of Relinquish Control request.,remote administration
+MMS rename,MMS rename,An MMS Command of Rename request.,remote administration
+MMS reportEventActionStatus,MMS reportEventActionStatus,An MMS Command of Report Event Action Status request.,remote administration
+MMS reportEventConditionStatus,MMS reportEventConditionStatus,An MMS Command of Report Event Condition Status request.,remote administration
+MMS reportEventEnrollmentStatus,MMS reportEventEnrollmentStatus,An MMS Command of Report Event Enrollment Status request.,remote administration
+MMS reportJournalStatus,MMS reportJournalStatus,An MMS Command of Report Journal Status request.,remote administration
+MMS reportPoolSemaphoreStatus,MMS reportPoolSemaphoreStatus,An MMS Command of Report Pool Semaphore Status request.,remote administration
+MMS reportSemaphoreEntryStatus,MMS reportSemaphoreEntryStatus,An MMS Command of Report Semaphore Entry Status request.,remote administration
+MMS reportSemaphoreStatus,MMS reportSemaphoreStatus,An MMS Command of Report Semaphore Status request.,remote administration
+MMS reset,MMS reset,An MMS Command of Reset request.,remote administration
+MMS resume,MMS resume,An MMS Command of Resume request.,remote administration
+MMS start,MMS start,An MMS Command of Start request.,remote administration
+MMS status,MMS status,An MMS Command of Status request.,remote administration
+MMS stop,MMS stop,An MMS Command of stop request.,remote administration
+MMS storeDomainContent,MMS storeDomainContent,An MMS Command of Store Domain Content request.,remote administration
+MMS takeControl,MMS takeControl,An MMS Command of Take Control request.,remote administration
+MMS terminateDownloadSequence,MMS terminateDownloadSequence,An MMS Command of Terminate Download Sequence request.,remote administration
+MMS terminateUploadSequence,MMS terminateUploadSequence,An MMS Command of Terminate Upload Sequence request.,remote administration
+MMS triggerEvent,MMS triggerEvent,An MMS Command of Trigger Event request.,remote administration
+MMS unconfirmedPDU,MMS unconfirmedPDU,An MMS Unconfirmed PDU message.,remote administration
+MMS uploadSegment,MMS uploadSegment,An MMS Command of Upload Segment request.,remote administration
+MMS write,MMS write,An MMS Command of Write request.,remote administration
+MMS writeJournal,MMS writeJournal,An MMS Command of Write Journal request.,remote administration
+MobaXterm,MobaXterm,Xserver and tabbed SSH client for Windows.,remote administration
+NateOn Remote Control,NateOn Remote Control,NateOn remote desktop software.,remote desktop control
+Naverisk,Naverisk,Cloud-based remote monitoring and management software.,remote administration
+Naverisk,Naverisk,Cloud-based remote monitoring and management software.,remote desktop control
+NetSarang,NetSarang,Network connectivity and management tools package.,remote administration
+NetSight,NetSight,Network management software.,remote administration
+NetWeaver,NetWeaver,Integrated server platform for SAP's various applications and services.,remote administration
+NeXTStep,NeXTStep,NeXTStep Window Server.,remote administration
+Omron FINS,Omron FINS,Factory Interface Network Service; a suite of protocols used by Omron programmable logic controllers.,remote administration
+Opalis Robot,Opalis Robot,System management and automation solution. Provides real-time monitoring; notification; corrective action and event driven job scheduling.,remote administration
+OpenSSH,OpenSSH,SSH client.,remote administration
+Parallels,Parallels,Cloud services enablement and virtual access.,remote desktop control
+PcAnywhere,PcAnywhere,PC remote control software.,remote desktop control
+PC-Duo,PC-Duo,PC remote control software.,remote desktop control
+PCoIP,PCoIP,A remote desktop system.,remote administration
+Philips Hue,Philips Hue,Remote controller for wireless light effects.,remote administration
+PuTTY,PuTTY,SSH client.,remote administration
+RADIUS,RADIUS,Provides centralized Authentication; Authorization; and Accounting (AAA) management for computers to connect and use a network service.,remote administration
+RADIUS-acct,RADIUS-acct,Radius accounting.,remote administration
+RDP,RDP,Remote Desktop Protocol provides users with a graphical interface to another computer.,remote desktop control
+RealVNC,RealVNC,A VNC package that supports client and server side; and also provides cloud-based services such as chat and file transfer.,remote administration
+Remote Job Service,Remote Job Service,Registered with IANA on port 71 tcp/udp.,remote administration
+Remote Telnet,Remote Telnet,Remote Telnet.,remote administration
+RemotePC,RemotePC,Remote desktop software.,remote administration
+RFB,RFB,Remote graphical display protocol; used for VNC sessions.,remote desktop control
+RJE,RJE,The process of sending jobs to Mainframe computers from remote workstations and by extension the process of receiving output from mainframe jobs at a remote workstation.,remote administration
+rlogin,rlogin,Unix utility that allows remote administration from one computer to another.,remote administration
+Rsupport,Rsupport,A remote management application for PC support.,remote administration
+Rsupport,Rsupport,A remote management application for PC support.,remote desktop control
+RustDesk,RustDesk,RustDesk is a full-featured open source remote control alternative for self-hosting and security with minimal configuration.,remote administration
+RustDesk,RustDesk,RustDesk is a full-featured open source remote control alternative for self-hosting and security with minimal configuration.,remote desktop control
+SCCM,SCCM,System Center Configuration Manager. Microsoft software for controlling and managing large groups of Windows computers.,remote administration
+SCCM,SCCM,System Center Configuration Manager. Microsoft software for controlling and managing large groups of Windows computers.,remote desktop control
+SCCM Remote Control,SCCM Remote Control,Remote control component of SCCM.,remote desktop control
+Sco I2 Dialog Daemon,Sco I2 Dialog Daemon,Registered with IANA on port 360 tcp/udp.,remote administration
+Scopia,Scopia,Avaya Scopia video conferencing system.,remote desktop control
+SF MGMT,SF MGMT,Sourcefire Appliance Management.,remote administration
+shell,shell,Remote shell; also known as rsh; a Unix utility that allows remote execution of commands.,remote desktop control
+ShowMyPC,ShowMyPC,Cloud-based remote support and desktop sharing.,remote administration
+ShowMyPC,ShowMyPC,Cloud-based remote support and desktop sharing.,remote desktop control
+SMSP,SMSP,Storage Management Services Protocol; registered with IANA on port 413 tcp/udp.,remote desktop control
+SNA Gateway,SNA Gateway,SNA Gateway Access Server enables users to exchange information and share resources between configured OpenVMS systems in DECnet and/or TCP/IP environments in a bidirectional manner.,remote administration
+SoftPC,SoftPC,Software emulation of x86 hardware.,remote desktop control
+SolarWinds,SolarWinds,Scalable IT Monitoring and Observability app.,remote administration
+SopCast,SopCast,P2P audio and video streaming.,remote administration
+Sophos RED,Sophos RED,Traffic generated betweeen Sophos Remote Ethernet Device and UTM Firewall.,remote administration
+SRMP,SRMP,Spider Remote Monitoring Protocol.,remote administration
+SSH,SSH,Secure Shell is a network protocol that allows data to be exchanged using a secure channel between two networked devices.,remote administration
+SShell,SShell,SSL shell.,remote desktop control
+Su-Mit Telnet,Su-Mit Telnet,Su-Mit Telnet Gateway.,remote administration
+Sun RPC,Sun RPC,Sun RPC is a widely deployed remote procedure call system.,remote desktop control
+SUPDUP,SUPDUP,The SUPDUP protocol provides for login to a remote system over a network with terminal-independent output.,remote administration
+syslog,syslog,A standard for logging program messages.,remote administration
+TeamViewer,TeamViewer,Remote desktop control and file transfer software.,remote desktop control
+TechInline,TechInline,Website that offers remote desktop control.,remote administration
+TechInline,TechInline,Website that offers remote desktop control.,remote desktop control
+Telnet,Telnet,A network protocol used on the Internet or local area networks to provide a bidirectional interactive text-oriented communications facility using a virtual terminal connection.,remote administration
+TELNETS,TELNETS,Telnet protocol over TLS/SSL.,remote administration
+Termius,Termius,SSH client.,remote administration
+Timbuktu,Timbuktu,A remote control software product developed by Motorola. Remote control software allows a user to control another computer across the local network or the Internet; viewing its screen and using its keyboard and mouse as if he or she were sitting in front of it. Timbuktu is compatible with computers running both Mac OS X and Windows.,remote administration
+Timbuktu,Timbuktu,A remote control software product developed by Motorola. Remote control software allows a user to control another computer across the local network or the Internet; viewing its screen and using its keyboard and mouse as if he or she were sitting in front of it. Timbuktu is compatible with computers running both Mac OS X and Windows.,remote desktop control
+TN3270,TN3270,Terminal client.,remote administration
+Trilead SSH-2,Trilead SSH-2,A Java implementation of the SSH protocol.,remote administration
+UiPath,UiPath,UiPath is a software platform for building automation robots to automate business processes; third-party applications; and administrative and IT tasks.,remote administration
+Vagrant,Vagrant,Tool for building and managing virtual machine environments in a single flow.,remote administration
+vCOM,vCOM,Virtual serial port driver.,remote administration
+VMware Remote Authentication,VMware Remote Authentication,VMware Daemon for authentication of remote VMs.,remote desktop control
+VMware Server Console,VMware Server Console,Management console for Cloud computing from VMWare.,remote administration
+VMware vCenter client,VMware vCenter client,VMware vCenter client.,remote administration
+VMware vMotion,VMware vMotion,Allows migration of one Virtual machine from one host to another.,remote desktop control
+VNC,VNC,Graphical desktop sharing protocol.,remote desktop control
+WebEx,WebEx,Cisco's online meeting and web conferencing application.,remote desktop control
+WebEx Connect,WebEx Connect,Logging into WebEx.,remote desktop control
+WinSCP,WinSCP,A free SFTP and FTP client for Windows.,remote administration
+Zoho::Zoho Assist,- Zoho Assist,A remote support and remote access software.,remote desktop control
+Zoom,Zoom,Remote conferencing via cloud computing.,remote desktop control
+Zoom::Zoom Meeting,- Zoom Meeting,Participating in a meeting on Zoom.,remote desktop control

--- a/lookups/cisco_secure_firewall_appid_remote_mgmt_and_desktop_tools.yml
+++ b/lookups/cisco_secure_firewall_appid_remote_mgmt_and_desktop_tools.yml
@@ -1,0 +1,9 @@
+name: cisco_secure_firewall_appid_remote_mgmt_and_desktop_tools
+date: 2025-05-28
+version: 1
+id: eda38373-77c4-4e42-89c8-f53fa58f5319
+author: Nasreddine Bencherchali, Splunk Threat Research Team
+lookup_type: csv
+description: A list of secure firewall application detectors metadata related to remote desktop and remote management utilities.
+min_matches: 1
+case_sensitive_match: false

--- a/lookups/cisco_secure_firewall_filetype_lookup.yml
+++ b/lookups/cisco_secure_firewall_filetype_lookup.yml
@@ -2,7 +2,7 @@ name: cisco_secure_firewall_filetype_lookup
 date: 2025-04-03
 version: 1
 id: 5850e5c3-543c-45b8-8b82-147ed49aba56
-author: Splunk Threat Research Team
+author: Nasreddine Bencherchali, Splunk Threat Research Team
 lookup_type: csv
 description: A list that maps filetypes in cisco secure firewall threat defense with their ids and description
 min_matches: 1

--- a/lookups/cisco_snort_ids_to_threat_mapping.yml
+++ b/lookups/cisco_snort_ids_to_threat_mapping.yml
@@ -2,7 +2,7 @@ name: cisco_snort_ids_to_threat_mapping
 date: 2025-05-12
 version: 1
 id: f08ae6ce-d7a8-423e-a778-be7178a719f9
-author: Splunk Threat Research Team
+author: Bhavin Patel, Nasreddine Bencherchali, Splunk Threat Research Team
 lookup_type: csv
 case_sensitive_match: false
 description: Mapping file of Snort IDs to Threats


### PR DESCRIPTION
The following PR maps some of Network CIM analytics we have to the Cisco datasources and providing test data. Below is the full list of updated analytics:

- Detect Outbound LDAP Traffic
- Detect Outbound SMB Traffic
- Internal Horizontal Port Scan
- Internal Horizontal Port Scan NMAP Top 20
- Internal Vertical Port Scan
- Prohibited Network Traffic Allowed
- Protocol or Port Mismatch
- Protocols passing authentication in cleartext
- TOR Traffic

Due to the nature of the mapping with the CSC TA. The Analytic `Detect Remote Access Software Usage Traffic` cannot be used as is. The current config is mapping the `Application` field to the CIM `app` field. Which is technically accurate. But in order to use this detection as is, we need to map the `ClientApplication` field which does not have an equivalent in CIM.

For this a new equivalent analytic has been created `Cisco Secure Firewall - Remote Access Software Usage Traffic` along with a dedicated lookup that is directly taken from Cisco Secure Firewall App Detectors list.
 