### PR TITLE
Add detection: Credential Dumping via Symlink to Shadow Copy New

### DIFF
--- a/detections/endpoint/credential_dumping_via_symlink_to_shadow_copy_new.yml
+++ b/detections/endpoint/credential_dumping_via_symlink_to_shadow_copy_new.yml
@@ -1,0 +1,53 @@
+name: Credential Dumping via Symlink to Shadow Copy New
+id: 7d0ce7cb-f1d2-4aec-ae7c-7480c92f555b
+version: 1
+date: '2025-11-05'
+author: PB
+description: 'The following analytic detects credential dumping activities that leverage symbolic links to access Windows shadow copies. It identifies processes that utilize the `mklink` command to create symlinks targeting shadow copies, which may indicate an attacker’s attempt to extract sensitive information, such as passwords and tokens, from these backups. By analyzing process command lines and their relationships with parent processes, the analytic effectively uncovers this malicious behavior.
+
+
+  Identifying this behavior is crucial for a SOC, as credential dumping is a common precursor to further attacks, such as lateral movement or privilege escalation within a network. By detecting these activities early, SOC teams can respond swiftly to mitigate potential breaches.
+
+
+  The impact of successful credential dumping can be severe, leading to unauthorized access to sensitive systems, data exfiltration, and a compromised security posture. Early detection helps to prevent attackers from leveraging stolen credentials to navigate the environment undetected, thus safeguarding organizational assets.'
+type: TTP
+status: production
+tags:
+  analytic_story:
+  - test
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1003.003
+  product:
+  - Splunk Enterprise Security
+  security_domain: threat
+search: "| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)\n  as lastTime from datamodel=Endpoint.Processes where `process_cmd` Processes.process=*mklink*\n  Processes.process=*HarddiskVolumeShadowCopy* by Processes.action Processes.dest\n  Processes.original_file_name Processes.parent_process Processes.parent_process_exec\n  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name\n  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid\n  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name\n  Processes.process_path Processes.user Processes.user_id Processes.vendor_product\n  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)`\n  | `credential_dumping_via_symlink_to_shadow_copy_filter`"
+how_to_implement: None
+known_false_positives: None
+references: null
+drilldown:
+  drilldown_searches:
+  - name: View the detection results for - "$user$" and "$dest$"
+    search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$user$" and "$dest$"
+    search: "| from datamodel Risk.All_Risk | search normalized_risk_object IN (\"$user$\",\n      \"$dest$\") starthoursago=168  | stats count min(_time) as firstTime max(_time)\n      as lastTime values(search_name) as \"Search Name\" values(risk_message) as \"Risk\n      Message\" values(analyticstories) as \"Analytic Stories\" values(annotations._all)\n      as \"Annotations\" values(annotations.mitre_attack.mitre_tactic) as \"ATT&CK Tactics\"\n      by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`"
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+rba:
+  message: An instance of $parent_process_name$ spawning $process_name$ was identified on endpoint $dest$ by user $user$ attempting to create symlink to a shadow copy to grab credentials.
+  risk_objects:
+  - field: dest
+    type: system
+    score: 81
+  - field: user
+    type: user
+    score: 81
+  threat_objects: []
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/attack_techniques/T1003.003/credential-dumping-via-symlink/data.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog


### PR DESCRIPTION
## Security Content Detection

**Name**: Credential Dumping via Symlink to Shadow Copy New

**Security Domain**: threat

**Path**: `detections/endpoint/credential_dumping_via_symlink_to_shadow_copy_new.yml`

**Author**: PB

This PR adds a new detection YAML generated by STRT Bot.