### PR TITLE
Suspicious mshta child process minor fixes

### DIFF
--- a/detections/endpoint/suspicious_mshta_child_process.yml
+++ b/detections/endpoint/suspicious_mshta_child_process.yml
@@ -1,7 +1,7 @@
 name: Suspicious mshta child process
 id: 60023bb6-5500-11eb-ae93-0242ac130002
-version: 10
-date: '2025-05-06'
+version: 11
+date: '2025-11-14'
 author: Michael Haag, Teoderick Contreras Splunk
 status: production
 type: TTP

--- a/detections/endpoint/suspicious_mshta_child_process.yml
+++ b/detections/endpoint/suspicious_mshta_child_process.yml
@@ -20,7 +20,7 @@ data_source:
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where Processes.parent_process_name=mshta.exe
   AND Processes.process_name IN ("powershell.exe","colorcpl.exe", "msbuild.exe", "microsoft.workflow.compiler.exe", 
-  "searchprotocolhost.exe", "scrcons.exe", "cscript.exe", "wscript.exe", "powershell.exe", "cmd.exe", "bitsadmin.exe") 
+  "searchprotocolhost.exe", "scrcons.exe", "cscript.exe", "wscript.exe", "cmd.exe", "bitsadmin.exe") 
   by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
@@ -57,7 +57,7 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: suspicious mshta child process detected on host $dest$ by user $user$.
+  message: Suspicious mshta child process $process_name$ detected on host $dest$ by user $user$.
   risk_objects:
   - field: user
     type: user


### PR DESCRIPTION
### Details
Powershell.exe was written twice, removing duplicate value
Adding process_name to risk message allows for better understanding of impact.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.