### PR TITLE
Add detection: Credential Dumping via Symlink to Shadow Copy New

### DIFF
--- a/detections/endpoint/credential_dumping_via_symlink_to_shadow_copy_new.yml
+++ b/detections/endpoint/credential_dumping_via_symlink_to_shadow_copy_new.yml
@@ -1,0 +1,82 @@
+name: Credential Dumping via Symlink to Shadow Copy New
+id: 46ee5343-bd03-451b-a8d0-255533d198a0
+version: 1
+date: '2025-11-12'
+author: PB
+description: >-
+  The following analytic detects the behavior of credential dumping through the creation
+  of symbolic links to volume shadow copies. It identifies instances where processes
+  utilize the `mklink` command along with accessing hard disk volume shadow copies,
+  indicating an attempt to access sensitive information stored in shadow copies. The
+  analytic captures this behavior by querying for specific process command patterns
+  and their contextual attributes within the security data model. Identifying this
+  behavior is crucial for a SOC because credential dumping is a common tactic used
+  by attackers to gain unauthorized access to systems and sensitive data, often leading
+  to further exploitation or lateral movement within a network. The impact of a successful
+  credential dumping attack can be severe, as it may result in compromised accounts,
+  data breaches, and heightened risk of other malicious activities, ultimately undermining
+  the organization’s security posture. Protecting against this behavior enhances the
+  SOC's ability to detect and mitigate potential threats effectively.
+data_source:
+- Sysmon EventID 1
+- Windows Event Log Security 4688
+- CrowdStrike ProcessRollup2
+type: TTP
+status: production
+tags:
+  analytic_story:
+  - Credential Dumping
+  asset_type: Endpoint
+  mitre_attack_id:
+  - T1003.003
+  product:
+  - Splunk Enterprise Security
+  security_domain: endpoint
+search: |-
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+    as lastTime from datamodel=Endpoint.Processes where `process_cmd` Processes.process=*mklink*
+    Processes.process=*HarddiskVolumeShadowCopy* by Processes.action Processes.dest
+    Processes.original_file_name Processes.parent_process Processes.parent_process_exec
+    Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
+    Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
+    Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
+    Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+    | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)`
+    | `credential_dumping_via_symlink_to_shadow_copy_new_filter`
+how_to_implement: None
+known_false_positives: None
+references: null
+rba:
+  message: An instance of $parent_process_name$ spawning $process_name$ was identified
+    on endpoint $dest$ by user $user$ attempting to create symlink to a shadow copy
+    to grab credentials.
+  risk_objects:
+  - field: user
+    type: user
+    score: 81
+  - field: dest
+    type: system
+    score: 81
+  threat_objects: []
+tests:
+- name: True Positive Test
+  attack_data:
+  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/attack_techniques/T1003.003/credential-dumping-via-symlink/data.log
+    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+    sourcetype: XmlWinEventLog
+drilldown_searches:
+- name: View the detection results for - "$user$" and "$dest$"
+  search: |-
+    %original_detection_search% | search  user = "$user$" dest = "$dest$"
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$
+- name: View risk events for the last 7 days for - "$user$" and "$dest$"
+  search: |-
+    | from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+          "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+          as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+          Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+          as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+          by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  earliest_offset: $info_min_time$
+  latest_offset: $info_max_time$


### PR DESCRIPTION
## Security Content Detection

**Name**: Credential Dumping via Symlink to Shadow Copy New

**Security Domain**: endpoint

**Path**: `detections/endpoint/credential_dumping_via_symlink_to_shadow_copy_new.yml`

**Author**: PB

### Similar Detections

The following similar detections were found using RAG similarity search:

1. **Credential Dumping via Copy Command from Shadow Copy** - [detections/endpoint/credential_dumping_via_copy_command_from_shadow_copy.yml](https://github.com/splunk/security_content/blob/develop/detections/endpoint/credential_dumping_via_copy_command_from_shadow_copy.yml) (Similarity: 74.6%)
2. **Windows Credential Dumping LSASS Memory Createdump** - [detections/endpoint/windows_credential_dumping_lsass_memory_createdump.yml](https://github.com/splunk/security_content/blob/develop/detections/endpoint/windows_credential_dumping_lsass_memory_createdump.yml) (Similarity: 57.4%)
3. **Windows Possible Credential Dumping** - [detections/endpoint/windows_possible_credential_dumping.yml](https://github.com/splunk/security_content/blob/develop/detections/endpoint/windows_possible_credential_dumping.yml) (Similarity: 53.9%)

This PR adds a new detection YAML generated by STRT Bot.