### PR TITLE
Fix rtf.exe file extensions matching in execution_of_file_with_multiple_extensions

### DIFF
--- a/detections/endpoint/execution_of_file_with_multiple_extensions.yml
+++ b/detections/endpoint/execution_of_file_with_multiple_extensions.yml
@@ -1,7 +1,7 @@
 name: Execution of File with Multiple Extensions
 id: b06a555e-dce0-417d-a2eb-28a5d8d66ef7
-version: 11
-date: '2025-05-02'
+version: 12
+date: '2025-11-12'
 author: Rico Valdez, Teoderick Contreras, Splunk
 status: production
 type: TTP
@@ -20,7 +20,7 @@ data_source:
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.process IN ("*.doc.exe",
   "*.xls.exe","*.ppt.exe", "*.htm.exe", "*.html.exe", "*.txt.exe", "*.pdf.exe", "*.docx.exe",
-  "*.xlsx.exe", "*.pptx.exe","*.one.exe", "*.bat.exe", "*rtf.exe") by Processes.action
+  "*.xlsx.exe", "*.pptx.exe","*.one.exe", "*.bat.exe", "*.rtf.exe") by Processes.action
   Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
   Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
   Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid


### PR DESCRIPTION
### Details

My organization received false positive findings generated by the detection "Execution of File with Multiple Extensions" due to the logic looking for "*rtf.exe", without a period before rtf. To match the rest of the logic in this detection, I've added that period to only capture instances of true multi-extension files. 

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [x] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/9.3.2411/manage-apps-and-add-ons-in-splunk-cloud-platform/manage-private-apps-on-your-splunk-cloud-platform-deployment#ariaid-title7) but the short version is that any changes to lookup files need to bump the the date and version in the associated YAML file.
