### PR TITLE
Fix #3720

### DIFF
--- a/detections/endpoint/windows_ad_self_dacl_assignment.yml
+++ b/detections/endpoint/windows_ad_self_dacl_assignment.yml
@@ -1,37 +1,90 @@
 name: Windows AD Self DACL Assignment
 id: 16132445-da9f-4d03-ad44-56d717dcd67d
-version: 6
-date: '2025-05-02'
+version: 7
+date: '2025-10-13'
 author: Dean Luxton
 status: production
 type: TTP
 data_source:
 - Windows Event Log Security 5136
 description: Detect when a user creates a new DACL in AD for their own AD object.
-search: '`wineventlog_security` EventCode=5136 | stats min(_time) as _time values(eval(if(OperationType=="%%14675",AttributeValue,null)))
-  as old_value values(eval(if(OperationType=="%%14674" ,AttributeValue,null))) as
-  new_value values(OperationType) as OperationType by ObjectClass ObjectDN OpCorrelationID
-  src_user SubjectLogonId dest | rex field=old_value max_match=10000 "\((?P<old_values>.*?)\)"
-  | rex field=new_value max_match=10000 "\((?P<new_ace>.*?)\)" | mvexpand new_ace
-  | where NOT new_ace IN (old_values) | rex field=new_ace "(?P<aceType>.*?);(?P<aceFlags>.*?);(?P<aceAccessRights>.*?);(?P<aceObjectGuid>.*?);(?P<aceInheritedTypeGuid>.*?);(?P<aceSid>.*?)$"
-  | rex max_match=100 field=aceAccessRights "(?P<AccessRights>[A-Z]{2})" | rex max_match=100
-  field=aceFlags "(?P<aceFlags>[A-Z]{2})" | lookup ace_type_lookup ace_type_string
-  as aceType OUTPUT ace_type_value as aceType | lookup ace_flag_lookup flag_string
-  as aceFlags OUTPUT flag_value as ace_flag_value | lookup ace_access_rights_lookup
-  access_rights_string as AccessRights OUTPUT access_rights_value | lookup msad_guid_lookup
-  guid as aceObjectGuid OUTPUT displayName as ControlAccessRights | lookup builtin_groups_lookup
-  builtin_group_string as aceSid OUTPUT builtin_group_name as builtin_group | eval
-  aceType=coalesce(ace_type_value,aceType), aceInheritance=coalesce(ace_flag_value,"This
-  object only"), aceAccessRights=if(aceAccessRights="CCDCLCSWRPWPDTLOCRSDRCWDWO","Full
-  control",coalesce(access_rights_value,AccessRights)), aceControlAccessRights=if((ControlAccessRights="Write
-  member" OR aceObjectGuid="bf9679c0-0de6-11d0-a285-00aa003049e2") AND (aceAccessRights="All
-  validated writes" OR AccessRights="SW"),"Add/remove self as member",coalesce(ControlAccessRights,aceObjectGuid)),user=coalesce(user,
-  group, builtin_group, aceSid) | stats values(aceType) as aceType values(aceInheritance)
-  as aceInheritance values(aceControlAccessRights) as aceControlAccessRights values(aceAccessRights)
-  as aceAccessRights values(new_ace) as new_ace values(aceInheritedTypeGuid) as aceInheritedTypeGuid
+search: |
+  `wineventlog_security` 
+  EventCode=5136 
+  | stats min(_time) as _time 
+          values(
+            eval(
+              if(OperationType=="%%14675",AttributeValue,null)
+              )
+          ) as old_value 
+          
+          values(
+            eval(
+              if(OperationType=="%%14674" ,AttributeValue,null)
+            )
+          ) as new_value 
+          
+          values(OperationType) as OperationType 
+  by ObjectClass ObjectDN OpCorrelationID src_user SubjectLogonId dest 
+  
+  | rex field=old_value max_match=10000 "\((?P<old_values>.*?)\)"
+  | rex field=new_value max_match=10000 "\((?P<new_ace>.*?)\)" 
+  | mvexpand new_ace
+  | where NOT new_ace IN (old_values) 
+  | rex field=new_ace "(?P<aceType>.*?);(?P<aceFlags>.*?);(?P<aceAccessRights>.*?);(?P<aceObjectGuid>.*?);(?P<aceInheritedTypeGuid>.*?);(?P<aceSid>.*?)$"
+  | rex max_match=100 field=aceAccessRights "(?P<AccessRights>[A-Z]{2})" 
+  | rex max_match=100 field=aceFlags "(?P<aceFlags>[A-Z]{2})" 
+  
+  | lookup ace_type_lookup ace_type_string as aceType OUTPUT ace_type_value as aceType 
+  | lookup ace_flag_lookup flag_string as aceFlags OUTPUT flag_value as ace_flag_value 
+  | lookup ace_access_rights_lookup access_rights_string as AccessRights OUTPUT access_rights_value 
+  | lookup msad_guid_lookup guid as aceObjectGuid OUTPUT displayName as ControlAccessRights 
+  
+  ``` Optional SID resolution lookups  
+  | lookup identity_lookup_expanded objectSid as aceSid OUTPUT downLevelDomainName as user  
+  | lookup admon_groups_def objectSid as aceSid OUTPUT cn as group  
+  ```
+  
+  | lookup builtin_groups_lookup builtin_group_string as aceSid OUTPUT builtin_group_name as builtin_group 
+  
+  | eval aceType = coalesce(ace_type_value, aceType), 
+         aceInheritance = coalesce(ace_flag_value, "This object only"), 
+         aceAccessRights = if(
+                              aceAccessRights = "CCDCLCSWRPWPDTLOCRSDRCWDWO", "Full control", coalesce(access_rights_value,AccessRights)
+                            ), 
+         aceControlAccessRights = if(
+                                (
+                                  ControlAccessRights = "Write member" 
+                                  OR 
+                                  aceObjectGuid = "bf9679c0-0de6-11d0-a285-00aa003049e2"
+                                ) AND 
+                                (
+                                  aceAccessRights = "All validated writes" 
+                                  OR 
+                                  AccessRights = "SW"
+                                ), 
+                                "Add/remove self as member", 
+                                coalesce(ControlAccessRights,aceObjectGuid)
+                              ), 
+         user=coalesce(user, group, builtin_group, aceSid) 
+         
+  | stats values(aceType) as aceType 
+          values(aceInheritance) as aceInheritance 
+          values(aceControlAccessRights) as aceControlAccessRights 
+          values(aceAccessRights) as aceAccessRights 
+          values(new_ace) as new_ace 
+          values(aceInheritedTypeGuid) as aceInheritedTypeGuid 
+  
   by _time ObjectClass ObjectDN src_user SubjectLogonId user OpCorrelationID dest
-  | eval aceControlAccessRights=if(mvcount(aceControlAccessRights)=1 AND aceControlAccessRights="","All
-  rights","aceControlAccessRights") | `windows_ad_self_dacl_assignment_filter`'
+  
+  | eval aceControlAccessRights = if(
+                                    mvcount(aceControlAccessRights) = 1 
+                                    AND 
+                                    aceControlAccessRights = "", "All rights", "aceControlAccessRights"
+                                  ) 
+  | rex field=user "\\\\(?P<nt_user>.*?)$" 
+  | where lower(src_user)=lower(nt_user)
+  | `windows_ad_self_dacl_assignment_filter`
 how_to_implement: Ensure you are ingesting Active Directory audit logs - specifically
   event 5136. See lantern article in references for further on how to onboard AD audit
   data. Ensure the wineventlog_security macro is configured with the correct indexes


### PR DESCRIPTION
This PR fixes the issue raised in #3720

Due to the automation in https://github.com/splunk/security_content/pull/3346 an accidental removal of a `where` and `rex` clauses was introduced.

This PR reintroduces them and beautify the SPL to be more readable. The results in attack data show a single match instead of many.

<img width="2836" height="538" alt="image" src="https://github.com/user-attachments/assets/5c6f5cec-90d2-47da-818c-4f7795e9da19" />
 