### PR TITLE
Multiple Updates & Fixes

### DIFF
--- a/detections/endpoint/cobalt_strike_named_pipes.yml
+++ b/detections/endpoint/cobalt_strike_named_pipes.yml
@@ -17,32 +17,32 @@ data_source:
 - Sysmon EventID 17
 - Sysmon EventID 18
 search: |
-  `sysmon` EventID=17 OR EventID=18 
+  `sysmon` (EventID=17 OR EventID=18)
   PipeName IN (
-    \\DserNamePipe*, 
-    \\interprocess_*,
-    \\lsarpc_*,
-    \\mojo_*,
-    \\msagent_*, 
-    \\MSSE-*, 
-    \\netlogon_*,
-    \\ntsvcs*,
-    \\postex_*, 
-    \\samr_*,
-    \\spoolss_*, 
-    \\srvsvc_*, 
-    \\status_*, 
-    \\UIA_PIPE*
-    \\win_svc*, 
-    \\winsock*, 
-    \\wkssvc_*,
+    "\\DserNamePipe*",
+    "\\interprocess_*",
+    "\\lsarpc_*",
+    "\\mojo_*",
+    "\\msagent_*",
+    "\\MSSE-*",
+    "\\netlogon_*",
+    "\\ntsvcs*",
+    "\\postex_*",
+    "\\samr_*",
+    "\\spoolss_*",
+    "\\srvsvc_*",
+    "\\status_*",
+    "\\UIA_PIPE"*
+    "\\win_svc*",
+    "\\winsock*",
+    "\\wkssvc_*",
   )
   | stats count min(_time) as firstTime max(_time) as lastTime
   by dest dvc pipe_name process_exec process_guid process_id process_name process_path
-  signature signature_id user_id vendor_product Image PipeName 
+  signature signature_id user_id vendor_product Image PipeName
   | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` 
-  | `cobalt_strike_named_pipes_filter`'
+  | `security_content_ctime(lastTime)`
+  | `cobalt_strike_named_pipes_filter`
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the process name, parent process, and command-line executions from your
   endpoints. If you are using Sysmon, you must have at least version 6.0.4 of the

--- a/detections/endpoint/cobalt_strike_named_pipes.yml
+++ b/detections/endpoint/cobalt_strike_named_pipes.yml
@@ -1,7 +1,7 @@
 name: Cobalt Strike Named Pipes
 id: 5876d429-0240-4709-8b93-ea8330b411b5
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-06-17'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -16,12 +16,33 @@ description: The following analytic detects the use of default or publicly known
 data_source:
 - Sysmon EventID 17
 - Sysmon EventID 18
-search: '`sysmon` EventID=17 OR EventID=18 PipeName IN (\\msagent_*, \\DserNamePipe*,
-  \\srvsvc_*, \\postex_*, \\status_*, \\MSSE-*, \\spoolss_*, \\win_svc*, \\ntsvcs*,
-  \\winsock*, \\UIA_PIPE*) | stats count min(_time) as firstTime max(_time) as lastTime
+search: |
+  `sysmon` EventID=17 OR EventID=18 
+  PipeName IN (
+    \\DserNamePipe*, 
+    \\interprocess_*,
+    \\lsarpc_*,
+    \\mojo_*,
+    \\msagent_*, 
+    \\MSSE-*, 
+    \\netlogon_*,
+    \\ntsvcs*,
+    \\postex_*, 
+    \\samr_*,
+    \\spoolss_*, 
+    \\srvsvc_*, 
+    \\status_*, 
+    \\UIA_PIPE*
+    \\win_svc*, 
+    \\winsock*, 
+    \\wkssvc_*,
+  )
+  | stats count min(_time) as firstTime max(_time) as lastTime
   by dest dvc pipe_name process_exec process_guid process_id process_name process_path
-  signature signature_id user_id vendor_product Image PipeName | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` | `cobalt_strike_named_pipes_filter`'
+  signature signature_id user_id vendor_product Image PipeName 
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` 
+  | `cobalt_strike_named_pipes_filter`'
 how_to_implement: To successfully implement this search, you need to be ingesting
   logs with the process name, parent process, and command-line executions from your
   endpoints. If you are using Sysmon, you must have at least version 6.0.4 of the

--- a/detections/endpoint/detect_renamed_winrar.yml
+++ b/detections/endpoint/detect_renamed_winrar.yml
@@ -1,7 +1,7 @@
 name: Detect Renamed WinRAR
 id: 1b7bfb2c-b8e6-11eb-99ac-acde48001122
-version: 12
-date: '2025-05-02'
+version: 13
+date: '2025-06-16'
 author: Michael Haag, Splunk
 status: production
 type: Hunting
@@ -18,13 +18,15 @@ data_source:
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.original_file_name=WinRAR.exe
-  (Processes.process_name!=rar.exe OR Processes.process_name!=winrar.exe) by Processes.action
-  Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  (Processes.process_name!=rar.exe AND Processes.process_name!=winrar.exe) 
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process 
+  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id 
+  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec 
+  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level 
+  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)`
   | `detect_renamed_winrar_filter`'
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related

--- a/detections/endpoint/excessive_usage_of_cacls_app.yml
+++ b/detections/endpoint/excessive_usage_of_cacls_app.yml
@@ -1,37 +1,56 @@
 name: Excessive Usage Of Cacls App
 id: 0bdf6092-af17-11eb-939a-acde48001122
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-06-17'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly
-description: The following analytic identifies excessive usage of `cacls.exe`, `xcacls.exe`,
-  or `icacls.exe` to change file or folder permissions. It leverages data from Endpoint
-  Detection and Response (EDR) agents, focusing on process names and command-line
-  executions. This activity is significant as it may indicate an adversary attempting
-  to restrict access to malware components or artifacts on a compromised system. If
-  confirmed malicious, this behavior could prevent users from deleting or accessing
+description: |
+  The following analytic identifies excessive usage of `cacls.exe`, `xcacls.exe`,
+  or `icacls.exe` to change file or folder permissions.
+  It looks for 10 or more execution of the aforementioned processes in the span of 1 minute. 
+  It leverages data from Endpoint Detection and Response (EDR) agents, 
+  focusing on process names and command-line executions.
+  This activity is significant as it may indicate an adversary attempting
+  to restrict access to malware components or artifacts on a compromised system.
+  If confirmed malicious, this behavior could prevent users from deleting or accessing
   critical files, aiding in the persistence and concealment of malicious activities.
 data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` values(Processes.dest) as dest
-  values(Processes.user) as user min(_time) as firstTime max(_time) as lastTime values(Processes.action)
-  as action values(Processes.original_file_name) as original_file_name values(Processes.parent_process_exec)
-  as parent_process_exec values(Processes.parent_process_guid) as parent_process_guid
-  values(Processes.parent_process_id) as parent_process_id values(Processes.parent_process_path)
-  as parent_process_path values(Processes.process) as process values(Processes.process_exec)
-  as process_exec values(Processes.process_guid) as process_guid values(Processes.process_hash)
-  as process_hash values(Processes.process_id) as process_id values(Processes.process_integrity_level)
-  as process_integrity_level values(Processes.process_name) as process_name values(Processes.process_path)
-  as process_path values(Processes.user_id) as user_id values(Processes.vendor_product)
-  as vendor_product count from datamodel=Endpoint.Processes where Processes.process_name
-  = "cacls.exe" OR Processes.process_name = "icacls.exe" OR Processes.process_name
-  = "XCACLS.exe" by Processes.parent_process_name Processes.parent_process Processes.dest
-  Processes.user _time span=1m | where count >=10 | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `excessive_usage_of_cacls_app_filter`'
-how_to_implement: The detection is based on data that originates from Endpoint Detection
+search: |
+  | tstats `security_content_summariesonly` 
+    min(_time) as firstTime 
+    max(_time) as lastTime 
+    values(Processes.dest) as dest
+    values(Processes.user) as user 
+    values(Processes.action) as action 
+    values(Processes.original_file_name) as original_file_name 
+    values(Processes.parent_process_exec) as parent_process_exec 
+    values(Processes.parent_process_guid) as parent_process_guid
+    values(Processes.parent_process_id) as parent_process_id 
+    values(Processes.parent_process_path) as parent_process_path 
+    values(Processes.process) as process 
+    values(Processes.process_exec) as process_exec 
+    values(Processes.process_guid) as process_guid 
+    values(Processes.process_hash) as process_hash 
+    values(Processes.process_id) as process_id 
+    values(Processes.process_integrity_level) as process_integrity_level 
+    values(Processes.process_name) as process_name 
+    values(Processes.process_path) as process_path 
+    values(Processes.user_id) as user_id 
+    values(Processes.vendor_product) as vendor_product count 
+  from datamodel=Endpoint.Processes where 
+  Processes.process_name IN( "icacls.exe", "cacls.exe", "xcacls.exe") 
+  by Processes.parent_process_name Processes.parent_process Processes.dest Processes.user _time span=1m 
+  | where count >=10 
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)` 
+  | `excessive_usage_of_cacls_app_filter`
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
   you must ingest logs that contain the process GUID, process name, and parent process.

--- a/detections/endpoint/icacls_deny_command.yml
+++ b/detections/endpoint/icacls_deny_command.yml
@@ -1,11 +1,12 @@
 name: Icacls Deny Command
 id: cf8d753e-a8fe-11eb-8f58-acde48001122
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-06-17'
 author: Teoderick Contreras, Splunk
 status: production
-type: TTP
-description: The following analytic detects instances where an adversary modifies
+type: Anomaly
+description: |
+  The following analytic detects instances where an adversary modifies
   security permissions of a file or directory using commands like "icacls.exe", "cacls.exe",
   or "xcacls.exe" with deny options. It leverages data from Endpoint Detection and
   Response (EDR) agents, focusing on process names and command-line executions. This
@@ -17,17 +18,22 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where Processes.process_name IN( "icacls.exe",
-  "cacls.exe", "xcacls.exe") AND Processes.process IN ("*/deny*", "*/D*") by Processes.action
-  Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `icacls_deny_command_filter`'
-how_to_implement: The detection is based on data that originates from Endpoint Detection
+search: |
+  | tstats `security_content_summariesonly` min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where 
+  Processes.process_name IN ( "icacls.exe", "cacls.exe", "xcacls.exe") AND 
+  Processes.process IN ("*/deny*", "*/d:*", "*/d ") 
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process 
+  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id 
+  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec 
+  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level 
+  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)`
+  | `icacls_deny_command_filter`
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
   you must ingest logs that contain the process GUID, process name, and parent process.

--- a/detections/endpoint/icacls_grant_command.yml
+++ b/detections/endpoint/icacls_grant_command.yml
@@ -1,11 +1,12 @@
 name: ICACLS Grant Command
 id: b1b1e316-accc-11eb-a9b4-acde48001122
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-06-17'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly
-description: The following analytic detects the use of the ICACLS command to grant
+description: |
+  The following analytic detects the use of the ICACLS command to grant
   additional access permissions to files or directories. It leverages data from Endpoint
   Detection and Response (EDR) agents, focusing on specific process names and command-line
   arguments. This activity is significant because it is commonly used by Advanced
@@ -17,17 +18,22 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where Processes.process_name IN( "icacls.exe",
-  "cacls.exe", "xcacls.exe") AND Processes.process IN ("*/grant*", "*/G*") by Processes.action
-  Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `icacls_grant_command_filter`'
-how_to_implement: The detection is based on data that originates from Endpoint Detection
+search: |
+  | tstats `security_content_summariesonly` min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where 
+  Processes.process_name IN ( "icacls.exe", "cacls.exe", "xcacls.exe") AND 
+  Processes.process IN ("*/grant*", "*/g:*", "*/g *") 
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process 
+  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id 
+  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec 
+  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level 
+  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)`
+  | `icacls_grant_command_filter`
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
   you must ingest logs that contain the process GUID, process name, and parent process.

--- a/detections/endpoint/modify_acl_permission_to_files_or_folder.yml
+++ b/detections/endpoint/modify_acl_permission_to_files_or_folder.yml
@@ -1,7 +1,7 @@
 name: Modify ACL permission To Files Or Folder
 id: 7e8458cc-acca-11eb-9e3f-acde48001122
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-06-17'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly
@@ -17,20 +17,27 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` values(Processes.process) as process
-  values(Processes.process_id) as process_id count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where (Processes.process_name = "cacls.exe"
-  OR Processes.process_name = "icacls.exe" OR Processes.process_name = "xcacls.exe")
-  AND Processes.process = "*/G*" AND (Processes.process = "* everyone:*"  OR Processes.process
-  = "* SYSTEM:*" OR Processes.process = "* S-1-1-0:*") by Processes.action Processes.dest
-  Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `modify_acl_permission_to_files_or_folder_filter`'
-how_to_implement: The detection is based on data that originates from Endpoint Detection
+search: |
+  | tstats `security_content_summariesonly` count 
+    min(_time) as firstTime 
+    max(_time) as lastTime
+    values(Processes.process) as process
+    values(Processes.process_id) as process_id 
+  from datamodel=Endpoint.Processes where 
+    Processes.process_name IN ("icacls.exe", "cacls.exe", "xcacls.exe") 
+    Processes.process IN ("*/grant*", "*/g:*", "*/g *") 
+    Processes.process IN ("* Everyone:*", "* SYSTEM:*", "* S-1-1-0:*")
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process 
+  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id 
+  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec 
+  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level 
+  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)`
+  | `modify_acl_permission_to_files_or_folder_filter`
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
   you must ingest logs that contain the process GUID, process name, and parent process.

--- a/detections/endpoint/network_traffic_to_active_directory_web_services_protocol.yml
+++ b/detections/endpoint/network_traffic_to_active_directory_web_services_protocol.yml
@@ -1,7 +1,7 @@
 name: Network Traffic to Active Directory Web Services Protocol
 id: 68a0056c-34cb-455f-b03d-df935ea62c4f
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-06-17'
 author: Michael Haag, Splunk
 status: production
 type: Hunting
@@ -30,7 +30,7 @@ how_to_implement: The detection is based on data that originates from network tr
 known_false_positives: False positives should be limited as the destination port is
   specific to Active Directory Web Services Protocol, however we recommend utilizing
   this analytic to hunt for non-standard processes querying the ADWS port. Filter
-  by App or dest_ip to AD servers and remove known proceses querying ADWS.
+  by App or dest_ip to AD servers and remove known processes querying ADWS.
 references:
 - https://github.com/FalconForceTeam/SOAPHound
 tags:

--- a/detections/endpoint/suspicious_copy_on_system32.yml
+++ b/detections/endpoint/suspicious_copy_on_system32.yml
@@ -22,7 +22,7 @@ data_source:
 search:
   '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where
-  parent_process_name IN (
+  Processes.parent_process_name IN (
     "cmd.exe", 
     "powershell_ise.exe",
     "powershell.exe", 
@@ -35,8 +35,8 @@ search:
     "* \"C:\\Windows\\System32\\*", 
     "* \'C:\\Windows\\System32\\*", 
     "* C:\\Windows\\System32\\*", 
-    "* \"C:\\Windows\\SysWow64\\*"
-    "* \'C:\\Windows\\SysWow64\\*"
+    "* \"C:\\Windows\\SysWow64\\*",
+    "* \'C:\\Windows\\SysWow64\\*",
     "* C:\\Windows\\SysWow64\\*"
   )
   by Processes.action Processes.dest Processes.original_file_name

--- a/detections/endpoint/suspicious_copy_on_system32.yml
+++ b/detections/endpoint/suspicious_copy_on_system32.yml
@@ -1,18 +1,19 @@
 name: Suspicious Copy on System32
 id: ce633e56-25b2-11ec-9e76-acde48001122
-version: 10
-date: '2025-05-02'
-author: Teoderick Contreras, Splunk
+version: 11
+date: '2025-06-17'
+author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production
-type: TTP
-description:
-  The following analytic detects suspicious file copy operations from the
-  System32 or SysWow64 directories, often indicative of malicious activity. It leverages
-  data from Endpoint Detection and Response (EDR) agents, focusing on processes initiated
-  by command-line tools like cmd.exe or PowerShell. This behavior is significant as
-  it may indicate an attempt to execute malicious code using legitimate system tools
-  (LOLBIN). If confirmed malicious, this activity could allow an attacker to execute
-  arbitrary code, potentially leading to system compromise or further lateral movement
+type: Anomaly
+description: |
+  The following analytic detects potentially suspicious file copy operations targeting the
+  System32 or SysWow64 directories as source, often indicative of malicious activity.
+  It leverages data from Endpoint Detection and Response (EDR) agents, 
+  focusing on activity initiated by command-line tools like cmd.exe or PowerShell.
+  This behavior is significant as it may indicate an attempt to evade defenses by copying
+  an existing binary from the system directory and renaming it.
+  If confirmed malicious, this activity could allow an attacker to execute
+  code undetected and potentially leading to system compromise or further lateral movement
   within the network.
 data_source:
   - Sysmon EventID 1
@@ -20,18 +21,34 @@ data_source:
   - CrowdStrike ProcessRollup2
 search:
   '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name
-  IN("cmd.exe", "powershell*","pwsh.exe", "sqlps.exe", "sqltoolsps.exe", "powershell_ise.exe")
-  AND `process_copy` AND Processes.process IN("*\\Windows\\System32\\*", "*\\Windows\\SysWow64\\*")
-  AND Processes.process = "*copy*" by Processes.action Processes.dest Processes.original_file_name
+  as lastTime from datamodel=Endpoint.Processes where
+  parent_process_name IN (
+    "cmd.exe", 
+    "powershell_ise.exe",
+    "powershell.exe", 
+    "pwsh.exe", 
+    "sqlps.exe", 
+    "sqltoolsps.exe"
+  )
+  `process_copy` 
+  Processes.process IN(
+    "* \"C:\\Windows\\System32\\*", 
+    "* 'C:\\Windows\\System32\\*", 
+    "* C:\\Windows\\System32\\*", 
+    "* \"C:\\Windows\\SysWow64\\*"
+    "* 'C:\\Windows\\SysWow64\\*"
+    "* C:\\Windows\\SysWow64\\*"
+  )
+  by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
   Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
   Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | eval splitted_commandline=split(process," ") | eval first_cmdline=lower(mvindex(splitted_commandline,0))
-  | where NOT LIKE(first_cmdline,"%\\windows\\system32\\%") AND NOT LIKE(first_cmdline,"%\\windows\\syswow64\\%")
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` |`suspicious_copy_on_system32_filter`'
+  Processes.user Processes.user_id Processes.vendor_product 
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)` 
+  | `suspicious_copy_on_system32_filter`'
 how_to_implement:
   The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related

--- a/detections/endpoint/suspicious_copy_on_system32.yml
+++ b/detections/endpoint/suspicious_copy_on_system32.yml
@@ -31,7 +31,7 @@ search: |
     "sqltoolsps.exe"
   )
   `process_copy` 
-  Processes.process IN(
+  Processes.process IN (
     "* \"C:\\Windows\\System32\\*", 
     "* \'C:\\Windows\\System32\\*", 
     "* C:\\Windows\\System32\\*", 
@@ -48,7 +48,7 @@ search: |
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 
-  | `suspicious_copy_on_system32_filter`'
+  | `suspicious_copy_on_system32_filter`
 how_to_implement: |
   The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related

--- a/detections/endpoint/suspicious_copy_on_system32.yml
+++ b/detections/endpoint/suspicious_copy_on_system32.yml
@@ -19,8 +19,8 @@ data_source:
   - Sysmon EventID 1
   - Windows Event Log Security 4688
   - CrowdStrike ProcessRollup2
-search:
-  '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where
   Processes.parent_process_name IN (
     "cmd.exe", 
@@ -49,7 +49,7 @@ search:
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 
   | `suspicious_copy_on_system32_filter`'
-how_to_implement:
+how_to_implement: |
   The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -59,7 +59,7 @@ how_to_implement:
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: every user may do this event but very un-ussual.
+known_false_positives: Copying files from System directories can happen for multiple admin reasons, allbeit rare without approval. Apply additional filters where needed.
 references:
   - https://www.hybrid-analysis.com/sample/8da5b75b6380a41eee3a399c43dfe0d99eeefaa1fd21027a07b1ecaa4cd96fdd?environmentId=120
   - https://www.microsoft.com/en-us/security/blog/2023/05/24/volt-typhoon-targets-us-critical-infrastructure-with-living-off-the-land-techniques/

--- a/detections/endpoint/suspicious_copy_on_system32.yml
+++ b/detections/endpoint/suspicious_copy_on_system32.yml
@@ -33,10 +33,10 @@ search:
   `process_copy` 
   Processes.process IN(
     "* \"C:\\Windows\\System32\\*", 
-    "* 'C:\\Windows\\System32\\*", 
+    "* \'C:\\Windows\\System32\\*", 
     "* C:\\Windows\\System32\\*", 
     "* \"C:\\Windows\\SysWow64\\*"
-    "* 'C:\\Windows\\SysWow64\\*"
+    "* \'C:\\Windows\\SysWow64\\*"
     "* C:\\Windows\\SysWow64\\*"
   )
   by Processes.action Processes.dest Processes.original_file_name

--- a/detections/endpoint/windows_file_and_directory_permissions_enable_inheritance.yml
+++ b/detections/endpoint/windows_file_and_directory_permissions_enable_inheritance.yml
@@ -3,9 +3,6 @@ id: 0247f90a-aca4-47b2-a94d-e30f445d7b41
 version: 3
 date: '2025-05-02'
 author: Teoderick Contreras, Splunk
-data_source:
-- Sysmon EventID 1
-- Windows Event Log Security 4688
 type: Hunting
 status: production
 description: The following analytic detects the enabling of permission inheritance
@@ -16,6 +13,9 @@ description: The following analytic detects the enabling of permission inheritan
   can indicate legitimate administrative actions but may also signal attempts to override
   restrictive custom permissions, potentially exposing sensitive files to unauthorized
   access.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
 search: '| tstats `security_content_summariesonly` min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.process_name IN( "icacls.exe",
   "cacls.exe", "xcacls.exe") AND Processes.process = "*/inheritance:e*" by Processes.action

--- a/detections/endpoint/windows_files_and_dirs_access_rights_modification_via_icacls.yml
+++ b/detections/endpoint/windows_files_and_dirs_access_rights_modification_via_icacls.yml
@@ -1,6 +1,6 @@
 name: Windows Files and Dirs Access Rights Modification Via Icacls
 id: c76b796c-27e1-4520-91c4-4a58695c749e
-version: 8
+version: 9
 date: '2025-05-02'
 author: Teoderick Contreras, Splunk
 status: production

--- a/detections/endpoint/windows_files_and_dirs_access_rights_modification_via_icacls.yml
+++ b/detections/endpoint/windows_files_and_dirs_access_rights_modification_via_icacls.yml
@@ -5,11 +5,8 @@ date: '2025-05-02'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
-data_source:
-- Sysmon EventID 1
-- Windows Event Log Security 4688
-- CrowdStrike ProcessRollup2
-description: The following analytic identifies the modification of security permissions
+description: |
+  The following analytic identifies the modification of security permissions
   on files or directories using tools like icacls.exe, cacls.exe, or xcacls.exe. It
   leverages data from Endpoint Detection and Response (EDR) agents, focusing on specific
   command-line executions. This activity is significant as it is commonly used by
@@ -17,16 +14,24 @@ description: The following analytic identifies the modification of security perm
   maintain control over compromised systems. If confirmed malicious, this behavior
   could allow attackers to hinder investigation, impede remediation efforts, and maintain
   persistent access to the compromised environment.
-search: '| tstats `security_content_summariesonly` min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where Processes.process_name IN( "icacls.exe",
-  "cacls.exe","xcacls.exe") AND Processes.process IN ("*:R*", "*:W*", "*:F*", "*:C*",,
-  "*:N*","*/P*", "*/E*") by Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `windows_files_and_dirs_access_rights_modification_via_icacls_filter`'
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: |
+  | tstats `security_content_summariesonly` min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where 
+  Processes.process_name IN ("icacls.exe", "cacls.exe","xcacls.exe") AND 
+  Processes.process IN ("*:R*", "*:W*", "*:F*", "*:C*", "*:N*", "*/P*", "*/E*") 
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
+  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id 
+  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
+  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
+  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product 
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)` 
+  | `windows_files_and_dirs_access_rights_modification_via_icacls_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,


### PR DESCRIPTION
This PR introduces a couple of update and fixes:

- `Cobalt Strike Named Pipes` - Added additional named pipes
- `Detect Renamed WinRAR` - Fixed issue in logic as reported in #3550
- `Icacls Deny Command` - Enhanced the logic by adding additional options
- `ICACLS Grant Command` - Enhanced the logic by adding additional options
- `Modify ACL permission To Files Or Folder` - Enhanced the logic by adding additional options
- `Suspicious Copy on System32` - Reworked the logic to avoid FPs and FNs. Namely the previous logic did not take into account xcopy (and its sisters) starting from a full path (AKA containing System32 or SysWOW64). It also incorrectly split the CommandLine on a space character which introduces inconsistency in the logic