### PR TITLE
Add Oracle Exploitation Snort Coverage

### DIFF
--- a/detections/network/cisco_secure_firewall___oracle_e_business_suite_correlation.yml
+++ b/detections/network/cisco_secure_firewall___oracle_e_business_suite_correlation.yml
@@ -66,10 +66,10 @@ how_to_implement: |
   The intrusion access policy must also be configured.
 known_false_positives: False positives should be very unlikely.
 references:
-  - www.oracle.com/security-alerts/alert-cve-2025-61882.html
-  - www.oracle.com/security-alerts/alert-cve-2025-61884.html
-  - labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
-  - cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
+  - https://www.oracle.com/security-alerts/alert-cve-2025-61882.html
+  - https://www.oracle.com/security-alerts/alert-cve-2025-61884.html
+  - https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
+  - https://cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
 drilldown_searches:
 - name: View the detection results for - "$dest_ip$" and "$src_ip$"
   search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'

--- a/detections/network/cisco_secure_firewall___oracle_e_business_suite_correlation.yml
+++ b/detections/network/cisco_secure_firewall___oracle_e_business_suite_correlation.yml
@@ -1,0 +1,117 @@
+name: Cisco Secure Firewall - Oracle E-Business Suite Correlation
+id: 9e995d21-6870-43de-acd9-76f372bcf323
+version: 1
+date: '2025-10-23'
+author: Nasreddine Bencherchali, Splunk, Talos NTDR
+status: production
+type: TTP
+description: |
+  This correlation rule identifies potential exploitation attempts of Oracle E-Business Suite vulnerabilities (CVE-2025-61882 and CVE-2025-61884) by correlating multiple intrusion signatures from Cisco Secure Firewall Threat Defense logs.
+  The detection looks for specific signatures that indicate attempts to exploit the TemplatePreview functionality and vulnerable SyncServlet endpoints as well as post compromise activity involving Cl0p.
+  By correlating these signatures, the analytic aims to identify coordinated exploitation attempts that may indicate an attacker is targeting Oracle E-Business Suite installations.
+  Security teams should investigate any instances of these correlated signatures, especially if they are found in conjunction with other suspicious network activity or on systems that should not be exposed to such threats.
+data_source:
+  - Cisco Secure Firewall Threat Defense Intrusion Event
+search: |
+  `cisco_secure_firewall` EventType=IntrusionEvent signature_id IN (65454, 65455, 65377, 65378, 65413, 65414, 65415, 65456)
+  | bin _time span=5m
+  | fillnull
+  | stats dc(signature_id) as unique_signature_count 
+          values(signature_id) as signature_id 
+          values(signature) as signature 
+          values(class_desc) as class_desc 
+          values(MitreAttackGroups) as MitreAttackGroups 
+          values(InlineResult) as InlineResult 
+          values(InlineResultReason) as InlineResultReason 
+          values(dest_port) as dest_port 
+          values(rule) as rule 
+          values(transport) as transport 
+          values(app) as app 
+          min(_time) as firstTime 
+          max(_time) as lastTime 
+          sum(eval(signature_id==65454)) as sig_template_preview
+          sum(eval(signature_id==65455)) as sig_sync_servlet
+          sum(eval(signature_id IN (65377,65378,65413,65414,65415,65456))) as sig_exploit_activity
+    by src_ip dest_ip
+  | where (
+            (
+              sig_exploit_activity >= 1 
+              AND 
+              (
+                sig_template_preview >= 1 
+                OR 
+                sig_sync_servlet >= 1
+              )
+            )
+          OR
+            (
+              sig_template_preview >= 1
+              AND 
+              sig_sync_servlet >= 1
+            )
+          OR
+            unique_signature_count >= 2
+          )
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `cisco_secure_firewall___oracle_e_business_suite_correlation_filter`
+how_to_implement: |
+  This search requires Cisco Secure Firewall Threat Defense Logs, which
+  includes the IntrusionEvent EventType. This search uses an input macro named `cisco_secure_firewall`.
+  We strongly recommend that you specify your environment-specific configurations
+  (index, source, sourcetype, etc.) for Cisco Secure Firewall Threat Defense logs. Replace the macro definition
+  with configurations for your Splunk environment. The search also uses a post-filter
+  macro designed to filter out known false positives.
+  The logs are to be ingested using the Splunk Add-on for Cisco Security Cloud (https://splunkbase.splunk.com/app/7404).
+  The intrusion access policy must also be configured.
+known_false_positives: False positives should be very unlikely.
+references:
+  - www.oracle.com/security-alerts/alert-cve-2025-61882.html
+  - www.oracle.com/security-alerts/alert-cve-2025-61884.html
+  - labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
+  - cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
+drilldown_searches:
+- name: View the detection results for - "$dest_ip$" and "$src_ip$"
+  search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest_ip$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+    as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
+    as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Multiple Oracle E-Business Suite exploitation signatures $signature_id$ detected from source IP $src_ip$ to destination IP $dest_ip$
+  risk_objects:
+    - field: dest_ip
+      type: system
+      score: 25
+  threat_objects:
+    - field: signature
+      type: signature
+    - field: src_ip
+      type: ip_address
+tags:
+  analytic_story: 
+    - Cisco Secure Firewall Threat Defense Analytics
+    - Oracle E-Business Suite Exploitation
+  asset_type: Network
+  cve:
+    - CVE-2025-61882
+    - CVE-2025-61884
+  security_domain: network
+  mitre_attack_id:
+    - T1190
+  product:
+    - Splunk Enterprise
+    - Splunk Cloud
+    - Splunk Enterprise Security
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/oracle_e_business_suite/oracle_e_business_suite.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/cisco_secure_firewall___oracle_e_business_suite_exploitation.yml
+++ b/detections/network/cisco_secure_firewall___oracle_e_business_suite_exploitation.yml
@@ -36,10 +36,10 @@ how_to_implement: |
   The intrusion access policy must also be configured.
 known_false_positives: False positives should be unlikely.
 references:
-  - www.oracle.com/security-alerts/alert-cve-2025-61882.html
-  - www.oracle.com/security-alerts/alert-cve-2025-61884.html
-  - labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
-  - cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
+  - https://www.oracle.com/security-alerts/alert-cve-2025-61882.html
+  - https://www.oracle.com/security-alerts/alert-cve-2025-61884.html
+  - https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
+  - https://cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
 drilldown_searches:
 - name: View the detection results for - "$dest_ip$" and "$src_ip$"
   search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'

--- a/detections/network/cisco_secure_firewall___oracle_e_business_suite_exploitation.yml
+++ b/detections/network/cisco_secure_firewall___oracle_e_business_suite_exploitation.yml
@@ -1,0 +1,84 @@
+name: Cisco Secure Firewall - Oracle E-Business Suite Exploitation
+id: 1c077b8a-95a3-4692-980d-c72fc50e9930
+version: 1
+date: '2025-04-26'
+author: Nasreddine Bencherchali, Splunk, Talos NTDR
+status: production
+type: TTP
+description: |
+  This analytic detects vulnerability exploitation and post-compromise activity associated with Oracle E-Business Suite web-application vulnerabilities, CVE-2025-61882 and CVE-2025-61884.
+  SIDs 65413-65415 detect detect Java.Backdoor.Cl0p variant payload downloads and Java.Backdoor.Cl0p outbound
+  command-and-control connection attempts.
+  SIDs 65456, 65377 and 65378 detect attempts to exploit these vulnerabilities.
+  Security teams should investigate any instances of these signatures, especially if they are found in conjunction with other suspicious network activity or on systems that should not be exposed to such threats.
+data_source:
+  - Cisco Secure Firewall Threat Defense Intrusion Event
+search: |
+  `cisco_secure_firewall`
+  EventType=IntrusionEvent
+  signature_id IN (65377, 65378, 65413, 65414, 65415, 65456)
+  | fillnull
+  | stats min(_time) as firstTime max(_time) as lastTime
+          by src_ip dest_ip dest_port transport signature_id signature
+             class_desc MitreAttackGroups rule InlineResult
+             InlineResultReason app
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `cisco_secure_firewall___oracle_e_business_suite_exploitation_filter`
+how_to_implement: |
+  This search requires Cisco Secure Firewall Threat Defense Logs, which
+  includes the IntrusionEvent EventType. This search uses an input macro named `cisco_secure_firewall`.
+  We strongly recommend that you specify your environment-specific configurations
+  (index, source, sourcetype, etc.) for Cisco Secure Firewall Threat Defense logs. Replace the macro definition
+  with configurations for your Splunk environment. The search also uses a post-filter
+  macro designed to filter out known false positives.
+  The logs are to be ingested using the Splunk Add-on for Cisco Security Cloud (https://splunkbase.splunk.com/app/7404).
+  The intrusion access policy must also be configured.
+known_false_positives: False positives should be unlikely.
+references:
+  - www.oracle.com/security-alerts/alert-cve-2025-61882.html
+  - www.oracle.com/security-alerts/alert-cve-2025-61884.html
+  - labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
+  - cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
+drilldown_searches:
+- name: View the detection results for - "$dest_ip$" and "$src_ip$"
+  search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$dest_ip$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+    as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
+    as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+rba:
+  message: Network activity associated with Oracle E-Business Suite exploitation detected from source IP $src_ip$ to destination IP $dest_ip$.
+  risk_objects:
+    - field: dest_ip
+      type: system
+      score: 25
+  threat_objects:
+    - field: signature
+      type: signature
+    - field: src_ip
+      type: ip_address
+tags:
+  analytic_story:
+    - Cisco Secure Firewall Threat Defense Analytics
+    - Oracle E-Business Suite Exploitation
+  asset_type: Network
+  security_domain: network
+  mitre_attack_id:
+    - T1190
+  product:
+    - Splunk Enterprise
+    - Splunk Cloud
+    - Splunk Enterprise Security
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/oracle_e_business_suite/oracle_e_business_suite.log
+    source: not_applicable
+    sourcetype: cisco:sfw:estreamer

--- a/detections/network/cisco_secure_firewall___oracle_e_business_suite_exploitation.yml
+++ b/detections/network/cisco_secure_firewall___oracle_e_business_suite_exploitation.yml
@@ -18,10 +18,19 @@ search: |
   EventType=IntrusionEvent
   signature_id IN (65377, 65378, 65413, 65414, 65415, 65456)
   | fillnull
-  | stats min(_time) as firstTime max(_time) as lastTime
-          by src_ip dest_ip dest_port transport signature_id signature
-             class_desc MitreAttackGroups rule InlineResult
-             InlineResultReason app
+  | stats values(signature_id) as signature_id 
+          values(signature) as signature 
+          values(class_desc) as class_desc 
+          values(MitreAttackGroups) as MitreAttackGroups 
+          values(InlineResult) as InlineResult 
+          values(InlineResultReason) as InlineResultReason 
+          values(dest_port) as dest_port 
+          values(rule) as rule 
+          values(transport) as transport 
+          values(app) as app 
+          min(_time) as firstTime 
+          max(_time) as lastTime 
+    by src_ip dest_ip
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___oracle_e_business_suite_exploitation_filter`

--- a/stories/oracle_e_business_suite_exploitation.yml
+++ b/stories/oracle_e_business_suite_exploitation.yml
@@ -1,0 +1,26 @@
+name: Oracle E-Business Suite Exploitation
+id: 3d34b43e-204a-4a57-895f-1aafaefdbcb8
+version: 1
+date: '2025-10-23'
+author: Nasreddine Bencherchali, splunk
+status: production
+description: |
+  Leverage searches that allow you to detect and investigate unusual activities
+  that might relate to the exploitation of Oracle E-Business Suite vulnerabilities (CVE-2025-61882 and CVE-2025-61884).
+narrative: |
+  This story addresses Oracle E-Business Suite exploitation. This story focuses on the detection of exploitation attempts
+  targeting Oracle E-Business Suite vulnerabilities, specifically CVE-2025-61882 and CVE-2025-61884. These vulnerabilities have been actively exploited in the wild,
+  allowing attackers to execute arbitrary code on vulnerable systems. The story provides analytics to help security operations centers (SOCs) and security researchers monitor and respond to potential exploitation attempts.
+references:
+  - www.oracle.com/security-alerts/alert-cve-2025-61882.html
+  - www.oracle.com/security-alerts/alert-cve-2025-61884.html
+  - labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
+  - cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
+tags:
+  category:
+  - Adversary Tactics
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  usecase: Advanced Threat Detection

--- a/stories/oracle_e_business_suite_exploitation.yml
+++ b/stories/oracle_e_business_suite_exploitation.yml
@@ -12,10 +12,10 @@ narrative: |
   targeting Oracle E-Business Suite vulnerabilities, specifically CVE-2025-61882 and CVE-2025-61884. These vulnerabilities have been actively exploited in the wild,
   allowing attackers to execute arbitrary code on vulnerable systems. The story provides analytics to help security operations centers (SOCs) and security researchers monitor and respond to potential exploitation attempts.
 references:
-  - www.oracle.com/security-alerts/alert-cve-2025-61882.html
-  - www.oracle.com/security-alerts/alert-cve-2025-61884.html
-  - labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
-  - cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
+  - https://www.oracle.com/security-alerts/alert-cve-2025-61882.html
+  - https://www.oracle.com/security-alerts/alert-cve-2025-61884.html
+  - https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
+  - https://cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
 tags:
   category:
   - Adversary Tactics


### PR DESCRIPTION
This PR adds 2 new analytic corresponding to the snort coverage added by TALOS NTDR.