### PR TITLE
Add detection: Credential Dumping via Symlink to Shadow Copy New

### DIFF
--- a/detections/threat/credential_dumping_via_symlink_to_shadow_copy_new/credential_dumping_via_symlink_to_shadow_copy_new.yml
+++ b/detections/threat/credential_dumping_via_symlink_to_shadow_copy_new/credential_dumping_via_symlink_to_shadow_copy_new.yml
@@ -1,0 +1,53 @@
+name: Credential Dumping via Symlink to Shadow Copy New
+id: 073bb738-f5dd-4c64-8724-b121122a0159
+version: 1
+date: '2025-11-03'
+author: PB
+description: 'The following analytic detects the behavior of credential dumping via the creation of symbolic links to Windows Volume Shadow Copies. It identifies processes that execute the `mklink` command targeting shadow copies, indicating a potential attempt to extract sensitive credentials stored in these backups. This behavior is detected by analyzing process command-line arguments within the Endpoint Processes data model, specifically looking for instances where symbolic links are created to shadow copy volumes.
+
+
+  Identifying this behavior is crucial for a Security Operations Center (SOC) because credential dumping is a common tactic employed by attackers to gain unauthorized access to systems and networks. By detecting this activity early, the SOC can respond to potential security breaches before attackers can exploit stolen credentials.
+
+
+  The impact of such an attack can be severe, leading to unauthorized access to sensitive information, compromise of user accounts, and potential lateral movement within the network, ultimately jeopardizing the organization''s security posture and integrity.'
+type: TTP
+status: production
+tags:
+  analytic_story:
+  - test
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1003.003
+  product:
+  - Splunk Enterprise Security
+  security_domain: threat
+search: "| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)\n  as lastTime from datamodel=Endpoint.Processes where `process_cmd` Processes.process=*mklink*\n  Processes.process=*HarddiskVolumeShadowCopy* by Processes.action Processes.dest\n  Processes.original_file_name Processes.parent_process Processes.parent_process_exec\n  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name\n  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid\n  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name\n  Processes.process_path Processes.user Processes.user_id Processes.vendor_product\n  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)`\n  | `credential_dumping_via_symlink_to_shadow_copy_filter`"
+how_to_implement: None
+known_false_positives: None
+references: null
+drilldown:
+  drilldown_searches:
+  - name: View the detection results for - "$user$" and "$dest$"
+    search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$user$" and "$dest$"
+    search: "| from datamodel Risk.All_Risk | search normalized_risk_object IN (\"$user$\",\n      \"$dest$\") starthoursago=168  | stats count min(_time) as firstTime max(_time)\n      as lastTime values(search_name) as \"Search Name\" values(risk_message) as \"Risk\n      Message\" values(analyticstories) as \"Analytic Stories\" values(annotations._all)\n      as \"Annotations\" values(annotations.mitre_attack.mitre_tactic) as \"ATT&CK Tactics\"\n      by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`"
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+rba:
+  message: An instance of $parent_process_name$ spawning $process_name$ was identified on endpoint $dest$ by user $user$ attempting to create symlink to a shadow copy to grab credentials.
+  risk_objects:
+  - field: user
+    type: user
+    score: 81
+  - field: dest
+    type: system
+    score: 81
+  threat_objects: []
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/attack_techniques/T1003.003/credential-dumping-via-symlink/data.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog


### PR DESCRIPTION
## Security Content Detection

**Name**: Credential Dumping via Symlink to Shadow Copy New

**Security Domain**: threat

**Path**: `detections/threat/credential_dumping_via_symlink_to_shadow_copy_new/credential_dumping_via_symlink_to_shadow_copy_new.yml`

**Author**: PB

This PR adds a new detection YAML generated by STRT Bot.