### PR TITLE
removed detections for 5.12.0

### DIFF
--- a/contentctl.yml
+++ b/contentctl.yml
@@ -3,7 +3,7 @@ app:
   uid: 3449
   title: ES Content Updates
   appid: DA-ESS-ContentUpdate
-  version: 5.11.0
+  version: 5.12.0
   description: Explore the Analytic Stories included with ES Content Updates.
   prefix: ESCU
   label: ESCU

--- a/removed/detections/any_powershell_downloadfile.yml
+++ b/removed/detections/any_powershell_downloadfile.yml
@@ -1,31 +1,31 @@
-name: Any Powershell DownloadString
-id: 4d015ef2-7adf-11eb-95da-acde48001122
-version: 14
-date: '2025-07-29'
+name: Any Powershell DownloadFile
+id: 1a93b7ea-7af7-11eb-adb5-acde48001122
+version: '16'
+date: '2025-06-23'
 author: Michael Haag, Splunk
-status: deprecated
+status: removed
 type: TTP
-description: The following analytic detects the use of PowerShell's `DownloadString`
+description: The following analytic detects the use of PowerShell's `DownloadFile`
   method to download files. It leverages data from Endpoint Detection and Response
-  (EDR) agents, focusing on process execution logs that include command-line details.
-  This activity is significant because `DownloadString` is commonly used in malicious
-  PowerShell scripts to fetch and execute remote code. If confirmed malicious, this
-  behavior could allow an attacker to download and run arbitrary code, potentially
-  leading to unauthorized access, data exfiltration, or further compromise of the
-  affected system.
+  (EDR) agents, focusing on process execution logs. This activity is significant as
+  it is commonly used in malicious frameworks to download and execute additional payloads.
+  If confirmed malicious, this could lead to unauthorized code execution, data exfiltration,
+  or further compromise of the system. Analysts should investigate the source and
+  destination of the download and review AMSI or PowerShell transaction logs for additional
+  context.
 data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_powershell` Processes.process=*.DownloadString*
+  as lastTime from datamodel=Endpoint.Processes where `process_powershell` Processes.process=*DownloadFile*
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
   Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
   Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
   Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
   Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)`|
-  `any_powershell_downloadstring_filter`'
+  `any_powershell_downloadfile_filter`'
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -39,10 +39,9 @@ known_false_positives: False positives may be present and filtering will need to
   by parent process or command line argument. It may be required to modify this query
   to an EDR product for more granular coverage.
 references:
-- https://docs.microsoft.com/en-us/dotnet/api/system.net.webclient.downloadstring?view=net-5.0
+- https://docs.microsoft.com/en-us/dotnet/api/system.net.webclient.downloadfile?view=net-5.0
 - https://blog.malwarebytes.com/malwarebytes-news/2021/02/lazyscripter-from-empire-to-double-rat/
 - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1059.001/T1059.001.md
-- https://thedfirreport.com/2023/05/22/icedid-macro-ends-in-nokoyawa-ransomware/
 drilldown_searches:
 - name: View the detection results for - "$user$" and "$dest$"
   search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
@@ -59,7 +58,7 @@ drilldown_searches:
   latest_offset: $info_max_time$
 rba:
   message: An instance of $parent_process_name$ spawning $process_name$ was identified
-    on endpoint $dest$ by user $user$. This behavior identifies the use of DownloadString
+    on endpoint $dest$ by user $user$. This behavior identifies the use of DownloadFile
     within PowerShell.
   risk_objects:
   - field: user
@@ -75,19 +74,23 @@ rba:
     type: process_name
 tags:
   analytic_story:
-  - Winter Vivern
+  - Log4Shell CVE-2021-44228
   - Phemedrone Stealer
   - Malicious PowerShell
+  - PXA Stealer
+  - China-Nexus Threat Activity
   - Data Destruction
-  - SysAid On-Prem Software CVE-2023-47246 Vulnerability
+  - Braodo Stealer
   - PHP-CGI RCE Attack on Japanese Organizations
   - Hermetic Wiper
-  - IcedID
   - Ingress Tool Transfer
-  - HAFNIUM Group
+  - Salt Typhoon
   - XWorm
-  - Scattered Spider
+  - DarkCrystal RAT
+  - Crypto Stealer
   asset_type: Endpoint
+  cve:
+  - CVE-2021-44228
   mitre_attack_id:
   - T1059.001
   - T1105

--- a/removed/detections/any_powershell_downloadstring.yml
+++ b/removed/detections/any_powershell_downloadstring.yml
@@ -1,31 +1,31 @@
-name: Any Powershell DownloadFile
-id: 1a93b7ea-7af7-11eb-adb5-acde48001122
-version: '16'
-date: '2025-06-23'
+name: Any Powershell DownloadString
+id: 4d015ef2-7adf-11eb-95da-acde48001122
+version: 14
+date: '2025-07-29'
 author: Michael Haag, Splunk
-status: deprecated
+status: removed
 type: TTP
-description: The following analytic detects the use of PowerShell's `DownloadFile`
+description: The following analytic detects the use of PowerShell's `DownloadString`
   method to download files. It leverages data from Endpoint Detection and Response
-  (EDR) agents, focusing on process execution logs. This activity is significant as
-  it is commonly used in malicious frameworks to download and execute additional payloads.
-  If confirmed malicious, this could lead to unauthorized code execution, data exfiltration,
-  or further compromise of the system. Analysts should investigate the source and
-  destination of the download and review AMSI or PowerShell transaction logs for additional
-  context.
+  (EDR) agents, focusing on process execution logs that include command-line details.
+  This activity is significant because `DownloadString` is commonly used in malicious
+  PowerShell scripts to fetch and execute remote code. If confirmed malicious, this
+  behavior could allow an attacker to download and run arbitrary code, potentially
+  leading to unauthorized access, data exfiltration, or further compromise of the
+  affected system.
 data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_powershell` Processes.process=*DownloadFile*
+  as lastTime from datamodel=Endpoint.Processes where `process_powershell` Processes.process=*.DownloadString*
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
   Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
   Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
   Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
   Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)`|
-  `any_powershell_downloadfile_filter`'
+  `any_powershell_downloadstring_filter`'
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -39,9 +39,10 @@ known_false_positives: False positives may be present and filtering will need to
   by parent process or command line argument. It may be required to modify this query
   to an EDR product for more granular coverage.
 references:
-- https://docs.microsoft.com/en-us/dotnet/api/system.net.webclient.downloadfile?view=net-5.0
+- https://docs.microsoft.com/en-us/dotnet/api/system.net.webclient.downloadstring?view=net-5.0
 - https://blog.malwarebytes.com/malwarebytes-news/2021/02/lazyscripter-from-empire-to-double-rat/
 - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1059.001/T1059.001.md
+- https://thedfirreport.com/2023/05/22/icedid-macro-ends-in-nokoyawa-ransomware/
 drilldown_searches:
 - name: View the detection results for - "$user$" and "$dest$"
   search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
@@ -58,7 +59,7 @@ drilldown_searches:
   latest_offset: $info_max_time$
 rba:
   message: An instance of $parent_process_name$ spawning $process_name$ was identified
-    on endpoint $dest$ by user $user$. This behavior identifies the use of DownloadFile
+    on endpoint $dest$ by user $user$. This behavior identifies the use of DownloadString
     within PowerShell.
   risk_objects:
   - field: user
@@ -74,23 +75,19 @@ rba:
     type: process_name
 tags:
   analytic_story:
-  - Log4Shell CVE-2021-44228
+  - Winter Vivern
   - Phemedrone Stealer
   - Malicious PowerShell
-  - PXA Stealer
-  - China-Nexus Threat Activity
   - Data Destruction
-  - Braodo Stealer
+  - SysAid On-Prem Software CVE-2023-47246 Vulnerability
   - PHP-CGI RCE Attack on Japanese Organizations
   - Hermetic Wiper
+  - IcedID
   - Ingress Tool Transfer
-  - Salt Typhoon
+  - HAFNIUM Group
   - XWorm
-  - DarkCrystal RAT
-  - Crypto Stealer
+  - Scattered Spider
   asset_type: Endpoint
-  cve:
-  - CVE-2021-44228
   mitre_attack_id:
   - T1059.001
   - T1105

--- a/removed/detections/windows_installutil_uninstall_option_with_network.yml
+++ b/removed/detections/windows_installutil_uninstall_option_with_network.yml
@@ -3,7 +3,7 @@ id: 1a52c836-43ef-11ec-a36c-acde48001122
 version: 13
 date: '2025-06-26'
 author: Michael Haag, Splunk
-status: deprecated
+status: removed
 type: TTP
 description: The following analytic identifies the use of Windows InstallUtil.exe
   making a remote network connection using the `/u` (uninstall) switch. This detection

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-contentctl==5.5.7
+contentctl==5.5.8


### PR DESCRIPTION
Removed as per https://help.splunk.com/en/splunk-enterprise-security-8/security-content-update/how-to-use-splunk-security-content/5.10/use-splunk-security-content/deprecated-analytics-in-escu