### PR TITLE
O365 BEC Email Hiding Rule Created (again)

### DIFF
--- a/detections/cloud/o365_bec_email_hiding_rule_created.yml
+++ b/detections/cloud/o365_bec_email_hiding_rule_created.yml
@@ -37,7 +37,7 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Potential BEC mailbox rule "$Name$" was created by $user$
+  message: Potential BEC mailbox rule - $Name$ was created by user - $user$
   risk_objects:
   - field: user
     type: user

--- a/detections/cloud/o365_bec_email_hiding_rule_created.yml
+++ b/detections/cloud/o365_bec_email_hiding_rule_created.yml
@@ -29,7 +29,7 @@ references:
 - https://attack.mitre.org/techniques/T1564/008/
 drilldown_searches:
 - name: View the detection results for - "$user$"
-  search: '%original_detection_search% | search  dest = "$user$"'
+  search: '%original_detection_search% | search  user = "$user$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 - name: View risk events for the last 7 days for $user$

--- a/detections/cloud/o365_bec_email_hiding_rule_created.yml
+++ b/detections/cloud/o365_bec_email_hiding_rule_created.yml
@@ -37,7 +37,7 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Potential BEC mailbox rule was created by $user$
+  message: Potential BEC mailbox rule "$Name$" was created by $user$
   risk_objects:
   - field: user
     type: user

--- a/detections/cloud/o365_bec_email_hiding_rule_created.yml
+++ b/detections/cloud/o365_bec_email_hiding_rule_created.yml
@@ -1,7 +1,7 @@
 name: O365 BEC Email Hiding Rule Created
 id: 603ebac2-f157-4df7-a6ac-34e8d0350f86
-version: 3
-date: '2025-07-01'
+version: 4
+date: '2025-07-23'
 author: '0xC0FFEEEE, Github Community'
 type: TTP
 status: production
@@ -18,6 +18,7 @@ search: |-
   | eval read_score=if(MarkAsRead="True", 1, 0) 
   | eval folder_score=if(match(MoveToFolder, "^(RSS|Conversation History|Archive)"), 1, 0) 
   | eval suspicious_score=entropy_score+len_score+read_score+folder_score 
+  | where suspicious_score>2 
   | `o365_bec_email_hiding_rule_created_filter`
 how_to_implement: You must install the Splunk Microsoft Office 365 Add-on and ingest
   Office 365 management activity events. You also need to have the Splunk TA URL 


### PR DESCRIPTION
### Details

Made a minor omission of the score threshold in my previous update.

Couple of other minor changes; fixing the drilldown field and updating the risk message

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.
