### PR TITLE
Internal horizontal port scan nmap iteration

### DIFF
--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -1,7 +1,7 @@
 name: Internal Horizontal Port Scan NMAP Top 20
 id: 3141a041-4f57-4277-9faa-9305ca1f8e5b
-version: 7
-date: '2025-10-14'
+version: 8
+date: '2025-12-02'
 author: Dean Luxton
 status: production
 type: TTP

--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -14,21 +14,28 @@ description: This analytic identifies instances where an internal host has attem
   or scanning activities, potentially signaling malicious intent or misconfiguration.
   By monitoring network traffic logs, this detection helps detect and respond to such
   behavior promptly, enhancing network security and preventing potential threats.
-search: '| tstats `security_content_summariesonly` values(All_Traffic.action) as action
-  values(All_Traffic.src_category) as src_category values(All_Traffic.dest_zone) as
-  dest_zone values(All_Traffic.src_zone) as src_zone values(All_Traffic.src_port)
-  as src_port count from datamodel=Network_Traffic where All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16")
-  AND All_Traffic.dest_port IN (21, 22, 23, 25, 53, 80, 110, 111, 135, 139, 143, 443,
-  445, 993, 995, 1723, 3306, 3389, 5900, 8080) by All_Traffic.src_ip All_Traffic.src
-  All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.dest All_Traffic.transport All_Traffic.rule span=1s _time |
-  `drop_dm_object_name("All_Traffic")`  | eval gtime=_time  | bin span=1h gtime  |
-  stats min(_time) as _time values(action) as action dc(dest_ip) as totalDestIPCount
-  values(src_category) as src_category values(dest_zone) as dest_zone values(src_zone)
-  as src_zone by src_ip dest_port gtime transport  | where totalDestIPCount>=250  |
-  eval dest_port=transport + "/" + dest_port  | stats min(_time) as _time values(action)
-  as action sum(totalDestIPCount) as totalDestIPCount values(src_category) as src_category
-  values(dest_port) as dest_ports values(dest_zone) as dest_zone values(src_zone)
-  as src_zone by src_ip gtime  | fields - gtime  | `internal_horizontal_port_scan_nmap_top_20_filter`'
+search: |
+  | tstats `security_content_summariesonly` values(All_Traffic.action) as action
+    values(All_Traffic.src_category) as src_category values(All_Traffic.dest_zone) as
+    dest_zone values(All_Traffic.src_zone) as src_zone values(All_Traffic.src_port)
+    as src_port count from datamodel=Network_Traffic where All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16")
+    AND All_Traffic.dest_port IN (21, 22, 23, 25, 53, 80, 110, 111, 135, 139, 143, 443,
+    445, 993, 995, 1723, 3306, 3389, 5900, 8080) by All_Traffic.src_ip All_Traffic.src
+    All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.dest All_Traffic.transport All_Traffic.rule span=1s _time
+  | `drop_dm_object_name("All_Traffic")`
+  | eval gtime=_time
+  | bin span=1h gtime
+  | stats min(_time) as _time values(action) as action dc(dest_ip) as totalDestIPCount
+      values(src_category) as src_category values(dest_zone) as dest_zone values(src_zone)
+      as src_zone by src_ip dest_port gtime transport
+  | where totalDestIPCount>=250
+  | eval dest_port=transport + "/" + dest_port
+  | stats min(_time) as _time values(action)
+      as action sum(totalDestIPCount) as totalDestIPCount values(src_category) as src_category
+      values(dest_port) as dest_ports values(dest_zone) as dest_zone values(src_zone)
+      as src_zone by src_ip gtime
+  | fields - gtime
+  | `internal_horizontal_port_scan_nmap_top_20_filter`
 how_to_implement: To properly run this search, Splunk needs to ingest data from networking
   telemetry sources such as firewalls like Cisco Secure Firewall, NetFlow, or host-based networking events. Ensure
   that the Network_Traffic data model is populated to enable this search effectively.

--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -15,26 +15,16 @@ description: This analytic identifies instances where an internal host has attem
   By monitoring network traffic logs, this detection helps detect and respond to such
   behavior promptly, enhancing network security and preventing potential threats.
 search: |
-  | tstats `security_content_summariesonly` values(All_Traffic.action) as action
-    values(All_Traffic.src_category) as src_category values(All_Traffic.dest_zone) as
-    dest_zone values(All_Traffic.src_zone) as src_zone values(All_Traffic.src_port)
-    as src_port count from datamodel=Network_Traffic where All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16")
-    AND All_Traffic.dest_port IN (21, 22, 23, 25, 53, 80, 110, 111, 135, 139, 143, 443,
-    445, 993, 995, 1723, 3306, 3389, 5900, 8080) by All_Traffic.src_ip All_Traffic.src
-    All_Traffic.dest_port All_Traffic.dest_ip All_Traffic.dest All_Traffic.transport All_Traffic.rule span=1s _time
+  | tstats `security_content_summariesonly` values(All_Traffic.action) as action values(All_Traffic.src_category) as src_category values(All_Traffic.dest_zone) as dest_zone values(All_Traffic.src_zone) as src_zone values(All_Traffic.src_port) as src_port dc(All_Traffic.dest_ip) as totalDestIPCount count min(_time) as firstTime max(_time) as lastTime from datamodel=Network_Traffic
+  where All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16") AND All_Traffic.dest_port IN (21, 22, 23, 25, 53, 80, 110, 111, 135, 139, 143, 443, 445, 993, 995, 1723, 3306, 3389, 5900, 8080)
+  by All_Traffic.src_ip All_Traffic.dest_port All_Traffic.transport span=1h _time
   | `drop_dm_object_name("All_Traffic")`
-  | eval gtime=_time
-  | bin span=1h gtime
-  | stats min(_time) as _time values(action) as action dc(dest_ip) as totalDestIPCount
-      values(src_category) as src_category values(dest_zone) as dest_zone values(src_zone)
-      as src_zone by src_ip dest_port gtime transport
   | where totalDestIPCount>=250
   | eval dest_port=transport + "/" + dest_port
-  | stats min(_time) as _time values(action)
-      as action sum(totalDestIPCount) as totalDestIPCount values(src_category) as src_category
-      values(dest_port) as dest_ports values(dest_zone) as dest_zone values(src_zone)
-      as src_zone by src_ip gtime
-  | fields - gtime
+  | stats min(firstTime) as firstTime max(lastTime) as lastTime values(action) as action sum(totalDestIPCount) as totalDestIPCount values(src_category) as src_category values(dest_port) as dest_ports dc(dest_port) as num_ports_scanned values(dest_zone) as dest_zone values(src_zone) as src_zone by _time src_ip
+  | fields - _time
+  | `security_content_ctime(lastTime)`
+  | `security_content_ctime(firstTime)`
   | `internal_horizontal_port_scan_nmap_top_20_filter`
 how_to_implement: To properly run this search, Splunk needs to ingest data from networking
   telemetry sources such as firewalls like Cisco Secure Firewall, NetFlow, or host-based networking events. Ensure
@@ -56,8 +46,7 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: $src_ip$ has scanned for ports $dest_ports$ across $totalDestIPCount$ destination
-    IPs
+  message: $src_ip$ has scanned for ports $dest_ports$ across $totalDestIPCount$ destination IPs
   risk_objects:
   - field: dest_ports
     type: system

--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -15,13 +15,13 @@ description: This analytic identifies instances where an internal host has attem
   By monitoring network traffic logs, this detection helps detect and respond to such
   behavior promptly, enhancing network security and preventing potential threats.
 search: |
-  | tstats `security_content_summariesonly` values(All_Traffic.action) as action values(All_Traffic.src_category) as src_category values(All_Traffic.dest_zone) as dest_zone values(All_Traffic.src_zone) as src_zone values(All_Traffic.src_port) as src_port dc(All_Traffic.dest_ip) as totalDestIPCount count min(_time) as firstTime max(_time) as lastTime from datamodel=Network_Traffic
+  | tstats `security_content_summariesonly` values(All_Traffic.action) as action values(All_Traffic.src_category) as src_category values(All_Traffic.dest_zone) as dest_zone values(All_Traffic.src_zone) as src_zone values(All_Traffic.src_port) as src_port dc(All_Traffic.dest_ip) as totalDestIPCount count min(_time) as firstTime max(_time) as lastTime values(All_Traffic.rule) as rule from datamodel=Network_Traffic
   where All_Traffic.src_ip IN ("10.0.0.0/8","172.16.0.0/12","192.168.0.0/16") AND All_Traffic.dest_port IN (21, 22, 23, 25, 53, 80, 110, 111, 135, 139, 143, 443, 445, 993, 995, 1723, 3306, 3389, 5900, 8080)
   by All_Traffic.src_ip All_Traffic.dest_port All_Traffic.transport span=1h _time
   | `drop_dm_object_name("All_Traffic")`
   | where totalDestIPCount>=250
   | eval dest_port=transport + "/" + dest_port
-  | stats min(firstTime) as firstTime max(lastTime) as lastTime values(action) as action sum(totalDestIPCount) as totalDestIPCount values(src_category) as src_category values(dest_port) as dest_ports dc(dest_port) as num_ports_scanned values(dest_zone) as dest_zone values(src_zone) as src_zone by _time src_ip
+  | stats min(firstTime) as firstTime max(lastTime) as lastTime values(action) as action sum(totalDestIPCount) as totalDestIPCount values(src_category) as src_category values(dest_port) as dest_ports dc(dest_port) as num_ports_scanned values(dest_zone) as dest_zone values(src_zone) as src_zone values(rule) as rule by _time src_ip
   | fields - _time
   | `security_content_ctime(lastTime)`
   | `security_content_ctime(firstTime)`

--- a/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
+++ b/detections/network/internal_horizontal_port_scan_nmap_top_20.yml
@@ -48,12 +48,10 @@ drilldown_searches:
 rba:
   message: $src_ip$ has scanned for ports $dest_ports$ across $totalDestIPCount$ destination IPs
   risk_objects:
-  - field: dest_ports
-    type: system
-    score: 72
-  threat_objects:
   - field: src_ip
-    type: ip_address
+    type: system
+    score: 50
+  threat_objects: []
 tags:
   analytic_story:
   - Network Discovery


### PR DESCRIPTION
### Details
Suggesting a few minor fixes to "Internal horizontal port scan nmap" in order to speed up, and enrich, the query. These changes made the query ~50% faster in our environments.

Changes:
- Moving the logic from the 2nd stats statement into tstats, speeding up the query quite a bit.
- Moving to using firstTime/lastTime so we have the scope of the scanning.
- Adding `num_ports_scanned` as a field in order to simplify tuning.
- Minor Syntax fix for the risk message

### Checklist

- [x] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [x] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [x] Validated SPL logic.
- [x] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.
