### PR TITLE
Update PowerShell parameter aliases

### DIFF
--- a/detections/endpoint/getwmiobject_ds_computer_with_powershell.yml
+++ b/detections/endpoint/getwmiobject_ds_computer_with_powershell.yml
@@ -1,7 +1,7 @@
 name: GetWmiObject Ds Computer with PowerShell
 id: 7141122c-3bc2-4aaa-ab3b-7a85a0bbefc3
-version: 6
-date: '2025-05-02'
+version: 7
+date: '2025-07-03'
 author: Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -20,8 +20,8 @@ data_source:
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where (Processes.process_name="powershell.exe")
-  (Processes.process=*Get-WmiObject* AND Processes.process="*namespace root\\directory\\ldap*"
-  AND Processes.process="*class ds_computer*") by Processes.action Processes.dest
+  (Processes.process=*Get-WmiObject* AND (Processes.process="*namespace root\\directory\\ldap*" OR Processes.process="*ns root\\directory\\ldap*")
+  AND (Processes.process="*class ds_computer*" OR Processes.process="*classname ds_computer*")) by Processes.action Processes.dest
   Processes.original_file_name Processes.parent_process Processes.parent_process_exec
   Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
   Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid

--- a/detections/endpoint/getwmiobject_ds_computer_with_powershell_script_block.yml
+++ b/detections/endpoint/getwmiobject_ds_computer_with_powershell_script_block.yml
@@ -1,7 +1,7 @@
 name: GetWmiObject Ds Computer with PowerShell Script Block
 id: 29b99201-723c-4118-847a-db2b3d3fb8ea
-version: 8
-date: '2025-06-24'
+version: 9
+date: '2025-07-03'
 author: Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -16,8 +16,8 @@ description:
 data_source:
   - Powershell Script Block Logging 4104
 search:
-  '`powershell` EventCode=4104 (ScriptBlockText=*Get-WmiObject* AND ScriptBlockText="*namespace
-  root\\directory\\ldap*" AND ScriptBlockText="*class ds_computer*") | fillnull |
+  '`powershell` EventCode=4104 (ScriptBlockText=*Get-WmiObject* AND (ScriptBlockText="*namespace
+  root\\directory\\ldap*" OR ScriptBlockText="*ns root\\directory\\ldap*") AND (ScriptBlockText="*class ds_computer*" OR ScriptBlockText="*classname ds_computer*")) | fillnull |
   stats count min(_time) as firstTime max(_time) as lastTime by dest signature signature_id
   user_id vendor_product EventID Guid Opcode Name Path ProcessID ScriptBlockId ScriptBlockText
   | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `getwmiobject_ds_computer_with_powershell_script_block_filter`'

--- a/detections/endpoint/getwmiobject_ds_group_with_powershell.yml
+++ b/detections/endpoint/getwmiobject_ds_group_with_powershell.yml
@@ -1,7 +1,7 @@
 name: GetWmiObject Ds Group with PowerShell
 id: df275a44-4527-443b-b884-7600e066e3eb
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-07-03'
 author: Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -19,8 +19,8 @@ data_source:
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where (Processes.process_name="powershell.exe")
-  (Processes.process=*Get-WmiObject* AND Processes.process="*namespace root\\directory\\ldap*"
-  AND Processes.process="*class ds_group*") by Processes.action Processes.dest Processes.original_file_name
+  (Processes.process=*Get-WmiObject* AND (Processes.process="*namespace root\\directory\\ldap*" OR Processes.process="*ns root\\directory\\ldap*")
+  AND (Processes.process="*class ds_group*" OR Processes.process="*classname ds_group*")) by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
   Processes.process Processes.process_exec Processes.process_guid Processes.process_hash

--- a/detections/endpoint/getwmiobject_ds_group_with_powershell_script_block.yml
+++ b/detections/endpoint/getwmiobject_ds_group_with_powershell_script_block.yml
@@ -1,7 +1,7 @@
 name: GetWmiObject Ds Group with PowerShell Script Block
 id: 67740bd3-1506-469c-b91d-effc322cc6e5
-version: 9
-date: '2025-06-24'
+version: 10
+date: '2025-07-03'
 author: Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -16,8 +16,8 @@ description:
 data_source:
   - Powershell Script Block Logging 4104
 search:
-  '`powershell` EventCode=4104 (ScriptBlockText=*Get-WmiObject* AND ScriptBlockText="*namespace
-  root\\directory\\ldap*" AND ScriptBlockText="*class ds_group*") | fillnull | stats
+  '`powershell` EventCode=4104 (ScriptBlockText=*Get-WmiObject* AND (ScriptBlockText="*namespace
+  root\\directory\\ldap*" OR ScriptBlockText="*ns root\\directory\\ldap*") AND (ScriptBlockText="*class ds_group*" OR ScriptBlockText="*classname ds_group*")) | fillnull | stats
   count min(_time) as firstTime max(_time) as lastTime by dest signature signature_id
   user_id vendor_product EventID Guid Opcode Name Path ProcessID ScriptBlockId ScriptBlockText
   | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` |`getwmiobject_ds_group_with_powershell_script_block_filter`'

--- a/detections/endpoint/getwmiobject_ds_user_with_powershell.yml
+++ b/detections/endpoint/getwmiobject_ds_user_with_powershell.yml
@@ -1,7 +1,7 @@
 name: GetWmiObject DS User with PowerShell
 id: 22d3b118-04df-11ec-8fa3-acde48001122
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-07-03'
 author: Teoderick Contreras, Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -21,7 +21,7 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   as lastTime from datamodel=Endpoint.Processes where (Processes.process_name="cmd.exe"
   OR Processes.process_name="powershell*") AND Processes.process = "*get-wmiobject*"
   AND Processes.process = "*ds_user*" AND Processes.process = "*root\\directory\\ldap*"
-  AND Processes.process = "*-namespace*" by Processes.action Processes.dest Processes.original_file_name
+  AND (Processes.process = "*-namespace*" OR Processes.process = "*-ns*") by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
   Processes.process Processes.process_exec Processes.process_guid Processes.process_hash

--- a/detections/endpoint/getwmiobject_ds_user_with_powershell_script_block.yml
+++ b/detections/endpoint/getwmiobject_ds_user_with_powershell_script_block.yml
@@ -1,7 +1,7 @@
 name: GetWmiObject DS User with PowerShell Script Block
 id: fabd364e-04f3-11ec-b34b-acde48001122
-version: 9
-date: '2025-05-02'
+version: 10
+date: '2025-07-03'
 author: Teoderick Contreras, Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -16,7 +16,7 @@ description: The following analytic detects the execution of the `Get-WmiObject`
 data_source:
 - Powershell Script Block Logging 4104
 search: '`powershell` EventCode=4104 ScriptBlockText = "*get-wmiobject*" ScriptBlockText
-  = "*ds_user*" ScriptBlockText = "*-namespace*" ScriptBlockText = "*root\\directory\\ldap*"
+  = "*ds_user*" (ScriptBlockText = "*-namespace*" OR ScriptBlockText = "*-ns*") ScriptBlockText = "*root\\directory\\ldap*"
   | fillnull | stats count min(_time) as firstTime max(_time) as lastTime by dest
   signature signature_id user_id vendor_product EventID Guid Opcode Name Path ProcessID
   ScriptBlockId ScriptBlockText | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`

--- a/detections/endpoint/interactive_session_on_remote_endpoint_with_powershell.yml
+++ b/detections/endpoint/interactive_session_on_remote_endpoint_with_powershell.yml
@@ -1,7 +1,7 @@
 name: Interactive Session on Remote Endpoint with PowerShell
 id: a4e8f3a4-48b2-11ec-bcfc-3e22fbd008af
-version: 11
-date: '2025-06-24'
+version: 12
+date: '2025-07-03'
 author: Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -17,7 +17,7 @@ description:
 data_source:
   - Powershell Script Block Logging 4104
 search:
-  '`powershell` EventCode=4104 (ScriptBlockText="*Enter-PSSession*" AND ScriptBlockText="*-ComputerName*")
+  '`powershell` EventCode=4104 (ScriptBlockText="*Enter-PSSession*" AND (ScriptBlockText="*-ComputerName*" OR ScriptBlockText="*-Cn*"))
   | fillnull | stats count min(_time) as firstTime max(_time) as lastTime by dest
   signature signature_id user_id vendor_product EventID Guid Opcode Name Path ProcessID
   ScriptBlockId ScriptBlockText | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`

--- a/detections/endpoint/remote_process_instantiation_via_winrm_and_powershell.yml
+++ b/detections/endpoint/remote_process_instantiation_via_winrm_and_powershell.yml
@@ -1,7 +1,7 @@
 name: Remote Process Instantiation via WinRM and PowerShell
 id: ba24cda8-4716-11ec-8009-3e22fbd008af
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-07-03'
 author: Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -19,7 +19,7 @@ data_source:
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where `process_powershell` (Processes.process="*Invoke-Command*"
-  AND Processes.process="*-ComputerName*") by Processes.action Processes.dest Processes.original_file_name
+  AND (Processes.process="*-ComputerName*" OR Processes.process="*-Cn*")) by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
   Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
@@ -41,6 +41,7 @@ known_false_positives: Administrators may leverage WinRM and `Invoke-Command` to
 references:
 - https://attack.mitre.org/techniques/T1021/006/
 - https://pentestlab.blog/2018/05/15/lateral-movement-winrm/
+- https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/invoke-command?view=powershell-7.4
 drilldown_searches:
 - name: View the detection results for - "$dest$"
   search: '%original_detection_search% | search  dest = "$dest$"'

--- a/detections/endpoint/remote_process_instantiation_via_winrm_and_powershell_script_block.yml
+++ b/detections/endpoint/remote_process_instantiation_via_winrm_and_powershell_script_block.yml
@@ -1,7 +1,7 @@
 name: Remote Process Instantiation via WinRM and PowerShell Script Block
 id: 7d4c618e-4716-11ec-951c-3e22fbd008af
-version: 9
-date: '2025-06-24'
+version: 10
+date: '2025-07-03'
 author: Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -16,7 +16,7 @@ description:
 data_source:
   - Powershell Script Block Logging 4104
 search:
-  '`powershell` EventCode=4104 (ScriptBlockText="*Invoke-Command*" AND ScriptBlockText="*-ComputerName*")
+  '`powershell` EventCode=4104 (ScriptBlockText="*Invoke-Command*" AND (ScriptBlockText="*-ComputerName*" OR ScriptBlockText="*-Cn*"))
   | fillnull | stats count min(_time) as firstTime max(_time) as lastTime by dest
   signature signature_id user_id vendor_product EventID Guid Opcode Name Path ProcessID
   ScriptBlockId ScriptBlockText | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`

--- a/detections/endpoint/remote_process_instantiation_via_wmi_and_powershell.yml
+++ b/detections/endpoint/remote_process_instantiation_via_wmi_and_powershell.yml
@@ -1,7 +1,7 @@
 name: Remote Process Instantiation via WMI and PowerShell
 id: 112638b4-4634-11ec-b9ab-3e22fbd008af
-version: 16
-date: '2025-05-02'
+version: 17
+date: '2025-07-03'
 author: Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -18,7 +18,7 @@ data_source:
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where `process_powershell` (Processes.process="*Invoke-WmiMethod*"
-  AND Processes.process="*-CN*" AND Processes.process="*-Class Win32_Process*" AND  Processes.process="*-Name
+  AND (Processes.process="*-CN*" OR Processes.process="*-ComputerName*") AND Processes.process="*-Class Win32_Process*" AND  Processes.process="*-Name
   create*") by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
   Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
   Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
@@ -35,7 +35,7 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: Administrators may leverage WWMI and powershell.exe to start
+known_false_positives: Administrators may leverage WMI and powershell.exe to start
   a process on remote systems, but this activity is usually limited to a small set
   of hosts or users.
 references:


### PR DESCRIPTION
### Details

This PR consists of some batch updates to PowerShell activity-based detections that include parameters in the detection logic for which a parameter alias exists.

The commands, and parameter aliases for said commands, that were looked at for this PR are as follows (links to relevant docs for aliases):

- [Get-WmiObject](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-wmiobject?view=powershell-5.1#parameters)
  - [Class / ClassName](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-wmiobject?view=powershell-5.1#-class)
  - [Namespace / NS](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-wmiobject?view=powershell-5.1#-namespace)
- [Invoke-WmiMethod](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/invoke-wmimethod?view=powershell-5.1#parameters)
  - [ComputerName / Cn](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/invoke-wmimethod?view=powershell-5.1#-computername)
- [Invoke-Command](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/invoke-command?view=powershell-5.1#parameters)
  - [ComputerName / Cn](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/invoke-command?view=powershell-5.1#-computername)
- [Enter-PSSession](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/enter-pssession?view=powershell-5.1#parameters)
  - [ComputerName / Cn](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/enter-pssession?view=powershell-5.1#-computername)

The purpose of these updates is to ensure the desired activity is captured by the detection, regardless of whether a parameter name or alias is used, for any parameters which have an alias.

The changes were made with minimum # LOC modified in mind, but happy to adjust formatting to whatever best practice is for the repo. Opted not to reflow any search blocks with long lines as a result of the added logic, but it'd be easy to adjust if that's the desired process. I additionally attempted to maintain consistent style with whichever individual detection was being modified, with minimum modification/potential disruption in mind, but would again be happy to refactor into more repeatable logic (e.g., a macro or two to replace components that are repeated across detections).

I'm unsure if this PR covers the exhaustive list of PowerShell-activity based detections with potential parameter alias visibility gaps, but I plan to keep searching/parsing some more in an attempt to surface any others.

Detections updated:

- `endpoint/getwmiobject_ds_computer_with_powershell`
- `endpoint/getwmiobject_ds_computer_with_powershell_script_block`
- `endpoint/getwmiobject_ds_group_with_powershell`
- `endpoint/getwmiobject_ds_group_with_powershell_script_block`
- `endpoint/getwmiobject_ds_user_with_powershell`
- `endpoint/getwmiobject_ds_user_with_powershell_script_block`
- `endpoint/interactive_session_on_remote_endpoint_with_powershell`
- `endpoint/remote_process_instantiation_via_winrm_and_powershell`
- `endpoint/remote_process_instantiation_via_winrm_and_powershell_script_block`
- `endpoint/remote_process_instantiation_via_wmi_and_powershell`

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/9.3.2411/manage-apps-and-add-ons-in-splunk-cloud-platform/manage-private-apps-on-your-splunk-cloud-platform-deployment#ariaid-title7) but the short version is that any changes to lookup files need to bump the the date and version in the associated YAML file.
