### PR TITLE
Remove duplicate filter macro

### DIFF
--- a/detections/endpoint/windows_rundll32_load_dll_in_temp_dir.yml
+++ b/detections/endpoint/windows_rundll32_load_dll_in_temp_dir.yml
@@ -1,22 +1,23 @@
 name: Windows Rundll32 Load DLL in Temp Dir
 id: 520da6fa-7d5d-4a3b-9c61-1087517b8d0f
-version: 1
-date: '2025-07-29'
+version: 2
+date: '2025-08-22'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly
-description: This detection identifies instances where rundll32.exe is used to load a DLL from a temporary directory, such as C:\Users\<User>\AppData\Local\Temp\ or C:\Windows\Temp\. While rundll32.exe is a legitimate Windows utility used to execute functions exported from DLLs, its use to load libraries from temporary locations is highly suspicious. These directories are commonly used by malware and red team tools to stage payloads or execute code in-memory without writing it to more persistent locations. This behavior often indicates defense evasion, initial access, or privilege escalation, especially when the DLL is unsigned, recently written, or executed shortly after download. In normal user workflows, DLLs are not typically loaded from Temp paths, making this a high-fidelity indicator of potentially malicious activity. Monitoring this pattern is essential for detecting threats that attempt to blend in with native system processes while bypassing traditional application controls. 
+description: This detection identifies instances where rundll32.exe is used to load a DLL from a temporary directory, such as C:\Users\<User>\AppData\Local\Temp\ or C:\Windows\Temp\. While rundll32.exe is a legitimate Windows utility used to execute functions exported from DLLs, its use to load libraries from temporary locations is highly suspicious. These directories are commonly used by malware and red team tools to stage payloads or execute code in-memory without writing it to more persistent locations. This behavior often indicates defense evasion, initial access, or privilege escalation, especially when the DLL is unsigned, recently written, or executed shortly after download. In normal user workflows, DLLs are not typically loaded from Temp paths, making this a high-fidelity indicator of potentially malicious activity. Monitoring this pattern is essential for detecting threats that attempt to blend in with native system processes while bypassing traditional application controls.
 data_source:
-- Sysmon EventID 1
-search: '| tstats `security_content_summariesonly` min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes 
+  - Sysmon EventID 1
+search:
+  '| tstats `security_content_summariesonly` min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where `process_rundll32` AND Processes.process IN ("*temp\\*", "*\\tmp\\*")
-  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product 
-  | `drop_dm_object_name(Processes)` 
-  | `security_content_ctime(firstTime)` 
-  | `security_content_ctime(lastTime)` 
-  | `rundll_loading_dll_by_ordinal_filter`
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
   | `windows_rundll32_load_dll_in_temp_dir_filter`'
-how_to_implement: The detection is based on data that originates from Endpoint Detection
+how_to_implement:
+  The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
   you must ingest logs that contain the process GUID, process name, and parent process.
@@ -27,44 +28,45 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   names and speed up the data modeling process.
 known_false_positives: unknown
 references:
-- https://blog.sekoia.io/interlock-ransomware-evolving-under-the-radar/
+  - https://blog.sekoia.io/interlock-ransomware-evolving-under-the-radar/
 drilldown_searches:
-- name: View the detection results for - "$dest$"
-  search: '%original_detection_search% | search  dest = "$dest$"'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
-    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
-    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
-    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
-    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
-    | `security_content_ctime(lastTime)`'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
+  - name: View the detection results for - "$dest$"
+    search: '%original_detection_search% | search  dest = "$dest$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$dest$"
+    search:
+      '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+      starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+      values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+      as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+      as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+      | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
 rba:
   message: Risk Message goes here
   risk_objects:
-  - field: dest
-    type: system
-    score: 50
+    - field: dest
+      type: system
+      score: 50
   threat_objects:
-  - field: parent_process_name
-    type: parent_process_name
+    - field: parent_process_name
+      type: parent_process_name
 tags:
   analytic_story:
-  - Interlock Rat
+    - Interlock Rat
   asset_type: Endpoint
   mitre_attack_id:
-  - T1218.011
+    - T1218.011
   product:
-  - Splunk Enterprise
-  - Splunk Enterprise Security
-  - Splunk Cloud
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
   security_domain: endpoint
 tests:
-- name: True Positive Test
-  attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1218.011/rundll32_dll_in_temp/rundll32_tmp.log
-    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    sourcetype: XmlWinEventLog
+  - name: True Positive Test
+    attack_data:
+      - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1218.011/rundll32_dll_in_temp/rundll32_tmp.log
+        source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+        sourcetype: XmlWinEventLog


### PR DESCRIPTION
### Details

Removes a duplicate filter macro from a detection.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/9.3.2411/manage-apps-and-add-ons-in-splunk-cloud-platform/manage-private-apps-on-your-splunk-cloud-platform-deployment#ariaid-title7) but the short version is that any changes to lookup files need to bump the the date and version in the associated YAML file.
