### PR TITLE
Fix Issues & Updates

### DIFF
--- a/detections/deprecated/detect_rundll32_application_control_bypass___advpack.yml
+++ b/detections/deprecated/detect_rundll32_application_control_bypass___advpack.yml
@@ -1,31 +1,31 @@
-name: Detect Rundll32 Application Control Bypass - setupapi
-id: 61e7b44a-6088-4f26-b788-9a96ba13b37a
-version: 11
-date: '2025-05-02'
+name: Detect Rundll32 Application Control Bypass - advpack
+id: 4aefadfe-9abd-4bf8-b3fd-867e9ef95bf8
+version: 12
+date: '2025-10-06'
 author: Michael Haag, Splunk
-status: production
+status: deprecated
 type: TTP
 description: The following analytic detects the execution of rundll32.exe loading
-  setupapi.dll and iesetupapi.dll via the LaunchINFSection function. This behavior
-  is identified using Endpoint Detection and Response (EDR) telemetry, focusing on
-  process creation events and command-line arguments. This activity is significant
-  as it indicates a potential application control bypass, allowing an attacker to
-  execute arbitrary script code. If confirmed malicious, this technique could enable
-  code execution, privilege escalation, or persistence within the environment, posing
-  a severe threat to system integrity and security.
+  advpack.dll or ieadvpack.dll via the LaunchINFSection function. This method is identified
+  using Endpoint Detection and Response (EDR) telemetry, focusing on command-line
+  executions and process details. This activity is significant as it indicates a potential
+  application control bypass, allowing script code execution from a file. If confirmed
+  malicious, an attacker could execute arbitrary code, potentially leading to privilege
+  escalation, persistence, or further network compromise. Investigate script content,
+  network connections, and any spawned child processes for further context.
 data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_rundll32` Processes.process=*setupapi*
+  as lastTime from datamodel=Endpoint.Processes where `process_rundll32` Processes.process=*advpack*
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
   Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
   Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
   Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
   Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `detect_rundll32_application_control_bypass___setupapi_filter`'
+  | `detect_rundll32_application_control_bypass___advpack_filter`'
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -35,13 +35,13 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: Although unlikely, some legitimate applications may use setupapi
-  triggering a false positive.
+known_false_positives: Although unlikely, some legitimate applications may use advpack.dll
+  or ieadvpack.dll, triggering a false positive.
 references:
 - https://attack.mitre.org/techniques/T1218/011/
 - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.011/T1218.011.md
 - https://lolbas-project.github.io/lolbas/Binaries/Rundll32/
-- https://lolbas-project.github.io/lolbas/Libraries/Setupapi/
+- https://lolbas-project.github.io/lolbas/Libraries/Advpack/
 - https://bohops.com/2018/02/26/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence/
 drilldown_searches:
 - name: View the detection results for - "$user$" and "$dest$"
@@ -58,8 +58,8 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: An instance of $parent_process_name$ spawning $process_name$ loading setupapi.dll
-    and iesetupapi.dll by calling the LaunchINFSection function on the command line
+  message: An instance of $parent_process_name$ spawning $process_name$ loading advpack.dll
+    and ieadvpack.dll by calling the LaunchINFSection function on the command line
     was identified on endpoint $dest$ by user $user$.
   risk_objects:
   - field: user

--- a/detections/deprecated/detect_rundll32_application_control_bypass___setupapi.yml
+++ b/detections/deprecated/detect_rundll32_application_control_bypass___setupapi.yml
@@ -1,31 +1,31 @@
-name: Detect Rundll32 Application Control Bypass - syssetup
-id: 71b9bf37-cde1-45fb-b899-1b0aa6fa1183
-version: 11
-date: '2025-05-02'
+name: Detect Rundll32 Application Control Bypass - setupapi
+id: 61e7b44a-6088-4f26-b788-9a96ba13b37a
+version: 12
+date: '2025-10-06'
 author: Michael Haag, Splunk
-status: production
+status: deprecated
 type: TTP
 description: The following analytic detects the execution of rundll32.exe loading
-  syssetup.dll via the LaunchINFSection function. This method is identified through
-  Endpoint Detection and Response (EDR) telemetry, focusing on command-line executions
-  and process details. This activity is significant as it indicates a potential application
-  control bypass, allowing script code execution from a file. If confirmed malicious,
-  an attacker could execute arbitrary code, potentially leading to privilege escalation,
-  persistence, or further network compromise. Investigate the script content, network
-  connections, and any spawned child processes for further context.
+  setupapi.dll and iesetupapi.dll via the LaunchINFSection function. This behavior
+  is identified using Endpoint Detection and Response (EDR) telemetry, focusing on
+  process creation events and command-line arguments. This activity is significant
+  as it indicates a potential application control bypass, allowing an attacker to
+  execute arbitrary script code. If confirmed malicious, this technique could enable
+  code execution, privilege escalation, or persistence within the environment, posing
+  a severe threat to system integrity and security.
 data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_rundll32` Processes.process=*syssetup*
+  as lastTime from datamodel=Endpoint.Processes where `process_rundll32` Processes.process=*setupapi*
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
   Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
   Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
   Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
   Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `detect_rundll32_application_control_bypass___syssetup_filter`'
+  | `detect_rundll32_application_control_bypass___setupapi_filter`'
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -35,13 +35,13 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: Although unlikely, some legitimate applications may use syssetup.dll,
+known_false_positives: Although unlikely, some legitimate applications may use setupapi
   triggering a false positive.
 references:
 - https://attack.mitre.org/techniques/T1218/011/
 - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.011/T1218.011.md
 - https://lolbas-project.github.io/lolbas/Binaries/Rundll32/
-- https://lolbas-project.github.io/lolbas/Libraries/Syssetup/
+- https://lolbas-project.github.io/lolbas/Libraries/Setupapi/
 - https://bohops.com/2018/02/26/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence/
 drilldown_searches:
 - name: View the detection results for - "$user$" and "$dest$"
@@ -58,9 +58,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: An instance of $parent_process_name$ spawning $process_name$ loading syssetup.dll
-    by calling the LaunchINFSection function on the command line was identified on
-    endpoint $dest$ by user $user$.
+  message: An instance of $parent_process_name$ spawning $process_name$ loading setupapi.dll
+    and iesetupapi.dll by calling the LaunchINFSection function on the command line
+    was identified on endpoint $dest$ by user $user$.
   risk_objects:
   - field: user
     type: user

--- a/detections/deprecated/detect_rundll32_application_control_bypass___syssetup.yml
+++ b/detections/deprecated/detect_rundll32_application_control_bypass___syssetup.yml
@@ -1,31 +1,31 @@
-name: Detect Rundll32 Application Control Bypass - advpack
-id: 4aefadfe-9abd-4bf8-b3fd-867e9ef95bf8
-version: 11
-date: '2025-05-02'
+name: Detect Rundll32 Application Control Bypass - syssetup
+id: 71b9bf37-cde1-45fb-b899-1b0aa6fa1183
+version: 12
+date: '2025-10-06'
 author: Michael Haag, Splunk
-status: production
+status: deprecated
 type: TTP
 description: The following analytic detects the execution of rundll32.exe loading
-  advpack.dll or ieadvpack.dll via the LaunchINFSection function. This method is identified
-  using Endpoint Detection and Response (EDR) telemetry, focusing on command-line
-  executions and process details. This activity is significant as it indicates a potential
-  application control bypass, allowing script code execution from a file. If confirmed
-  malicious, an attacker could execute arbitrary code, potentially leading to privilege
-  escalation, persistence, or further network compromise. Investigate script content,
-  network connections, and any spawned child processes for further context.
+  syssetup.dll via the LaunchINFSection function. This method is identified through
+  Endpoint Detection and Response (EDR) telemetry, focusing on command-line executions
+  and process details. This activity is significant as it indicates a potential application
+  control bypass, allowing script code execution from a file. If confirmed malicious,
+  an attacker could execute arbitrary code, potentially leading to privilege escalation,
+  persistence, or further network compromise. Investigate the script content, network
+  connections, and any spawned child processes for further context.
 data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_rundll32` Processes.process=*advpack*
+  as lastTime from datamodel=Endpoint.Processes where `process_rundll32` Processes.process=*syssetup*
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
   Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
   Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
   Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
   Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `detect_rundll32_application_control_bypass___advpack_filter`'
+  | `detect_rundll32_application_control_bypass___syssetup_filter`'
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -35,13 +35,13 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: Although unlikely, some legitimate applications may use advpack.dll
-  or ieadvpack.dll, triggering a false positive.
+known_false_positives: Although unlikely, some legitimate applications may use syssetup.dll,
+  triggering a false positive.
 references:
 - https://attack.mitre.org/techniques/T1218/011/
 - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.011/T1218.011.md
 - https://lolbas-project.github.io/lolbas/Binaries/Rundll32/
-- https://lolbas-project.github.io/lolbas/Libraries/Advpack/
+- https://lolbas-project.github.io/lolbas/Libraries/Syssetup/
 - https://bohops.com/2018/02/26/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence/
 drilldown_searches:
 - name: View the detection results for - "$user$" and "$dest$"
@@ -58,9 +58,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: An instance of $parent_process_name$ spawning $process_name$ loading advpack.dll
-    and ieadvpack.dll by calling the LaunchINFSection function on the command line
-    was identified on endpoint $dest$ by user $user$.
+  message: An instance of $parent_process_name$ spawning $process_name$ loading syssetup.dll
+    by calling the LaunchINFSection function on the command line was identified on
+    endpoint $dest$ by user $user$.
   risk_objects:
   - field: user
     type: user

--- a/detections/deprecated/windows_change_default_file_association_for_no_file_ext.yml
+++ b/detections/deprecated/windows_change_default_file_association_for_no_file_ext.yml
@@ -1,9 +1,9 @@
 name: Windows Change Default File Association For No File Ext
 id: dbdf52ad-d6a1-4b68-975f-0a10939d8e38
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-10-06'
 author: Teoderick Contreras, Splunk
-status: production
+status: deprecated
 type: TTP
 description: The following analytic detects attempts to change the default file association
   for files without an extension to open with Notepad.exe. It leverages data from

--- a/detections/endpoint/add_or_set_windows_defender_exclusion.yml
+++ b/detections/endpoint/add_or_set_windows_defender_exclusion.yml
@@ -1,11 +1,12 @@
 name: Add or Set Windows Defender Exclusion
 id: 773b66fe-4dd9-11ec-8289-acde48001122
-version: '10'
-date: '2025-05-06'
-author: Teoderick Contreras, Splunk
+version: 11
+date: '2025-10-01'
+author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production
 type: TTP
-description: The following analytic detects the use of commands to add or set exclusions
+description: |
+  The following analytic detects the use of commands to add or set exclusions
   in Windows Defender. It leverages data from Endpoint Detection and Response (EDR)
   agents, focusing on command-line executions involving "Add-MpPreference" or "Set-MpPreference"
   with exclusion parameters. This activity is significant because adversaries often
@@ -14,20 +15,33 @@ description: The following analytic detects the use of commands to add or set ex
   detection, maintain persistence, and execute further malicious activities without
   interference from Windows Defender.
 data_source:
-- Sysmon EventID 1
-- Windows Event Log Security 4688
-- CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where (Processes.process = "*Add-MpPreference
-  *" OR Processes.process = "*Set-MpPreference *") AND Processes.process="*-exclusion*"
+  - Sysmon EventID 1
+  - Windows Event Log Security 4688
+  - CrowdStrike ProcessRollup2
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where 
+  (
+    Processes.process = "*Add-MpPreference *"
+    OR 
+    Processes.process = "*Set-MpPreference *"
+  ) 
+  Processes.process IN (
+        "*-Exclusion*", 
+        "*-ControlledFolderAccessAllowedApplications*", 
+        "*-AttackSurfaceReductionOnlyExclusions*"
+        )
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
-  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
-  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
-  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
-  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `add_or_set_windows_defender_exclusion_filter`'
-how_to_implement: The detection is based on data that originates from Endpoint Detection
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
+     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
+     Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
+     Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)`
+  | `add_or_set_windows_defender_exclusion_filter`
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
   you must ingest logs that contain the process GUID, process name, and parent process.
@@ -36,59 +50,60 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: Admin or user may choose to use this windows features. Filter
-  as needed.
+known_false_positives: |
+  Admin or user may choose to use this windows features. Filter as needed.
 references:
-- https://tccontre.blogspot.com/2020/01/remcos-rat-evading-windows-defender-av.html
-- https://app.any.run/tasks/cf1245de-06a7-4366-8209-8e3006f2bfe5/
-- https://www.microsoft.com/security/blog/2022/01/15/destructive-malware-targeting-ukrainian-organizations/
+  - https://tccontre.blogspot.com/2020/01/remcos-rat-evading-windows-defender-av.html
+  - https://app.any.run/tasks/cf1245de-06a7-4366-8209-8e3006f2bfe5/
+  - https://www.microsoft.com/security/blog/2022/01/15/destructive-malware-targeting-ukrainian-organizations/
+  - https://learn.microsoft.com/en-us/powershell/module/defender/add-mppreference?view=windowsserver2025-ps
 drilldown_searches:
-- name: View the detection results for - "$user$" and "$dest$"
-  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$user$" and "$dest$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
-    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
-    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
-    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
-    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
-    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
+  - name: View the detection results for - "$user$" and "$dest$"
+    search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$user$" and "$dest$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+      "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+      as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+      Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+      as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+      by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
 rba:
   message: exclusion command $process$ executed on $dest$
   risk_objects:
-  - field: user
-    type: user
-    score: 64
-  - field: dest
-    type: system
-    score: 64
+    - field: user
+      type: user
+      score: 64
+    - field: dest
+      type: system
+      score: 64
   threat_objects: []
 tags:
   analytic_story:
-  - Compromised Windows Host
-  - AgentTesla
-  - Data Destruction
-  - Remcos
-  - CISA AA22-320A
-  - ValleyRAT
-  - XWorm
-  - WhisperGate
-  - Windows Defense Evasion Tactics
-  - Crypto Stealer
+    - Compromised Windows Host
+    - AgentTesla
+    - Data Destruction
+    - Remcos
+    - CISA AA22-320A
+    - ValleyRAT
+    - XWorm
+    - WhisperGate
+    - Windows Defense Evasion Tactics
+    - Crypto Stealer
   asset_type: Endpoint
   mitre_attack_id:
-  - T1562.001
+    - T1562.001
   product:
-  - Splunk Enterprise
-  - Splunk Enterprise Security
-  - Splunk Cloud
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
   security_domain: endpoint
 tests:
-- name: True Positive Test
-  attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1562.001/defender_exclusion_sysmon/sysmon.log
-    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    sourcetype: XmlWinEventLog
+  - name: True Positive Test
+    attack_data:
+    - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1562.001/defender_exclusion_sysmon/sysmon.log
+      source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+      sourcetype: XmlWinEventLog

--- a/detections/endpoint/attempt_to_add_certificate_to_untrusted_store.yml
+++ b/detections/endpoint/attempt_to_add_certificate_to_untrusted_store.yml
@@ -1,16 +1,16 @@
 name: Attempt To Add Certificate To Untrusted Store
 id: 6bc5243e-ef36-45dc-9b12-f4a6be131159
-version: 15
-date: '2025-05-02'
+version: 16
+date: '2025-10-06'
 author: Patrick Bareiss, Rico Valdez, Splunk
 status: production
-type: TTP
-description: The following analytic detects attempts to add a certificate to the untrusted
-  certificate store using the 'certutil -addstore' command. It leverages process activity
-  and command-line arguments from Endpoint Detection and Response (EDR) logs mapped
-  to the Splunk `Processes` data model. This activity is significant as it may indicate
-  an attacker trying to disable security tools to gain unauthorized access. If confirmed
-  malicious, this could lead to the compromise of system security, allowing attackers
+type: Anomaly
+description: |
+  The following analytic detects attempts to add a certificate to the untrusted
+  certificate store using the 'certutil -addstore' command. 
+  It leverages process activity and command-line arguments from Endpoint Detection and Response (EDR) logs mapped to the Splunk `Processes` data model. 
+  This activity is significant as it may indicate an attacker trying to disable security tools to gain unauthorized access.
+  If confirmed malicious, this could lead to the compromise of system security, allowing attackers
   to bypass defenses and potentially escalate privileges or persist in the environment.
 data_source:
 - Sysmon EventID 1

--- a/detections/endpoint/common_ransomware_extensions.yml
+++ b/detections/endpoint/common_ransomware_extensions.yml
@@ -1,7 +1,7 @@
 name: Common Ransomware Extensions
 id: a9e5c5db-db11-43ca-86a8-c852d1b2c0ec
-version: 15
-date: '2025-07-29'
+version: 16
+date: '2025-10-01'
 author: David Dorsey, Michael Haag, Splunk, Steven Dick
 status: production
 type: TTP
@@ -15,23 +15,46 @@ description: The following analytic detects modifications to files with extensio
   data integrity and availability.
 data_source:
 - Sysmon EventID 11
-search: '| tstats `security_content_summariesonly` min(_time) as firstTime max(_time)
-  as lastTime count latest(Filesystem.user) as user values(Filesystem.file_path) as
-  file_path from datamodel=Endpoint.Filesystem by Filesystem.action Filesystem.dest
-  Filesystem.file_access_time Filesystem.file_create_time Filesystem.file_hash Filesystem.file_modify_time
-  Filesystem.file_name Filesystem.file_path Filesystem.file_acl Filesystem.file_size
-  Filesystem.process_guid Filesystem.process_id Filesystem.user Filesystem.vendor_product
-  | `drop_dm_object_name(Filesystem)` | rex field=file_name "(?<file_extension>\.[^\.]+)$"
+search: |
+  | tstats `security_content_summariesonly` 
+    min(_time) as firstTime 
+    max(_time) as lastTime 
+    count latest(Filesystem.user) as user 
+          values(Filesystem.file_path) as file_path 
+    from datamodel=Endpoint.Filesystem by 
+          Filesystem.action Filesystem.dest
+          Filesystem.file_access_time Filesystem.file_create_time 
+          Filesystem.file_hash Filesystem.file_modify_time
+          Filesystem.file_name Filesystem.file_path 
+          Filesystem.file_acl Filesystem.file_size
+          Filesystem.process_guid Filesystem.process_id 
+          Filesystem.user Filesystem.vendor_product
+  | `drop_dm_object_name(Filesystem)` 
+  | rex field=file_name "(?<file_extension>(\.[^\.]+){1,2})$"
   | lookup update=true ransomware_extensions_lookup Extensions AS file_extension OUTPUT
-  Extensions Name | search Name !=False | stats min(firstTime) as firstTime max(lastTime)
-  as lastTime dc(file_path) as path_count dc(file_name) as file_count values(action)
-  as action values(file_access_time) as file_access_time values(file_create_time)
-  as file_create_time values(file_hash) as file_hash values(file_modify_time) as file_modify_time
-  values(file_acl) as file_acl values(file_size) as file_size values(process_guid)
-  as process_guid values(process_id) as process_id values(user) as user values(vendor_product)
-  as vendor_product values(file_name) as file_name values(file_extension) as file_extension values(Name) as Name by dest 
+  Extensions Name 
+  | search Name !=False 
+  | stats min(firstTime) as firstTime 
+          max(lastTime) as lastTime 
+          dc(file_path) as path_count 
+          dc(file_name) as file_count 
+          values(action) as action 
+          values(file_access_time) as file_access_time 
+          values(file_create_time) as file_create_time 
+          values(file_hash) as file_hash 
+          values(file_modify_time) as file_modify_time
+          values(file_acl) as file_acl 
+          values(file_size) as file_size 
+          values(process_guid) as process_guid 
+          values(process_id) as process_id 
+          values(user) as user 
+          values(vendor_product) as vendor_product 
+          values(file_name) as file_name 
+          values(file_extension) as file_extension 
+          values(Name) as Name 
+    by dest 
   | where path_count > 1 OR file_count > 20 
-  | `common_ransomware_extensions_filter`'
+  | `common_ransomware_extensions_filter`
 how_to_implement: You must be ingesting data that records the filesystem activity
   from your hosts to populate the Endpoint Filesystem data model node. To see the
   additional metadata, add the following fields, if not already present, please review

--- a/detections/endpoint/linux_service_started_or_enabled.yml
+++ b/detections/endpoint/linux_service_started_or_enabled.yml
@@ -1,7 +1,7 @@
 name: Linux Service Started Or Enabled
 id: e0428212-61b7-11ec-88a3-acde48001122
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-10-08'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly

--- a/detections/endpoint/linux_service_started_or_enabled.yml
+++ b/detections/endpoint/linux_service_started_or_enabled.yml
@@ -54,7 +54,7 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: a commandline $process$ that may create or start a service on $dest
+  message: a commandline $process$ that may create or start a service on $dest$
   risk_objects:
   - field: dest
     type: system

--- a/detections/endpoint/usn_journal_deletion.yml
+++ b/detections/endpoint/usn_journal_deletion.yml
@@ -1,7 +1,7 @@
 name: USN Journal Deletion
 id: b6e0ff70-b122-4227-9368-4cf322ab43c3
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-10-07'
 author: David Dorsey, Splunk
 status: production
 type: TTP
@@ -17,16 +17,29 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count values(Processes.process)
-  as process values(Processes.parent_process) as parent_process min(_time) as firstTime
-  max(_time) as lastTime from datamodel=Endpoint.Processes where Processes.process_name=fsutil.exe
+search: |
+  | tstats `security_content_summariesonly` 
+    count values(Processes.process) as process 
+          values(Processes.parent_process) as parent_process 
+          min(_time) as firstTime
+          max(_time) as lastTime 
+  
+  from datamodel=Endpoint.Processes where 
+  
+  Processes.process_name=fsutil.exe
+  Processes.process = "*usn*" 
+  Processes.process = "*deletejournal*"
+  
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
-  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
-  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
-  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
-  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)`
-  | search process="*deletejournal*" AND process="*usn*" | `usn_journal_deletion_filter`'
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
+     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
+     Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
+     Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `usn_journal_deletion_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -37,7 +50,8 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
 known_false_positives: None identified
-references: []
+references: 
+- https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil-usn
 drilldown_searches:
 - name: View the detection results for - "$dest$"
   search: '%original_detection_search% | search  dest = "$dest$"'
@@ -53,7 +67,7 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Possible USN journal deletion on $dest$
+  message: Possible USN journal deletion on $dest$ via $process$
   risk_objects:
   - field: dest
     type: system

--- a/detections/endpoint/web_or_application_server_spawning_a_shell.yml
+++ b/detections/endpoint/web_or_application_server_spawning_a_shell.yml
@@ -43,7 +43,7 @@ search: |
   | `drop_dm_object_name(Processes)` 
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)`
-  | `web_or_application_server_spawning_shell_filter`
+  | `web_or_application_server_spawning_a_shell_filter`
 how_to_implement: |
   The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related

--- a/detections/endpoint/web_or_application_server_spawning_shell.yml
+++ b/detections/endpoint/web_or_application_server_spawning_shell.yml
@@ -1,11 +1,12 @@
-name: Linux Java Spawning Shell
-id: 7b09db8a-5c20-11ec-9945-acde48001122
-version: 9
+name: Web or Application Server Spawning a Shell
+id: 8fdb41ad-091c-4d7a-af1d-9123fe94b539
+version: 1
 date: '2025-10-07'
-author: Michael Haag, Splunk
+author: Michael Haag, Nasreddine Bencherchali, Splunk
 status: production
 type: TTP
-description: The following analytic detects instances where Java, or Tomcat
+description: |
+  The following analytic detects instances where Java, or Tomcat
   processes spawn a Linux shell, which may indicate exploitation attempts, such as
   those related to CVE-2021-44228 (Log4Shell). This detection leverages Endpoint Detection
   and Response (EDR) telemetry, focusing on process names and parent-child process
@@ -15,6 +16,7 @@ description: The following analytic detects instances where Java, or Tomcat
   access, posing a severe threat to the environment.
 data_source:
 - Sysmon for Linux EventID 1
+- Sysmon EventID 1
 search: |
   | tstats `security_content_summariesonly` 
     count min(_time) as firstTime 
@@ -22,20 +24,28 @@ search: |
   
   from datamodel=Endpoint.Processes where 
   
-  Processes.parent_process_name IN ("java", "tomcat")
-  `linux_shells` 
+  (
+    Processes.parent_process_name IN ("java", "tomcat", "httpd", "lighttpd", "apache2", "nginx", "node", "caddy")
+    `linux_shells`
+  )
+  OR
+  (
+    Processes.parent_process_name IN ("httpd.exe", "nginx.exe", "php.exe", "php-cgi.exe", "tomcat*.exe", "caddy.exe", "UMWorkerProcess.exe", "w3wp.exe", "ws_TomcatService.exe", "node.exe", "java.exe")
+    `windows_shells`
+  )
   
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
      Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
-     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec 
+     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
      Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level 
      Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   
   | `drop_dm_object_name(Processes)` 
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)`
-  | `linux_java_spawning_shell_filter`
-how_to_implement: The detection is based on data that originates from Endpoint Detection
+  | `web_or_application_server_spawning_shell_filter`
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
   you must ingest logs that contain the process GUID, process name, and parent process.
@@ -44,8 +54,8 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: Filtering may be required on internal developer build systems
-  or classify assets as web facing and restrict the analytic based on asset type.
+known_false_positives: |
+  Filtering may be required on internal developer build systems or classify assets as web facing and restrict the analytic based on asset type.
 references:
 - https://blog.netlab.360.com/ten-families-of-malicious-samples-are-spreading-using-the-log4j2-vulnerability-now/
 - https://gist.github.com/olafhartong/916ebc673ba066537740164f7e7e1d72
@@ -82,8 +92,6 @@ tags:
   - Hermetic Wiper
   - Log4Shell CVE-2021-44228
   asset_type: Endpoint
-  cve:
-  - CVE-2021-44228
   mitre_attack_id:
   - T1190
   - T1133

--- a/detections/endpoint/windows_application_whitelisting_bypass_attempt_via_rundll32.yml
+++ b/detections/endpoint/windows_application_whitelisting_bypass_attempt_via_rundll32.yml
@@ -1,0 +1,112 @@
+name: Windows Application Whitelisting Bypass Attempt via Rundll32
+id: 1ef5dab0-e1f1-495d-a272-d134583c10b1
+version: 1
+date: '2025-10-06'
+author: Michael Haag, Splunk
+status: production
+type: TTP
+description: |
+  The following analytic detects the execution of rundll32.exe calling one of the following DLLs:
+
+  - Advpack.dll
+  - Ieadvpack.dll
+  - Syssetup.dll
+  - Setupapi.dll
+  
+  with one of the following functions: "LaunchINFSection", "InstallHinfSection", "SetupInfObjectInstallAction".
+  This method is identified through Endpoint Detection and Response (EDR) telemetry, 
+  focusing on command-line executions and process details. 
+  This activity is significant as it indicates a potential application
+  control or whitelisting bypass, allowing script code execution from a file.
+  If confirmed malicious, an attacker could execute arbitrary code, potentially leading to privilege escalation,
+  persistence, or further network compromise.
+  Investigate the script content, network connections, and any spawned child processes for further context.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where 
+  `process_rundll32` 
+  Processes.process IN ("*syssetup*", "*advpack*", "*setupapi*")
+  Processes.process IN ("*LaunchINFSection*", "*InstallHinfSection*", "*SetupInfObjectInstallAction*")
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
+     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
+     Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
+     Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)`
+  | `windows_application_whitelisting_bypass_attempt_via_rundll32_filter`'
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. 
+  These logs must be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. 
+  The logs must also be mapped to the `Processes` node of the `Endpoint` data model. 
+  Use the Splunk Common Information Model (CIM) to normalize the field names and speed up the data modeling process.
+known_false_positives: |
+  Although unlikely, some legitimate applications may leverage one of the following DLLs syssetup.dll, dvpack.dll, ieadvpack.dll and can trigger a false positive. Apply additional filters as needed.
+references:
+- https://attack.mitre.org/techniques/T1218/011/
+- https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.011/T1218.011.md
+- https://lolbas-project.github.io/lolbas/Binaries/Rundll32/
+- https://bohops.com/2018/02/26/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence/
+- https://lolbas-project.github.io/lolbas/Libraries/Advpack/
+- https://lolbas-project.github.io/lolbas/Libraries/Ieadvpack/
+- https://lolbas-project.github.io/lolbas/Libraries/Setupapi/
+- https://lolbas-project.github.io/lolbas/Libraries/Syssetup/
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: An instance of $parent_process_name$ spawning $process_name$ loading syssetup.dll
+    by calling the LaunchINFSection function on the command line was identified on
+    endpoint $dest$ by user $user$.
+  risk_objects:
+  - field: user
+    type: user
+    score: 80
+  - field: dest
+    type: system
+    score: 80
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+  - field: process_name
+    type: process_name
+tags:
+  analytic_story:
+  - Suspicious Rundll32 Activity
+  - Living Off The Land
+  - Compromised Windows Host
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1218.011
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1218.011/atomic_red_team/windows-sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/endpoint/windows_application_whitelisting_bypass_attempt_via_rundll32.yml
+++ b/detections/endpoint/windows_application_whitelisting_bypass_attempt_via_rundll32.yml
@@ -26,8 +26,10 @@ data_source:
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: |
-  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where 
+  | tstats `security_content_summariesonly` 
+    count min(_time) as firstTime 
+    max(_time) as lastTime 
+  from datamodel=Endpoint.Processes where 
   `process_rundll32` 
   Processes.process IN ("*syssetup*", "*advpack*", "*setupapi*")
   Processes.process IN ("*LaunchINFSection*", "*InstallHinfSection*", "*SetupInfObjectInstallAction*")
@@ -39,7 +41,7 @@ search: |
   | `drop_dm_object_name(Processes)` 
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)`
-  | `windows_application_whitelisting_bypass_attempt_via_rundll32_filter`'
+  | `windows_application_whitelisting_bypass_attempt_via_rundll32_filter`
 how_to_implement: |
   The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related

--- a/detections/endpoint/windows_archived_collected_data_in_temp_folder.yml
+++ b/detections/endpoint/windows_archived_collected_data_in_temp_folder.yml
@@ -1,12 +1,12 @@
 name: Windows Archived Collected Data In TEMP Folder
 id: cb56a1ea-e0b1-46d5-913f-e024cba40cbe
-version: 5
-date: '2025-05-02'
+version: 6
+date: '2025-10-06'
 author: Teoderick Contreras, Splunk
+status: production
+type: Anomaly
 data_source:
 - Sysmon EventID 11
-type: TTP
-status: production
 description: The following analytic detects the creation of archived files in a temporary
   folder, which may contain collected data. This behavior is often associated with
   malicious activity, where attackers compress sensitive information before exfiltration.
@@ -15,20 +15,30 @@ description: The following analytic detects the creation of archived files in a 
   this pattern, security teams can quickly respond to potential data collection and
   exfiltration attempts, minimizing the risk of data breaches and improving overall
   threat detection.
-search: '|tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime FROM datamodel=Endpoint.Filesystem where Filesystem.file_name IN ("*.zip",
-  "*.rar", "*.tar", "*.7z") Filesystem.file_path = "*\\temp\\*" by Filesystem.action
-  Filesystem.dest Filesystem.file_access_time Filesystem.file_create_time Filesystem.file_hash
-  Filesystem.file_modify_time Filesystem.file_name Filesystem.file_path Filesystem.file_acl
-  Filesystem.file_size Filesystem.process_guid Filesystem.process_id Filesystem.user
-  Filesystem.vendor_product | `drop_dm_object_name(Filesystem)` | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` | `windows_archived_collected_data_in_temp_folder_filter`'
+search: |
+  | tstats `security_content_summariesonly` 
+    count min(_time) as firstTime 
+    max(_time) as lastTime 
+  FROM datamodel=Endpoint.Filesystem where 
+    Filesystem.file_name IN ("*.zip", "*.rar", "*.tar", "*.7z") 
+    Filesystem.file_path IN ("*\\AppData\\Local\\Temp\\*", "*\\Windows\\Temp\\*")
+  by Filesystem.action Filesystem.dest Filesystem.file_access_time 
+     Filesystem.file_create_time Filesystem.file_hash Filesystem.file_modify_time 
+     Filesystem.file_name Filesystem.file_path Filesystem.file_acl Filesystem.file_size 
+     Filesystem.process_guid Filesystem.process_id Filesystem.user Filesystem.vendor_product 
+  | `drop_dm_object_name(Filesystem)` 
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` 
+  | `windows_archived_collected_data_in_temp_folder_filter`
 how_to_implement: To successfully implement this search you need to be ingesting information
   on process that include the name of the process responsible for the changes from
   your endpoints into the `Endpoint` datamodel in the `Processes` node. In addition,
   confirm the latest CIM App 4.20 or higher is installed and the latest TA for the
   endpoint product.
-known_false_positives: unknown
+known_false_positives: |
+  Some installers, debugging or support tools may create archive files in the temp folder.
+  Legitimate software may also use temporary folders for archiving purposes.
+  Review and apply filters as needed.
 references:
 - https://x.com/suyog41/status/1825869470323056748
 - https://g0njxa.medium.com/from-vietnam-to-united-states-malware-fraud-and-dropshipping-98b7a7b2c36d
@@ -47,11 +57,11 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: A archive file [$file_name$] was creatd in %temp% folder on [$dest$].
+  message: An archive file [$file_name$] was created in a temporary folder on [$dest$].
   risk_objects:
   - field: dest
     type: system
-    score: 64
+    score: 40
   threat_objects: []
 tags:
   analytic_story:

--- a/detections/endpoint/windows_autoit3_execution.yml
+++ b/detections/endpoint/windows_autoit3_execution.yml
@@ -1,7 +1,7 @@
 name: Windows AutoIt3 Execution
 id: 0ecb40d9-492b-4a57-9f87-515dd742794c
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-10-06'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -9,23 +9,36 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-description: The following analytic detects the execution of AutoIt3, a scripting
-  language often used for automating Windows GUI tasks and general scripting. It identifies
-  instances where AutoIt3 or its variants are executed by searching for process names
-  or original file names matching 'autoit3.exe'. This activity is significant because
-  attackers frequently use AutoIt3 to automate malicious actions, such as executing
-  malware. If confirmed malicious, this activity could lead to unauthorized code execution,
+description: |
+  The following analytic detects the execution of AutoIt3, a scripting
+  language often used for automating Windows GUI tasks and general scripting. 
+  It identifies instances where AutoIt3 or its variants are executed by searching for process names
+  or original file names matching 'autoit3.exe'. 
+  This activity is significant because attackers frequently use AutoIt3 to automate malicious actions, such as executing malware. 
+  If confirmed malicious, this activity could lead to unauthorized code execution, 
   system compromise, or further propagation of malware within the environment.
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where Processes.process_name IN ("autoit3.exe",
-  "autoit*.exe") OR Processes.original_file_name IN ("autoit3.exe", "autoit*.exe")
-  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
-  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
-  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
-  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
-  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `windows_autoit3_execution_filter`'
+search: |
+  | tstats `security_content_summariesonly` 
+    count min(_time) as firstTime 
+    max(_time) as lastTime 
+  from datamodel=Endpoint.Processes where 
+  (
+    Processes.process_name = "autoit*.exe" 
+    OR 
+    Processes.original_file_name = "autoit*.exe"
+  )
+  by Processes.action Processes.dest Processes.original_file_name 
+     Processes.parent_process Processes.parent_process_exec 
+     Processes.parent_process_guid Processes.parent_process_id
+     Processes.parent_process_name Processes.parent_process_path 
+     Processes.process Processes.process_exec Processes.process_guid 
+     Processes.process_hash Processes.process_id Processes.process_integrity_level
+     Processes.process_name Processes.process_path Processes.user 
+     Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)`
+  | `windows_autoit3_execution_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/windows_certutil_root_certificate_addition.yml
+++ b/detections/endpoint/windows_certutil_root_certificate_addition.yml
@@ -1,39 +1,71 @@
 name: Windows Certutil Root Certificate Addition
 id: e9926391-ec0c-4bad-8a95-e450dbf6aae4
-version: 1
-date: '2025-08-06'
-author: Teoderick Contreras, Splunk
+version: 2
+date: '2025-10-06'
+author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production
-type: Anomaly
-description: The following analytic detects the use of certutil.exe to add a certificate to the Root certificate store using the -addstore root command. In this case, the certificate is loaded from a temporary file path (e.g., %TEMP%), which is highly suspicious and uncommon in legitimate administrative activity. This behavior may indicate an adversary is installing a malicious root certificate to intercept HTTPS traffic, impersonate trusted entities, or bypass security controls. The use of flags such as -f (force) and -Enterprise, combined with loading .tmp files from user-writable locations, is consistent with post-exploitation activity seen in credential theft and adversary-in-the-middle (AiTM) attacks. This should be investigated immediately, especially if correlated with unauthorized privilege use or prior certificate modifications.You should monitor when new certificates are added to the root store because this store is what your system uses to decide which websites, apps, and software can be trusted. If an attacker manages to add their own certificate there, they can silently intercept encrypted traffic, impersonate trusted websites, or make malicious programs look safe. This means they could steal sensitive data, bypass security tools, and keep access to your system even after other malware is removed. In simple terms, adding a rogue root certificate gives attackers a master key to your trust system — and if it goes unnoticed, the impact could be a complete compromise of your security.
+type: TTP
+description: |
+  The following analytic detects the use of certutil.exe to add a certificate to the Root certificate store using the "-addstore" flag.
+  In this case, the certificate is loaded from a temporary file path (e.g., %TEMP%) or other uncommon locations (e.g. C:\\Users\\Public\\), which is highly suspicious and uncommon in legitimate administrative activity.
+  This behavior may indicate an adversary is installing a malicious root certificate to intercept HTTPS traffic, impersonate trusted entities, or bypass security controls. 
+  The use of flags such as -f (force) and -Enterprise, combined with loading .tmp files from user-writable locations, is consistent with post-exploitation activity seen in credential theft and adversary-in-the-middle (AiTM) attacks. 
+  This should be investigated immediately, especially if correlated with unauthorized privilege use or prior certificate modifications.
+  You should monitor when new certificates are added to the root store because this store is what your system uses to decide which websites, apps, and software can be trusted. 
+  If an attacker manages to add their own certificate there, they can silently intercept encrypted traffic, impersonate trusted websites, or make malicious programs look safe. 
+  This means they could steal sensitive data, bypass security tools, and keep access to your system even after other malware is removed.
 data_source:
-- Sysmon EventID 1
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime values(Processes.process)
-  as process max(_time) as lastTime from datamodel=Endpoint.Processes 
-  where `process_certutil` Processes.process=*-addstore* Processes.process=*root*
+  - Sysmon EventID 1
+  - Windows Event Log Security 4688
+  - CrowdStrike ProcessRollup2
+search: |
+  | tstats `security_content_summariesonly` 
+    count min(_time) as firstTime 
+    max(_time) as lastTime
+    values(Processes.process) as process 
+  from datamodel=Endpoint.Processes where 
+  `process_certutil` 
+  Processes.process=*-addstore* 
+  Processes.process=*root*
+  Processes.process IN (
+        "*:\\PerfLogs\\*",
+        "*:\\Windows\\Temp\\*",
+        "*\\AppData\\Local\\Temp\\*",
+        "*\\ProgramData\\*",
+        "*\\Users\\Public\\*",
+        "*%AppData%*",
+        "*%Public%*",
+        "*%Temp%*",
+        "*%tmp%*"
+        )
   by Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product 
+     Processes.parent_process Processes.parent_process_exec 
+     Processes.parent_process_guid Processes.parent_process_id 
+     Processes.parent_process_name Processes.parent_process_path
+     Processes.process Processes.process_exec Processes.process_guid 
+     Processes.process_hash Processes.process_id Processes.process_integrity_level 
+     Processes.process_name Processes.process_path Processes.user 
+     Processes.user_id Processes.vendor_product 
   | `drop_dm_object_name("Processes")`
   | `security_content_ctime(firstTime)` 
   |`security_content_ctime(lastTime)` 
-  | `windows_certutil_root_certificate_addition_filter`'
-how_to_implement: The detection is based on data that originates from Endpoint Detection
+  | `windows_certutil_root_certificate_addition_filter`
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
-  telemetry from the endpoints where the agent is installed. To implement this search,
-  you must ingest logs that contain the process GUID, process name, and parent process.
-  Additionally, you must ingest complete command-line executions. These logs must
-  be processed using the appropriate Splunk Technology Add-ons that are specific to
-  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
-  data model. Use the Splunk Common Information Model (CIM) to normalize the field
-  names and speed up the data modeling process.
-known_false_positives: administrator may use certutil to add a root certificate to the store.
-  Filter as needed or restrict to critical assets on the perimeter.
+  telemetry from the endpoints where the agent is installed. 
+  To implement this search, you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. 
+  These logs must be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. 
+  The logs must also be mapped to the `Processes` node of the `Endpoint` data model. 
+  Use the Splunk Common Information Model (CIM) to normalize the field names and speed up the data modeling process.
+known_false_positives: |
+  Administrators or third party utilities may use leverage certutil in order to add a root certificate to the store. Filter as needed or restrict to critical assets on the perimeter.
 references:
 - https://www.microsoft.com/en-us/security/blog/2025/07/31/frozen-in-transit-secret-blizzards-aitm-campaign-against-diplomats/
+- https://www.deepinstinct.com/blog/iranian-threat-actor-continues-to-develop-mass-exploitation-tools
+- https://unit42.paloaltonetworks.com/retefe-banking-trojan-targets-sweden-switzerland-and-japan/
 drilldown_searches:
 - name: View the detection results for - "$dest$"
   search: '%original_detection_search% | search  dest = "$dest$"'
@@ -49,11 +81,11 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: A certificate was added to the Root certificate store by a suspicious process named $process_name$ with the process path $process_path$ on dest $dest$.
+  message: A potentially suspicious certificate was added to the Root certificate store via Certutil on $dest$.
   risk_objects:
   - field: dest
     type: system
-    score: 40
+    score: 60
   threat_objects:
   - field: parent_process_name
     type: parent_process_name

--- a/detections/endpoint/windows_change_file_association_command_to_notepad.yml
+++ b/detections/endpoint/windows_change_file_association_command_to_notepad.yml
@@ -1,0 +1,102 @@
+name: Windows Change File Association Command To Notepad
+id: 339155d6-34cb-4788-9d00-e67f190af93a
+version: 1
+date: '2025-10-06'
+author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
+status: production
+type: TTP
+description: |
+  The following analytic detects attempts to change the command value of a file association of an extension to open with Notepad.exe.
+  It leverages data from Endpoint Detection and Response (EDR) agents, focusing on specific command-line patterns and registry modifications.
+  This activity is significant as it can indicate an attempt to manipulate file handling behavior, a technique observed in APT and ransomware attacks like Prestige.
+  After changing the extension of all encrypted files to a new one, Prestige ransomware modifies the file association for that extension to open with Notepad.exe in order to display a ransom note.
+data_source:
+  - Sysmon EventID 1
+  - Windows Event Log Security 4688
+  - CrowdStrike ProcessRollup2
+search: |
+  | tstats `security_content_summariesonly` 
+    count min(_time) as firstTime 
+    max(_time) as lastTime
+
+  from datamodel=Endpoint.Processes where 
+  
+  (
+    (`process_reg` AND Processes.process="* add *")
+    OR
+    (`process_powershell` AND Processes.process IN ("*New-ItemProperty*", "*Set-ItemProperty*", "* sp *"))
+  )
+  
+  Processes.process IN ("*HKCR\\*", "*HKEY_CLASSES_ROOT\\*")
+  Processes.process = "*\\shell\\open\\command*"
+  Processes.process = "*Notepad.exe*"
+
+  ```
+  The exclusion below aims to filter the default notepad association as well as links to the notepad package from the Microsoft Store. 
+  ```
+
+  NOT Processes.process IN ("*\\Applications\\notepad.exe\\*", "*\\WindowsApps\\Microsoft.WindowsNotepad*")
+
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process 
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id 
+     Processes.parent_process_name Processes.parent_process_path Processes.process 
+     Processes.process_exec Processes.process_guid Processes.process_hash Processes.process_id 
+     Processes.process_integrity_level Processes.process_name Processes.process_path Processes.user 
+     Processes.user_id Processes.vendor_product
+
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)` 
+  | `windows_change_file_association_command_to_notepad_filter`
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: Unlikely
+references:
+- https://www.microsoft.com/en-us/security/blog/2022/10/14/new-prestige-ransomware-impacts-organizations-in-ukraine-and-poland/
+drilldown_searches:
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Process with commandline $process$ set the execution command of a file association to notepad.exe on $dest$
+  risk_objects:
+  - field: dest
+    type: system
+    score: 70
+  threat_objects: []
+tags:
+  analytic_story:
+  - Prestige Ransomware
+  - Compromised Windows Host
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1546.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/prestige_ransomware/sysmon.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/endpoint/windows_curl_download_to_suspicious_path.yml
+++ b/detections/endpoint/windows_curl_download_to_suspicious_path.yml
@@ -1,7 +1,7 @@
 name: Windows Curl Download to Suspicious Path
 id: c32f091e-30db-11ec-8738-acde48001122
-version: 16
-date: '2025-09-16'
+version: 17
+date: '2025-10-01'
 author: Michael Haag, Nasreddine Bencherchali, Splunk
 status: production
 type: TTP
@@ -23,7 +23,7 @@ search: |
   | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where
   `process_curl`
-  Processes.process IN ("*-O *","*--output*")
+  Processes.process IN ("*-O *","*--output*", "*--output-dir*"))
   Processes.process IN (
         "*:\\PerfLogs\\*",
         "*:\\Windows\\Temp\\*",

--- a/detections/endpoint/windows_curl_download_to_suspicious_path.yml
+++ b/detections/endpoint/windows_curl_download_to_suspicious_path.yml
@@ -23,7 +23,7 @@ search: |
   | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where
   `process_curl`
-  Processes.process IN ("*-O *","*--output*", "*--output-dir*"))
+  Processes.process IN ("*-O *","*--output*", "*--output-dir*")
   Processes.process IN (
         "*:\\PerfLogs\\*",
         "*:\\Windows\\Temp\\*",

--- a/detections/endpoint/windows_curl_download_to_suspicious_path.yml
+++ b/detections/endpoint/windows_curl_download_to_suspicious_path.yml
@@ -1,6 +1,6 @@
 name: Windows Curl Download to Suspicious Path
 id: c32f091e-30db-11ec-8738-acde48001122
-version: 17
+version: 16
 date: '2025-10-01'
 author: Michael Haag, Nasreddine Bencherchali, Splunk
 status: production

--- a/detections/endpoint/windows_information_discovery_fsutil.yml
+++ b/detections/endpoint/windows_information_discovery_fsutil.yml
@@ -1,32 +1,48 @@
 name: Windows Information Discovery Fsutil
 id: 2181f261-93e6-4166-a5a9-47deac58feff
-version: 6
-date: '2025-05-02'
-author: Teoderick Contreras, Splunk
+version: 7
+date: '2025-10-07'
+author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
-description: The following analytic identifies the execution of the Windows built-in
-  tool FSUTIL with the FSINFO parameter to discover file system information. This
-  detection leverages data from Endpoint Detection and Response (EDR) agents, focusing
-  on process execution logs that include command-line details. Monitoring this activity
-  is significant because FSUTIL can be abused by adversaries to gather detailed information
-  about the file system, aiding in further exploitation. If confirmed malicious, this
-  activity could enable attackers to map the file system, identify valuable data,
-  and plan subsequent actions such as privilege escalation or persistence.
+description: |
+  The following analytic identifies the execution of the Windows built-in tool FSUTIL with the "FSINFO" or "Volume" parameters, in order to discover file system and disk information.
+  This detection leverages data from Endpoint Detection and Response (EDR) agents, focusing on process execution logs that include command-line details.
+  Monitoring this activity is significant because FSUTIL can be abused by adversaries to gather detailed information about the file system, aiding in further exploitation.
+  If confirmed malicious, this activity could enable attackers to map the file system, identify valuable data, and plan subsequent actions such as privilege escalation or persistence.
 data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where Processes.process_name="fsutil.exe"
-  OR Processes.original_file_name = "fsutil.exe" AND Processes.process = "*fsinfo*"
+search: |
+  | tstats `security_content_summariesonly`
+    count min(_time) as firstTime
+          max(_time) as lastTime
+  from datamodel=Endpoint.Processes where
+
+  (
+    Processes.process_name="fsutil.exe"
+    OR
+    Processes.original_file_name = "fsutil.exe"
+  )
+  (
+    Processes.process = "*fsinfo*"
+    OR
+    (
+      Processes.process = "*volume*"
+      AND 
+      Processes.process IN ("*diskfree*", "*list*")
+    )
+  )
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
-  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
-  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
-  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
-  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `windows_information_discovery_fsutil_filter`'
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
+     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
+     Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
+     Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `windows_information_discovery_fsutil_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -39,8 +55,10 @@ how_to_implement: The detection is based on data that originates from Endpoint D
 known_false_positives: unknown
 references:
 - https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil
+- https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil-volume
 - https://github.com/carlospolop/PEASS-ng/tree/master/winPEAS
 - https://www.microsoft.com/en-us/security/blog/2022/10/14/new-prestige-ransomware-impacts-organizations-in-ukraine-and-poland/
+- https://www.microsoft.com/en-us/security/blog/2021/01/20/deep-dive-into-the-solorigate-second-stage-activation-from-sunburst-to-teardrop-and-raindrop/
 drilldown_searches:
 - name: View the detection results for - "$dest$"
   search: '%original_detection_search% | search  dest = "$dest$"'

--- a/detections/endpoint/windows_java_spawning_shells.yml
+++ b/detections/endpoint/windows_java_spawning_shells.yml
@@ -1,7 +1,7 @@
 name: Windows Java Spawning Shells
 id: 28c81306-5c47-11ec-bfea-acde48001122
-version: 10
-date: '2025-05-02'
+version: 11
+date: '2025-10-07'
 author: Michael Haag, Splunk
 status: experimental
 type: TTP
@@ -17,8 +17,10 @@ data_source:
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name=java.exe
-  OR Processes.parent_process_name=w3wp.exe `windows_shells` by Processes.action Processes.dest
+  as lastTime from datamodel=Endpoint.Processes where 
+  Processes.parent_process_name IN ("java.exe", "tomcat.exe")
+  `windows_shells` 
+  by Processes.action Processes.dest
   Processes.original_file_name Processes.parent_process Processes.parent_process_exec
   Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
   Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid

--- a/detections/endpoint/windows_remote_management_execute_shell.yml
+++ b/detections/endpoint/windows_remote_management_execute_shell.yml
@@ -1,7 +1,7 @@
 name: Windows Remote Management Execute Shell
 id: 28b80028-851d-4b8d-88a5-375ba115418a
-version: 3
-date: '2025-05-02'
+version: 4
+date: '2025-10-07'
 author: Teoderick Contreras, Splunk
 data_source:
 - Sysmon EventID 1
@@ -18,7 +18,7 @@ description: The following analytic detects the execution of winrshost.exe initi
   signaling a potential security incident.
 search: '| tstats `security_content_summariesonly` min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name="winrshost.exe"
-  AND Processes.process_name IN ("cmd.exe","*powershell*") by Processes.action Processes.dest
+  AND Processes.process_name IN ("cmd.exe","*powershell*", "pwsh.exe") by Processes.action Processes.dest
   Processes.original_file_name Processes.parent_process Processes.parent_process_exec
   Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
   Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid

--- a/detections/endpoint/windows_renamed_powershell_execution.yml
+++ b/detections/endpoint/windows_renamed_powershell_execution.yml
@@ -1,25 +1,46 @@
 name: Windows Renamed Powershell Execution
 id: c08014de-cc5a-42de-9775-76ecd5b37bbd
-version: 1
-date: '2025-05-07'
-author: Teoderick Contreras, Splunk
+version: 2
+date: '2025-10-07'
+author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production
 type: TTP
 description: The following analytic identifies instances where the PowerShell executable has been renamed and executed under an alternate filename. This behavior is commonly associated with attempts to evade security controls or bypass logging mechanisms that monitor standard PowerShell usage. While rare in legitimate environments, renamed PowerShell binaries are frequently observed in malicious campaigns leveraging Living-off-the-Land Binaries (LOLBins) and fileless malware techniques. This detection flags executions of PowerShell where the process name does not match the default powershell.exe or pwsh.exe, especially when invoked from unusual paths or accompanied by suspicious command-line arguments.
 data_source:
 - Sysmon EventID 1
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where Processes.process_name!=powershell.exe AND Processes.process_name!=pwsh.exe
-  AND Processes.original_file_name=powershell.EXE by Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product 
+search: |
+  | tstats `security_content_summariesonly` 
+    count min(_time) as firstTime 
+          max(_time) as lastTime 
+
+  from datamodel=Endpoint.Processes where 
+  
+  (
+    Processes.original_file_name = PowerShell.EXE
+    Processes.process_name != powershell.exe
+  )
+  OR
+  (
+    Processes.original_file_name = pwsh.dll
+    Processes.process_name != pwsh.exe
+  )
+  OR
+  (
+    Processes.original_file_name = powershell_ise.EXE
+    Processes.process_name != powershell_ise.exe
+  )
+  
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process 
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id 
+     Processes.parent_process_name Processes.parent_process_path Processes.process 
+     Processes.process_exec Processes.process_guid Processes.process_hash Processes.process_id 
+     Processes.process_integrity_level Processes.process_name Processes.process_path Processes.user 
+     Processes.user_id Processes.vendor_product 
+     
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)`
-  | `windows_renamed_powershell_execution_filter`'
+  | `windows_renamed_powershell_execution_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/windows_rundll32_apply_user_settings_changes.yml
+++ b/detections/endpoint/windows_rundll32_apply_user_settings_changes.yml
@@ -1,32 +1,41 @@
 name: Windows Rundll32 Apply User Settings Changes
 id: b9fb8d97-dbc9-4a09-804c-ff0e3862bb2d
-version: 7
-date: '2025-05-02'
-author: Teoderick Contreras, Splunk
+version: 8
+date: '2025-10-07'
+author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production
-type: TTP
+type: Anomaly
+description: |
+  The following analytic detects the execution of rundll32 with a call to the user32 DLL, specifically the UpdatePerUserSystemParameters function.
+  This function is responsible for updating system parameters, such as desktop backgrounds, display settings, and visual themes. 
+  It leverages data from Endpoint Detection and Response (EDR) agents, focusing on command-line executions.
+  This activity can be significant as it is an uncommon way to apply settings. It was also observed as part of Rhysida Ransomware activity. 
+  If confirmed malicious, this could allow an attacker to disguise activities or make unauthorized system changes, potentially leading to persistent unauthorized access.
 data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-description: The following analytic detects the execution of a suspicious rundll32
-  command line that updates user-specific system parameters, such as desktop backgrounds,
-  display settings, and visual themes. It leverages data from Endpoint Detection and
-  Response (EDR) agents, focusing on command-line executions involving "user32.dll,UpdatePerUserSystemParameters."
-  This activity is significant as it is uncommon for legitimate purposes and has been
-  observed in Rhysida Ransomware for defense evasion. If confirmed malicious, this
-  could allow an attacker to disguise activities or make unauthorized system changes,
-  potentially leading to persistent unauthorized access.
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where Processes.process_name=rundll32.exe
-  Processes.process= "*user32.dll,UpdatePerUserSystemParameters*" by Processes.action
-  Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `windows_rundll32_apply_user_settings_changes_filter`'
+search: |
+  | tstats `security_content_summariesonly` 
+    count min(_time) as firstTime 
+          max(_time) as lastTime 
+          
+  from datamodel=Endpoint.Processes where 
+  
+  `process_rundll32`
+  Processes.process = "*user32.dll*"
+  Processes.process = "*UpdatePerUserSystemParameters*" 
+  
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process 
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id 
+     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec 
+     Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level 
+     Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)`
+  | `windows_rundll32_apply_user_settings_changes_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -36,9 +45,11 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: unknown
+known_false_positives: Unknown
 references:
 - https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-319a
+- https://www.cisa.gov/sites/default/files/publications/aa22-264a-iranian-cyber-actors-conduct-cyber-operations-against-the-government-of-albania.pdf
+- https://cdn.pathfactory.com/assets/10555/contents/400686/13f4424c-05b4-46db-bb9c-6bf9b5436ec4.pdf
 drilldown_searches:
 - name: View the detection results for - "$dest$"
   search: '%original_detection_search% | search  dest = "$dest$"'

--- a/detections/endpoint/windows_scheduled_task_created_via_xml.yml
+++ b/detections/endpoint/windows_scheduled_task_created_via_xml.yml
@@ -1,32 +1,39 @@
 name: Windows Scheduled Task Created Via XML
 id: 7e03b682-3965-4598-8e91-a60a40a3f7e4
-version: 9
-date: '2025-05-26'
-author: Teoderick Contreras, Splunk
+version: 10
+date: '2025-10-07'
+author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production
-type: TTP
+type: Anomaly
+description: |
+  The following analytic detects the creation of scheduled tasks in Windows using schtasks.exe with the "XML" parameter.
+  This detection leverages data from Endpoint Detection and Response (EDR) agents, focusing on command-line executions and process details.
+  This activity is significant as it is a common technique for establishing persistence or achieving privilege escalation, often used by malware like Trickbot and Winter-Vivern. While creating a scheduled task via XML may be legitimate, it can also be abused by attackers. If confirmed malicious, this could allow attackers to maintain access, execute additional payloads, and potentially lead to data theft or ransomware deployment.
 data_source:
-- Sysmon EventID 1
-- Windows Event Log Security 4688
-- CrowdStrike ProcessRollup2
-description: The following analytic detects the creation of scheduled tasks in Windows
-  using schtasks.exe with the -create flag and an XML parameter. This detection leverages
-  data from Endpoint Detection and Response (EDR) agents, focusing on command-line
-  executions and process details. This activity is significant as it is a common technique
-  for establishing persistence or achieving privilege escalation, often used by malware
-  like Trickbot and Winter-Vivern. If confirmed malicious, this could allow attackers
-  to maintain access, execute additional payloads, and potentially lead to data theft
-  or ransomware deployment.
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where Processes.process_name=schtasks.exe
-  Processes.process=*create* Processes.process="* /xml *" by Processes.action Processes.dest
-  Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `windows_scheduled_task_created_via_xml_filter`'
+  - Sysmon EventID 1
+  - Windows Event Log Security 4688
+  - CrowdStrike ProcessRollup2
+search: |
+  | tstats `security_content_summariesonly` 
+    count min(_time) as firstTime
+          max(_time) as lastTime
+
+  from datamodel=Endpoint.Processes where 
+  
+  `process_schtasks`
+  Processes.process IN ("* /create *", "* -create *")
+  Processes.process IN ("* /xml *", "* -xml *")
+  
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process 
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id 
+     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec 
+     Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level 
+     Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+
+  | `drop_dm_object_name(Processes)` 
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)`
+  | `windows_scheduled_task_created_via_xml_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -36,8 +43,7 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: It is possible scripts or administrators may trigger this analytic.
-  Filter as needed based on parent process, application.
+known_false_positives: Installers are known to create scheduled tasks via XML. Apply additional filters as needed. 
 references:
 - https://twitter.com/_CERT_UA/status/1620781684257091584
 - https://cert.gov.ua/article/3761104
@@ -56,15 +62,14 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: A scheduled task process, $process_name$, with 'create' or 'delete' commands
-    present in the command line.
+  message: A scheduled task was created via $process$, based on an XML file by user $user$ on host $dest$
   risk_objects:
   - field: dest
     type: system
-    score: 49
+    score: 40
   - field: user
     type: user
-    score: 49
+    score: 40
   threat_objects: []
 tags:
   analytic_story:

--- a/detections/endpoint/windows_symlink_evaluation_change_via_fsutil.yml
+++ b/detections/endpoint/windows_symlink_evaluation_change_via_fsutil.yml
@@ -56,8 +56,17 @@ references:
 - https://www.group-ib.com/blog/blackcat/
 - https://www.intrinsec.com/alphv-ransomware-gang-analysis/
 drilldown_searches:
-- name: View detection results for "$dest$"
-  search: '%original_detection_search% | search dest="$dest$"'
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:

--- a/detections/endpoint/windows_symlink_evaluation_change_via_fsutil.yml
+++ b/detections/endpoint/windows_symlink_evaluation_change_via_fsutil.yml
@@ -28,11 +28,11 @@ search: |
     Processes.process="*set*"
     Processes.process="*SymlinkEvaluation*"
     
-    by Processes.dest Processes.user Processes.process_name Processes.process
-       Processes.process_path Processes.parent_process_name Processes.parent_process
-       Processes.parent_process_path Processes.process_guid Processes.parent_process_guid
-       Processes.process_id Processes.parent_process_id Processes.process_integrity_level
-       Processes.vendor_product Processes.original_file_name Processes.process_hash
+    by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
+    Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
+    Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
+    Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
+    Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)`

--- a/detections/endpoint/windows_symlink_evaluation_change_via_fsutil.yml
+++ b/detections/endpoint/windows_symlink_evaluation_change_via_fsutil.yml
@@ -1,0 +1,88 @@
+name: Windows Symlink Evaluation Change via Fsutil
+id: 9777e7e3-2499-4a16-a519-ebe33630c1e8
+version: 1
+date: '2025-10-07'
+author: Nasreddine Bencherchali, Splunk
+status: production
+type: Anomaly
+description: |
+  This analytic detects the execution of the Windows built-in tool Fsutil.exe with
+  the "behavior", "set" and "SymlinkEvaluation" parameters.
+  Attackers can abuse this to alter symlink evaluation behavior on Windows, potentially enabling remote traversal over SMB shares or evading defenses. 
+  Such changes should be uncommon or even rare in enterprise environments and should be investigated.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+search: |
+  | tstats `security_content_summariesonly`
+      count min(_time) as firstTime max(_time) as lastTime
+    from datamodel=Endpoint.Processes where 
+    
+    (
+      Processes.process_name="fsutil.exe"
+      OR Processes.original_file_name="fsutil.exe"
+    )
+
+    Processes.process="*behavior*"
+    Processes.process="*set*"
+    Processes.process="*SymlinkEvaluation*"
+    
+    by Processes.dest Processes.user Processes.process_name Processes.process
+       Processes.process_path Processes.parent_process_name Processes.parent_process
+       Processes.parent_process_path Processes.process_guid Processes.parent_process_guid
+       Processes.process_id Processes.parent_process_id Processes.process_integrity_level
+       Processes.vendor_product Processes.original_file_name Processes.process_hash
+  
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `windows_symlink_evaluation_change_via_fsutil_filter`
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
+  and Response (EDR) agents. These agents are designed to provide security-related
+  telemetry from the endpoints where the agent is installed. To implement this search,
+  you must ingest logs that contain the process GUID, process name, and parent process.
+  Additionally, you must ingest complete command-line executions. These logs must
+  be processed using the appropriate Splunk Technology Add-ons that are specific to
+  the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
+  data model. Use the Splunk Common Information Model (CIM) to normalize the field
+  names and speed up the data modeling process.
+known_false_positives: |
+  Edge cases may exist in environments where this command is used for legitimate purposes.
+  However, such usage is expected to be uncommon. It is recommended to investigate any occurrences of this command, and apply filters as necessary.
+references:
+- https://learn.microsoft.com/windows-server/administration/windows-commands/fsutil-behavior
+- https://www.group-ib.com/blog/blackcat/
+- https://www.intrinsec.com/alphv-ransomware-gang-analysis/
+drilldown_searches:
+- name: View detection results for "$dest$"
+  search: '%original_detection_search% | search dest="$dest$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: process $process_name$ with command line "$process$" modified SymlinkEvaluation on $dest$
+  risk_objects:
+  - field: dest
+    type: system
+    score: 35
+  threat_objects:
+  - field: parent_process_name
+    type: parent_process_name
+tags:
+  analytic_story:
+  - Windows Post-Exploitation
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1222.001
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  security_domain: endpoint
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1222.001/fsutil_symlink_eval/fsutil_symlink_eval.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog

--- a/detections/endpoint/winevent_scheduled_task_created_within_public_path.yml
+++ b/detections/endpoint/winevent_scheduled_task_created_within_public_path.yml
@@ -1,7 +1,7 @@
 name: WinEvent Scheduled Task Created Within Public Path
 id: 5d9c6eee-988c-11eb-8253-acde48001122
-version: 18
-date: '2025-08-22'
+version: 19
+date: 2025-10-01
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -15,11 +15,19 @@ description: The following analytic detects the creation of scheduled tasks
   posing a severe threat to system integrity and security.
 data_source:
 - Windows Event Log Security 4698
-search: '`wineventlog_security` EventCode=4698 TaskContent IN ("*\\users\\public\\*",
-  "*\\programdata\\*", "*\\temp\\*", "*\\Windows\\Tasks\\*", "*\\appdata\\*", "*\\perflogs\\*")
-  | stats count min(_time) as firstTime max(_time) as lastTime by Computer, TaskName,
-  TaskContent |  rename Computer as dest | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `winevent_scheduled_task_created_within_public_path_filter`'
+search: |
+  `wineventlog_security`
+  EventCode=4698 
+  TaskContent IN (
+    "*\\users\\public\\*", "*\\programdata\\*", "*\\temp\\*", 
+    "*\\Windows\\Tasks\\*", "*\\appdata\\*", "*\\perflogs\\*"
+    )
+  | stats count min(_time) as firstTime max(_time) as lastTime 
+    by Computer, TaskName, TaskContent, user 
+  |  rename Computer as dest 
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)`
+  | `winevent_scheduled_task_created_within_public_path_filter`
 how_to_implement: To successfully implement this search, you need to be 
   ingesting Windows Security Event Logs with 4698 EventCode enabled. The Windows
   TA is also required.

--- a/lookups/ransomware_extensions_lookup.csv
+++ b/lookups/ransomware_extensions_lookup.csv
@@ -1,312 +1,261 @@
 Extensions,Name
-*.enc,.CryptoHasYou.
+*._ryp,Rakhni
+*.0x0,Ungluk
+*.1999,Ungluk
+*.1nt3rlock,Interlock
+*.1txt,Enigma
+*.73i87A,Xorist
 *.777,777
-*.R4A,7ev3n
-*.R5A,7ev3n
 *.7h9r,7h9r
 *.8lock8,8lock8
-*.encrypt,Alpha Ransomware
-*.amba,AMBA
+*.aaa,TeslaCrypt 0.x - 2.2.0
+*.abc,TeslaCrypt 0.x - 2.2.0
 *.adk,Angry Duck
-*.encrypted,Apocalypse
-*.SecureCrypted,Apocalypse
-*.FuckYourData,Apocalypse
-*.unavailable,Apocalypse
-*.bleepYourFiles,Apocalypse
-*.Where_my_files.txt,Apocalypse
-*.encrypted,ApocalypseVM
-*.locked,ApocalypseVM
-*.locky,AutoLocky
 *.adr,BaksoCrypt
+*.AES256,Rakhni
+*.AFD,Jigsaw
+*.aga,CryFile
+*.amba,AMBA
+*.areyoulovemyrans,Samas-Samsam
+*.AreYouLoveMyRansFile,Samas-Samsam
+*.asier,Locky
 *.avos,AvosLocker
 *.avos2,AvosLocker
 *.avoslinux,AvosLocker
-*.bart.zip,Bart
 *.bart,Bart
-*.perl,Bart
-*.clf,BitCryptor
+*.bart.zip,Bart
+*.basta, BlackBasta
+*.better_call_saul,Troldesh
 *.bitstak,BitStak
-*.Silent,BlackShades Crypter
+*.bleepYourFiles,Apocalypse
+*.bloc,Rector
 *.blocatto,Blocatto
-*.cry,Central Security Treatment Organization
+*.breeding123,Samas-Samsam
+*.btc-help-you,Samas-Samsam
+*.btc,Jigsaw
+*.btcbtcbtc,Samas-Samsam
+*.cactus, Cactus
+*.canihelpyou,Samas-Samsam
+*.cbf,Offline ransomware
+*.CCCRRRPPP,Unlock92
 *.cerber,Cerber
 *.cerber2,Cerber
 *.cerber3,Cerber
-*.clf,CoinVault
+*.checkdiskenced,Samas-Samsam
+*.chifrator@qq_com,Rakhni
+*.cifgksaffsfyghd,Samas-Samsam
+*.clf,BitCryptor / CoinVault / CryptoGraphic Locker
+*.Cllp,Clop
+*.Clop,Clop
+*.code,CryptoMix
+*.country82000,Samas-Samsam
 *.coverton,Coverton
-*.enigma,Coverton
-*.czvxce,Coverton
+*.crashed,RemindMe
+*.crime,iLock / iLockLight / Lortok
+*.crinf,CryptInfinite
 *.criptiko,CryFile
 *.criptoko,CryFile
 *.criptokod,CryFile
 *.cripttt,CryFile
-*.aga,CryFile
-*.cry,CryLocker
-*.ENCRYPTED,Crypren
-*.crypt38,Crypt38
-*.scl,CryptFIle2
-*.crinf,CryptInfinite
-*.frtrss,CryptoFortress
-*.clf,CryptoGraphic Locker
 *.crjoker,CryptoJoker
-*.encrypted ,CryptoLocker
-*.ENC,CryptoLocker
-*.code,CryptoMix
-*.scl,CryptoMix
 *.crptrgr,CryptoRoger
-*.locked,CryptoShocker
-*.CryptoTorLocker2015!,CryptoTorLocker2015
-*.crypt,CryptXXX
-*.crypt,CryptXXX 2.0
-*.crypt,CryptXXX 3.0
-*.cryp1,CryptXXX 3.0
-*.crypz,CryptXXX 3.0
-*.cryptz,CryptXXX 3.0
-*.cryp1,CryptXXX 3.1
-*.ctbl,CTB-Locker
-*.encrypted,CuteRansomware
-*.ded,DEDCryptor
-*.domino,Domino
-*.locked,EDA2 / HiddenTear
-*.isis,EduCrypt
-*.locked,EduCrypt
-*.ha3,El-Polocker
-*.enigma,Enigma
-*.1txt,Enigma
-*.exotic,Exotic
-*.locked,Fakben
-*.fantom,Fantom
-*.Z81928819,GhostCrypt
-*.purge,Globe v1
-*.globe,Globe v3
-*.locked,GNL Locker
-*.crypt,Gomasom
-*.herbst,Herbst
-*.cry,Hi Buddy!
-*.locky,Hucky
-*.crime,iLock
-*.crime,iLockLight
-*.btc,Jigsaw
-*.kkk,Jigsaw
-*.fun,Jigsaw
-*.gws,Jigsaw
-*.porno,Jigsaw
-*.payransom,Jigsaw
-*.payms,Jigsaw
-*.paymst,Jigsaw
-*.AFD,Jigsaw
-*.paybtcs,Jigsaw
-*.epic,Jigsaw
-*.xyz,Jigsaw
-*.locked,Job Crypter
-*.encrypted,KeRanger
-*.keybtc@inbox_com,KeyBTC
-*.rip,Killer Locker
-*.kimcilware,KimcilWare
-*.locked,KimcilWare
-*.kostya,Kostya
-*.kratos,KratosCrypt
-*.LeChiffre,LeChiffre
-*.locky,Locky
-*.zepto,Locky
-*.odin,Locky
-*.shit,Locky
-*.thor,Locky
-*.asier,Locky
-*.zzzzz,Locky
-*.osiris,Locky
-*.lock93,Lock93
-*.crime,Lortok
-*.oor,LowLevel04
-*.magic,Magic
-*.Lock,MIRCOP
-*.fucked,MireWare
-*.fuck,MireWare
-*.locked,MM Locker
-*.KEYZ,Mobef
-*.KEYH0LES,Mobef
+*.CRRRT,Unlock92
+*.cry,Central Security Treatment Organization / CryLocker / Hi Buddy! / Rakhni
+*.cryp1,CryptXXX
+*.crypt,CryptXXX / Gomasom / R980
+*.crypt38,Crypt38
 *.crypted,Nemucod
-*.odcodc,ODCODC
-*.cbf,Offline ransomware
-*.LOL!,OMG! Ransomware
-*.OMG!,OMG! Ransomware
-*.padcrypt,PadCrypt
-*.locked,Philadelphia
-*.locked,PokemonGO
-*.filock,Popcorn Time
-*.locky,PowerWare
-*.crypt,R980
-*.locked,RAA encryptor
-*.RDM,Radamant
-*.RRK,Radamant
-*.RAD,Radamant
-*.RADAMANT,Radamant
-*.locked,Rakhni
-*.kraken,Rakhni
+*.crypto,Rakhni / Zimbra
+*.CryptoTorLocker2015!,CryptoTorLocker2015
+*.cryptz,CryptXXX 3.0
+*.crypz,CryptXXX 3.0
+*.CrySiS,Virus-Encoder
+*.ctbl,CTB-Locker
+*.cts, Cactus
+*.czvxce,Coverton
+*.da_vinci_code,Troldesh
 *.darkness,Rakhni
-*.nochance,Rakhni
-*.oshit,Rakhni
-*.oplata@qq_com,Rakhni
-*.relock@qq_com,Rakhni
-*.crypto,Rakhni
-*.helpdecrypt@ukr.net,Rakhni
-*.pizda@qq_com,Rakhni
+*.ded,DEDCryptor
+*.disposed2017,Samas-Samsam
+*.domino,Domino
 *.dyatel@qq_com,Rakhni
-*._ryp,Rakhni
-*.nalog@qq_com,Rakhni
-*.chifrator@qq_com,Rakhni
-*.gruzin@qq_com,Rakhni
-*.troyancoder@qq_com,Rakhni
-*.encrypted,Rakhni
-*.cry,Rakhni
-*.AES256,Rakhni
-*.enc,Rakhni
-*.hb15,Rakhni
-*.vscrypt,Rector
-*.infected,Rector
-*.bloc,Rector
-*.korrektor,Rector
-*.rekt,RektLocker
-*.remind,RemindMe
-*.crashed,RemindMe
-*.rokku,Rokku
+*.ecc,TeslaCrypt 0.x - 2.2.0
+*.encedRSA,Samas-Samsam
+*.EnCiPhErEd,Xorist
+*.encmywork,Samas-Samsam
+*.encoderpass,Xorist
+*.encrypt,Alpha Ransomware
+*.encrypted,CryptoLocker / Apocalypse / CuteRansomware / Others
 *.encryptedAES,Samas-Samsam
 *.encryptedRSA,Samas-Samsam
-*.encedRSA,Samas-Samsam
-*.justbtcwillhelpyou,Samas-Samsam
-*.btcbtcbtc,Samas-Samsam
-*.btc-help-you,Samas-Samsam
-*.only-we_can_help_you,Samas-Samsam
-*.iwanthelpuuu,Samas-Samsam
-*.notfoundrans,Samas-Samsam
-*.encmywork,Samas-Samsam
-*.weapologize,Samas-Samsam
-*.stubbin,Samas-Samsam
-*.areyoulovemyrans,Samas-Samsam
-*.loveransisgood,Samas-Samsam
-*.myransext2017,Samas-Samsam
-*.disposed2017,Samas-Samsam
-*.prosperous666,Samas-Samsam
-*.supported2017,Samas-Samsam
-*.country82000,Samas-Samsam
-*.moments2900,Samas-Samsam
-*.breeding123,Samas-Samsam
-*.mention9823,Samas-Samsam
-*.suppose666,Samas-Samsam
-*.skjdthghh,Samas-Samsam
-*.cifgksaffsfyghd,Samas-Samsam
-*.iaufkakfhsaraf,Samas-Samsam
-*.filegofprencrp,Samas-Samsam
-*.weencedufiles,Samas-Samsam
 *.encryptedyourfiles,Samas-Samsam
-*.letmetrydecfiles,Samas-Samsam
-*.otherinformation,Samas-Samsam
-*.weareyourfriends,Samas-Samsam
-*.noproblemwedecfiles,Samas-Samsam
-*.powerfulldecrypt,Samas-Samsam
-*.wowreadfordecryp,Samas-Samsam
-*.wowwhereismyfiles,Samas-Samsam
-*.helpmeencedfiles,Samas-Samsam
-*.theworldisyours,Samas-Samsam
-*.vekanhelpu,Samas-Samsam
-*.howcanihelpusir,Samas-Samsam
-*.VforVendetta,Samas-Samsam
-*.checkdiskenced,Samas-Samsam
-*.goforhelp,Samas-Samsam
-*.iloveworld,Samas-Samsam
-*.canihelpyou,Samas-Samsam
-*.AreYouLoveMyRansFile,Samas-Samsam
-*.fucku,Samas-Samsam
-*.happenencedfiles,Samas-Samsam
-*.iwishiyou,Samas-Samsam
-*.powerfulldecryp,Samas-Samsam
-*.suppose665,Samas-Samsam
-*.Whereisyourfiles,Samas-Samsam
-*.sanction,Sanction
-*.locked,Shark
-*.shino,ShinoLocker
-*.locked,SkidLocker / Pompous
-*.encrypted,Smrss32
-*.RSNSlocked,SNSLocker
-*.RSplited,SNSLocker
-*.sport,Sport
-*.locked,Stampado
-*.locked,Strictor
-*.surprise,Surprise
-*.tzu,Surprise
-*.szf,SZFLocker
-*.xcri,TeleCrypt
-*.vvv,TeslaCrypt 0.x - 2.2.0
-*.ecc,TeslaCrypt 0.x - 2.2.0
+*.enigma,Coverton / Enigma
+*.epic,Jigsaw
+*.exotic,Exotic
 *.exx,TeslaCrypt 0.x - 2.2.0
 *.ezz,TeslaCrypt 0.x - 2.2.0
-*.abc,TeslaCrypt 0.x - 2.2.0
-*.aaa,TeslaCrypt 0.x - 2.2.0
-*.zzz,TeslaCrypt 0.x - 2.2.0
-*.xyz,TeslaCrypt 0.x - 2.2.0
-*.micro,TeslaCrypt 3.0+
-*.xxx,TeslaCrypt 3.0+
-*.ttt,TeslaCrypt 3.0+
-*.mp3,TeslaCrypt 3.0+
-*.Encrypted,TorrentLocker
-*.enc,TorrentLocker
-*.toxcrypt,Toxcrypt
-*.better_call_saul,Troldesh
-*.xtbl,Troldesh
-*.da_vinci_code,Troldesh
-*.windows10,Troldesh
-*.enc,TrueCrypter
-*.locked,Turkish Ransom
-*.H3LL,Ungluk
-*.0x0,Ungluk
-*.1999,Ungluk
-*.CRRRT,Unlock92
-*.CCCRRRPPP,Unlock92
-*.vault,VaultCrypt
-*.xort,VaultCrypt
-*.trun,VaultCrypt
-*.Venusf,VenusLocker
-*.Venusp,VenusLocker
-*.CrySiS,Virus-Encoder
-*.xtbl,Virus-Encoder
-*.wflx,WildFire Locker
-*.EnCiPhErEd,Xorist
-*.73i87A,Xorist
-*.p5tkjw,Xorist
-*.PoAr2w,Xorist
+*.fantom,Fantom
+*.filegofprencrp,Samas-Samsam
 *.fileiscryptedhard,Xorist
-*.encoderpass,Xorist
-*.zc3791,Xorist
-*.xrtn,XRTN
-*.zcrypt,Zcrypt
-*.crypto,Zimbra
-*.vault,Zlader / Russian
-*.zyklon,Zyklon
-*.wncry,WannaCry
-*.wcry,WannaCry
-*.wnry,WannaCry
-*.wncryt,WannaCry
-*.WNCRYT,WannaCry
-*.RYK,Ryuk
-*.Clop,Clop
-*.Cllp,Clop
-*.JSWORM,JSWorm
-*.NEMTY_*,Nemty
-*.NEFILIM,Nefilim
-*.OFFWHITE,Offwhite
-*.TELEGRAM,Telegram
+*.filock,Popcorn Time
+*.frtrss,CryptoFortress
+*.fuck,MireWare
+*.fucked,MireWare
+*.fucku,Samas-Samsam
+*.FuckYourData,Apocalypse
+*.fun,Jigsaw
 *.FUSION,Fusion
-*.MILIHPEN,Milihpen
 *.GANGBANG,Gangbang
-*.reddot,RedDot
+*.globe,Globe v3
+*.goforhelp,Samas-Samsam
+*.gruzin@qq_com,Rakhni
+*.gws,Jigsaw
+*.H3LL,Ungluk
+*.ha3,El-Polocker
+*.happenencedfiles,Samas-Samsam
+*.hb15,Rakhni
+*.helpdecrypt@ukr.net,Rakhni
+*.helpmeencedfiles,Samas-Samsam
+*.herbst,Herbst
+*.howcanihelpusir,Samas-Samsam
+*.iaufkakfhsaraf,Samas-Samsam
+*.iloveworld,Samas-Samsam
+*.infected,Rector
+*.interlock,Interlock
+*.isis,EduCrypt
+*.iwanthelpuuu,Samas-Samsam
+*.iwishiyou,Samas-Samsam
+*.JSWORM,JSWorm
+*.justbtcwillhelpyou,Samas-Samsam
+*.keybtc@inbox_com,KeyBTC
+*.KEYH0LES,Mobef
+*.KEYZ,Mobef
+*.kimcilware,KimcilWare
+*.kkk,Jigsaw
+*.korrektor,Rector
+*.kostya,Kostya
+*.kraken,Rakhni
+*.kratos,KratosCrypt
+*.LeChiffre,LeChiffre
+*.letmetrydecfiles,Samas-Samsam
+*.lock93,Lock93
+*.locked,ApocalypseVM / CryptoShocker / HiddenTear / Others
+*.locky,AutoLocky
+*.locky,Hucky
+*.locky,Locky
+*.locky,PowerWare
+*.LOL!,OMG! Ransomware
+*.loveransisgood,Samas-Samsam
+*.magic,Magic
 *.MEDUSA,Medusa
+*.mention9823,Samas-Samsam
+*.micro,TeslaCrypt 3.0+
+*.MILIHPEN,Milihpen
+*.moments2900,Samas-Samsam
+*.mp3,TeslaCrypt 3.0+
+*.myransext2017,Samas-Samsam
+*.nalog@qq_com,Rakhni
+*.NEFILIM,Nefilim
+*.NEMTY_*,Nemty
+*.nochance,Rakhni
+*.noproblemwedecfiles,Samas-Samsam
+*.notfoundrans,Samas-Samsam
+*.odcodc,ODCODC
+*.odin,Locky
+*.OFFWHITE,Offwhite
+*.OMG!,OMG! Ransomware
+*.only-we_can_help_you,Samas-Samsam
+*.oor,LowLevel04
+*.oplata@qq_com,Rakhni
+*.oshit,Rakhni
+*.osiris,Locky
+*.otherinformation,Samas-Samsam
+*.p5tkjw,Xorist
+*.padcrypt,PadCrypt
+*.paybtcs,Jigsaw
+*.payms,Jigsaw
+*.paymst,Jigsaw
+*.payransom,Jigsaw
+*.perl,Bart
+*.pizda@qq_com,Rakhni
+*.PoAr2w,Xorist
+*.porno,Jigsaw
+*.powerfulldecryp,Samas-Samsam
+*.powerfulldecrypt,Samas-Samsam
+*.prosperous666,Samas-Samsam
+*.purge,Globe v1
+*.R4A,7ev3n
+*.R5A,7ev3n
+*.RAD,Radamant
+*.RADAMANT,Radamant
+*.RDM,Radamant
+*.reddot,RedDot
+*.rekt,RektLocker
+*.relock@qq_com,Rakhni
+*.remind,RemindMe
 *.rhysida,Rhysida
-*.basta, BlackBasta
-*.cts, Cactus
-*.cactus, Cactus
+*.rip,Killer Locker
+*.rokku,Rokku
+*.RRK,Radamant
+*.RSNSlocked,SNSLocker
+*.RSplited,SNSLocker
+*.RYK,Ryuk
+*.sanction,Sanction
+*.scl,CryptFIle2 / CryptoMix
+*.SecureCrypted,Apocalypse
+*.shino,ShinoLocker
+*.shit,Locky
+*.Silent,BlackShades Crypter
+*.skjdthghh,Samas-Samsam
+*.sport,Sport
+*.stubbin,Samas-Samsam
+*.supported2017,Samas-Samsam
+*.suppose665,Samas-Samsam
+*.suppose666,Samas-Samsam
+*.surprise,Surprise
+*.szf,SZFLocker
+*.TELEGRAM,Telegram
+*.termite,Termite
+*.theworldisyours,Samas-Samsam
+*.thor,Locky
+*.toxcrypt,Toxcrypt
+*.troyancoder@qq_com,Rakhni
+*.trun,VaultCrypt
+*.tzu,Surprise
+*.unavailable,Apocalypse
 *.vanhelsing,Vanhelsing
 *.vanlocker,Vanhelsing
-*.termite,Termite
-*.interlock,Interlock
-*.1nt3rlock,Interlock
-*.locked,NailaoLocker
+*.vault,VaultCrypt / Zlader
+*.vekanhelpu,Samas-Samsam
+*.Venusf,VenusLocker
+*.Venusp,VenusLocker
+*.VforVendetta,Samas-Samsam
+*.vscrypt,Rector
+*.vvv,TeslaCrypt 0.x - 2.2.0
+*.wcry,WannaCry
+*.weapologize,Samas-Samsam
+*.weareyourfriends,Samas-Samsam
+*.weencedufiles,Samas-Samsam
+*.wflx,WildFire Locker
+*.Where_my_files.txt,Apocalypse
+*.Whereisyourfiles,Samas-Samsam
+*.windows10,Troldesh
+*.wncry,WannaCry
+*.wncryt,WannaCry
+*.wnry,WannaCry
+*.wowreadfordecryp,Samas-Samsam
+*.wowwhereismyfiles,Samas-Samsam
+*.xcri,TeleCrypt
+*.xort,VaultCrypt
+*.xrtn,XRTN
+*.xtbl,Troldesh / Virus-Encoder
+*.xxx,TeslaCrypt 3.0+
+*.xyz,Jigsaw
+*.xyz,TeslaCrypt 0.x - 2.2.0
+*.Z81928819,GhostCrypt
+*.zc3791,Xorist
+*.zcrypt,Zcrypt
+*.zepto,Locky
+*.zyklon,Zyklon
+*.zzz,TeslaCrypt 0.x - 2.2.0
+*.zzzzz,Locky

--- a/lookups/ransomware_extensions_lookup.yml
+++ b/lookups/ransomware_extensions_lookup.yml
@@ -1,6 +1,6 @@
 name: ransomware_extensions_lookup
-date: 2025-07-28
-version: 4
+date: 2025-10-01
+version: 5
 id: eaf9e6bb-55fa-4bab-89a5-b0229638c526
 author: Splunk Threat Research Team
 lookup_type: csv

--- a/removed/deprecation_mapping.YML
+++ b/removed/deprecation_mapping.YML
@@ -1,16 +1,16 @@
 detections:
   - content: Detect Rundll32 Application Control Bypass - setupapi
-    removed_in_version: 5.16.0
+    removed_in_version: 5.17.0
     reason: Detection has been deprecated since it has been replaced with a better named detection that reflect a much better consistent logic
     replacement_content:
     - Windows Application Whitelisting Bypass Attempt via Rundll32
   - content: Detect Rundll32 Application Control Bypass - syssetup
-    removed_in_version: 5.16.0
+    removed_in_version: 5.17.0
     reason: Detection has been deprecated since it has been replaced with a better named detection that reflect a much better consistent logic
     replacement_content:
     - Windows Application Whitelisting Bypass Attempt via Rundll32
   - content: Detect Rundll32 Application Control Bypass - advpack
-    removed_in_version: 5.16.0
+    removed_in_version: 5.17.0
     reason: Detection has been deprecated since it has been replaced with a better named detection that reflect a much better consistent logic
     replacement_content:
     - Windows Application Whitelisting Bypass Attempt via Rundll32

--- a/removed/deprecation_mapping.YML
+++ b/removed/deprecation_mapping.YML
@@ -1,4 +1,19 @@
 detections:
+  - content: Detect Rundll32 Application Control Bypass - setupapi
+    removed_in_version: 5.16.0
+    reason: Detection has been deprecated since it has been replaced with a better named detection that reflect a much better consistent logic
+    replacement_content:
+    - Windows Application Whitelisting Bypass Attempt via Rundll32
+  - content: Detect Rundll32 Application Control Bypass - syssetup
+    removed_in_version: 5.16.0
+    reason: Detection has been deprecated since it has been replaced with a better named detection that reflect a much better consistent logic
+    replacement_content:
+    - Windows Application Whitelisting Bypass Attempt via Rundll32
+  - content: Detect Rundll32 Application Control Bypass - advpack
+    removed_in_version: 5.16.0
+    reason: Detection has been deprecated since it has been replaced with a better named detection that reflect a much better consistent logic
+    replacement_content:
+    - Windows Application Whitelisting Bypass Attempt via Rundll32
   - content: Cisco Secure Application Alerts
     removed_in_version: 5.14.0
     reason: Detection has been deprecated since it has been replaced with a better named detection to reflect the correct product

--- a/removed/deprecation_mapping.YML
+++ b/removed/deprecation_mapping.YML
@@ -1,4 +1,9 @@
 detections:
+  - content: Windows Change Default File Association For No File Ext
+    removed_in_version: 5.17.0
+    reason: Detection has been deprecated since it has been replaced with a better named detection that reflect a much better consistent logic
+    replacement_content:
+    - Windows Change File Association Command To Notepad
   - content: Detect Rundll32 Application Control Bypass - setupapi
     removed_in_version: 5.17.0
     reason: Detection has been deprecated since it has been replaced with a better named detection that reflect a much better consistent logic


### PR DESCRIPTION
This PR fixes the following issues

- Fix #3684
- Fix #3702
- Fix #3605
- Fix #3714

It also updates/adds these rules

- Deprecate `Detect Rundll32 Application Control Bypass - advpack`, `Detect Rundll32 Application Control Bypass - setupapi` and `Detect Rundll32 Application Control Bypass - syssetup` in favor of a unified rule `Windows Application Whitelisting Bypass Attempt via Rundll32` since they are all related. - cc @MHaggis 
- Deprecate `Windows Change Default File Association For No File Ext` and replace it by `Windows Change File Association Command To Notepad`. The reason is that the original rule was incorrectly looking file without extensions, but in reality the TTP is a TA after encrypting files with a certain extensions (in this case `.enc` they add a handler for that extensions to open all files with notepad and the ransom note). cc @t-contreras 

- Updates `Add or Set Windows Defender Exclusion` with additional flags, namely `ControlledFolderAccessAllowedApplications` and `AttackSurfaceReductionOnlyExclusions`
- Reduce the `Attempt To Add Certificate To Untrusted Store` analytic to an `Anomaly` because this is found to be common by some installers.
- Fix the regex in `Common Ransomware Extensions` to account for double extension files.
- Updated `Linux Java Spawning Shell` and `Windows Java Spawning Shells` by removing `apache` and `w3wp.exe` respectively as they are unrelated to those rules. I did create `Web or Application Server Spawning a Shell` as a generic rule covering both linux and windows instances with a lot more web server and app server names.
- Updated `USN Journal Deletion` in order to filter for the deletion keyword at the search level not after the results for better performance.
- Updated `Windows Archived Collected Data In TEMP Folder` to used specific folders instead of just `\\temp\\` to avoid accidental FPs. As well as reducing it to an Anomaly rule since I found multiple cases where a match was found.
- Updated `Windows AutoIt3 Execution` - Added an OFN field and removed the overlap of the string.
- Updated `Windows Certutil Root Certificate Addition` by focusing on specific paths in order to avoid FPs. Since installers were found doing this as per elastic rule and VT results.
- Added the `--output-dir` flag to the rule `Windows Curl Download to Suspicious Path`
- Updated `Windows Information Discovery Fsutil` with additional flags, namely the `volume` sub-command that allows the discovery of disk information and was used by a TA before.
- Added `pwsh.exe` as a possible value to `Windows Remote Management Execute Shell`
- Enhanced `Windows Renamed Powershell Execution` by adding OFN fields, `powershell_ise.exe` and split the logic to be more accurate.
- Split the string logic in `Windows Rundll32 Apply User Settings Changes` to be more generic and avoid easy bypass using spaces.
- Updated `Windows Scheduled Task Created Via XML` with additional flags and OFN field as well as updated the different metadata sections.
- Added new analytic `Windows Symlink Evaluation Change via Fsutil`