### PR TITLE
Fix - Windows Kerberos Local Successful Logon

### DIFF
--- a/detections/endpoint/windows_kerberos_local_successful_logon.yml
+++ b/detections/endpoint/windows_kerberos_local_successful_logon.yml
@@ -1,7 +1,7 @@
 name: Windows Kerberos Local Successful Logon
 id: 8309c3a8-4d34-48ae-ad66-631658214653
-version: 9
-date: '2025-10-14'
+version: 10
+date: '2025-11-06'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -16,7 +16,7 @@ description: The following analytic identifies a local successful authentication
 data_source:
 - Windows Event Log Security 4624
 search: '`wineventlog_security`  EventCode=4624 LogonType=3 AuthenticationPackageName=Kerberos
-  action=success src=127.0.0.1 | stats count min(_time) as firstTime max(_time) as
+  action=success src=127.0.0.1  | fillnull | stats count min(_time) as firstTime max(_time) as
   lastTime by action app authentication_method dest dvc process process_id process_name
   process_path signature signature_id src src_port status subject user user_group
   vendor_product | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`

--- a/detections/endpoint/windows_svchost_exe_parent_process_anomaly.yml
+++ b/detections/endpoint/windows_svchost_exe_parent_process_anomaly.yml
@@ -74,7 +74,7 @@ tags:
   - Splunk Enterprise Security
   - Splunk Cloud
   security_domain: endpoint
-  manual_test: This detection analytic is not passing unit tests due to a change with the latest windows 9.1.0 TA causing sysmon parsing to fail and the data does not get mapped to the datamodel correctly. Issue details: https://github.com/splunk/splunk-add-on-for-microsoft-windows/issues/563
+  manual_test: This detection analytic is not passing unit tests due to a change with the latest windows 9.1.0 TA causing sysmon parsing to fail and the data does not get mapped to the datamodel correctly. Issue details- https://github.com/splunk/splunk-add-on-for-microsoft-windows/issues/563
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/endpoint/windows_svchost_exe_parent_process_anomaly.yml
+++ b/detections/endpoint/windows_svchost_exe_parent_process_anomaly.yml
@@ -1,7 +1,7 @@
 name: Windows Svchost.exe Parent Process Anomaly
 id: 1d38e5e9-2ff8-4c47-872c-bf1657cefab5
-version: 4
-date: '2025-05-02'
+version: 5
+date: '2025-11-06'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly

--- a/detections/endpoint/windows_svchost_exe_parent_process_anomaly.yml
+++ b/detections/endpoint/windows_svchost_exe_parent_process_anomaly.yml
@@ -1,7 +1,7 @@
 name: Windows Svchost.exe Parent Process Anomaly
 id: 1d38e5e9-2ff8-4c47-872c-bf1657cefab5
-version: 4
-date: '2025-05-02'
+version: 5
+date: '2025-11-07'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly
@@ -74,6 +74,7 @@ tags:
   - Splunk Enterprise Security
   - Splunk Cloud
   security_domain: endpoint
+  manual_test: This detection analytic is not passing unit tests due to a change with the latest windows 9.1.0 TA causing sysmon parsing to fail and the data does not get mapped to the datamodel correctly. Issue details: https://github.com/splunk/splunk-add-on-for-microsoft-windows/issues/563
 tests:
 - name: True Positive Test
   attack_data:

--- a/detections/endpoint/windows_svchost_exe_parent_process_anomaly.yml
+++ b/detections/endpoint/windows_svchost_exe_parent_process_anomaly.yml
@@ -1,7 +1,7 @@
 name: Windows Svchost.exe Parent Process Anomaly
 id: 1d38e5e9-2ff8-4c47-872c-bf1657cefab5
-version: 5
-date: '2025-11-06'
+version: 4
+date: '2025-05-02'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly


### PR DESCRIPTION
adding fillnull as the latest TA does not alias fields process_path and process_name and its not present in the raw event

Manual test added for this issue: https://github.com/splunk/splunk-add-on-for-microsoft-windows/issues/563