### PR TITLE
chore: user_agent field fix in both the Azure AD authentication detections. Minor spelling mistake fixes.

### DIFF
--- a/detections/cloud/azure_ad_high_number_of_failed_authentications_for_user.yml
+++ b/detections/cloud/azure_ad_high_number_of_failed_authentications_for_user.yml
@@ -15,7 +15,11 @@ description: The following analytic identifies an Azure AD account experiencing 
   based on their specific environment to reduce false positives.
 data_source:
 - Azure Active Directory
-search: '`azure_monitor_aad` category=SignInLogs properties.status.errorCode=50126 properties.authenticationDetails{}.succeeded=false 
+search: |
+  `azure_monitor_aad`
+  category=SignInLogs
+  properties.status.errorCode=50126
+  properties.authenticationDetails{}.succeeded=false 
   | rename properties.userAgent as user_agent 
   | rename properties.* as * 
   | bin span=10m _time 
@@ -24,7 +28,7 @@ search: '`azure_monitor_aad` category=SignInLogs properties.status.errorCode=501
   | where count > 20 
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 
-  | `azure_ad_high_number_of_failed_authentications_for_user_filter`'
+  | `azure_ad_high_number_of_failed_authentications_for_user_filter`
 how_to_implement: You must install the latest version of Splunk Add-on for Microsoft
   Cloud Services from Splunkbase (https://splunkbase.splunk.com/app/3110/#/details).
   You must be ingesting Azure Active Directory events into your Splunk environment

--- a/detections/cloud/azure_ad_high_number_of_failed_authentications_for_user.yml
+++ b/detections/cloud/azure_ad_high_number_of_failed_authentications_for_user.yml
@@ -19,15 +19,14 @@ search: |
   `azure_monitor_aad`
   category=SignInLogs
   properties.status.errorCode=50126
-  properties.authenticationDetails{}.succeeded=false 
-  | rename properties.userAgent as user_agent 
-  | rename properties.* as * 
-  | bin span=10m _time 
+  properties.authenticationDetails{}.succeeded=false
+  | rename properties.* as *
+  | bin span=10m _time
   | fillnull value=null
-  | stats count min(_time) as firstTime max(_time) as lastTime values(dest) as dest values(src) as src values(user_agent) as user_agent by user _time vendor_account vendor_product 
-  | where count > 20 
-  | `security_content_ctime(firstTime)` 
-  | `security_content_ctime(lastTime)` 
+  | stats count min(_time) as firstTime max(_time) as lastTime values(dest) as dest values(src) as src values(user_agent) as user_agent by user _time vendor_account vendor_product
+  | where count > 20
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
   | `azure_ad_high_number_of_failed_authentications_for_user_filter`
 how_to_implement: You must install the latest version of Splunk Add-on for Microsoft
   Cloud Services from Splunkbase (https://splunkbase.splunk.com/app/3110/#/details).
@@ -75,7 +74,7 @@ tags:
 tests:
 - name: True Positive Test
   attack_data:
-  - data: 
+  - data:
       https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1110.001/azure_ad_high_number_of_failed_authentications_for_user/azuread.log
     source: Azure AD
     sourcetype: azure:monitor:aad

--- a/detections/cloud/azure_ad_high_number_of_failed_authentications_for_user.yml
+++ b/detections/cloud/azure_ad_high_number_of_failed_authentications_for_user.yml
@@ -15,11 +15,11 @@ description: The following analytic identifies an Azure AD account experiencing 
   based on their specific environment to reduce false positives.
 data_source:
 - Azure Active Directory
-search: '`azure_monitor_aad` category= SignInLogs properties.status.errorCode=50126 properties.authenticationDetails{}.succeeded=false 
-  | rename properties.* as * 
-  | bucket span=10m _time 
+search: '`azure_monitor_aad` category=SignInLogs properties.status.errorCode=50126 properties.authenticationDetails{}.succeeded=false 
   | rename properties.userAgent as user_agent 
-  | fillnull 
+  | rename properties.* as * 
+  | bin span=10m _time 
+  | fillnull value=null
   | stats count min(_time) as firstTime max(_time) as lastTime values(dest) as dest values(src) as src values(user_agent) as user_agent by user _time vendor_account vendor_product 
   | where count > 20 
   | `security_content_ctime(firstTime)` 
@@ -31,7 +31,7 @@ how_to_implement: You must install the latest version of Splunk Add-on for Micro
   through an EventHub. This analytic was written to be used with the azure:monitor:aad
   sourcetype leveraging the SignInLogs log category.
 known_false_positives: A user with more than 20 failed authentication attempts in
-  the span of 5 minutes may also be triggered by a broken application.
+  the span of 10 minutes may also be triggered by a broken application.
 references:
 - https://attack.mitre.org/techniques/T1110/
 - https://attack.mitre.org/techniques/T1110/001/
@@ -50,8 +50,7 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: User $user$ failed to authenticate more than 20 times in the span of 5
-    minutes.
+  message: User $user$ failed to authenticate more than 20 times in the span of 10 minutes.
   risk_objects:
   - field: user
     type: user

--- a/detections/cloud/azure_ad_high_number_of_failed_authentications_from_ip.yml
+++ b/detections/cloud/azure_ad_high_number_of_failed_authentications_from_ip.yml
@@ -14,13 +14,16 @@ description: The following analytic detects an IP address with 20 or more failed
   within the Azure environment.
 data_source:
 - Azure Active Directory
-search: '`azure_monitor_aad` category= SignInLogs properties.status.errorCode=50126 properties.authenticationDetails{}.succeeded=false 
-  | rename properties.* as * 
-  | bucket span=10m _time 
+search: '`azure_monitor_aad` category=SignInLogs properties.status.errorCode=50126 properties.authenticationDetails{}.succeeded=false 
   | rename properties.userAgent as user_agent 
-  | fillnull 
+  | rename properties.* as * 
+  | bin span=10m _time 
+  | fillnull value=null
   | stats count min(_time) as firstTime max(_time) as lastTime values(dest) as dest values(user) as user values(user_agent) as user_agent by src _time vendor_account vendor_product 
-  | where count > 20  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `azure_ad_high_number_of_failed_authentications_from_ip_filter`'
+  | where count > 20
+  | `security_content_ctime(firstTime)` 
+  | `security_content_ctime(lastTime)` 
+  | `azure_ad_high_number_of_failed_authentications_from_ip_filter`'
 how_to_implement: You must install the latest version of Splunk Add-on for Microsoft
   Cloud Services from Splunkbase (https://splunkbase.splunk.com/app/3110/#/details).
   You must be ingesting Azure Active Directory events into your Splunk environment
@@ -47,8 +50,7 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: $src$ failed to authenticate more than 20 times in the span of 10 minutes
-    minutes.
+  message: $src$ failed to authenticate more than 20 times in the span of 10 minutes.
   risk_objects:
   - field: user
     type: user

--- a/detections/cloud/azure_ad_high_number_of_failed_authentications_from_ip.yml
+++ b/detections/cloud/azure_ad_high_number_of_failed_authentications_from_ip.yml
@@ -14,7 +14,11 @@ description: The following analytic detects an IP address with 20 or more failed
   within the Azure environment.
 data_source:
 - Azure Active Directory
-search: '`azure_monitor_aad` category=SignInLogs properties.status.errorCode=50126 properties.authenticationDetails{}.succeeded=false 
+search: |
+  `azure_monitor_aad`
+  category=SignInLogs
+  properties.status.errorCode=50126
+  properties.authenticationDetails{}.succeeded=false 
   | rename properties.userAgent as user_agent 
   | rename properties.* as * 
   | bin span=10m _time 
@@ -23,7 +27,7 @@ search: '`azure_monitor_aad` category=SignInLogs properties.status.errorCode=501
   | where count > 20
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 
-  | `azure_ad_high_number_of_failed_authentications_from_ip_filter`'
+  | `azure_ad_high_number_of_failed_authentications_from_ip_filter`
 how_to_implement: You must install the latest version of Splunk Add-on for Microsoft
   Cloud Services from Splunkbase (https://splunkbase.splunk.com/app/3110/#/details).
   You must be ingesting Azure Active Directory events into your Splunk environment

--- a/detections/cloud/azure_ad_high_number_of_failed_authentications_from_ip.yml
+++ b/detections/cloud/azure_ad_high_number_of_failed_authentications_from_ip.yml
@@ -18,15 +18,14 @@ search: |
   `azure_monitor_aad`
   category=SignInLogs
   properties.status.errorCode=50126
-  properties.authenticationDetails{}.succeeded=false 
-  | rename properties.userAgent as user_agent 
-  | rename properties.* as * 
-  | bin span=10m _time 
+  properties.authenticationDetails{}.succeeded=false
+  | rename properties.* as *
+  | bin span=10m _time
   | fillnull value=null
-  | stats count min(_time) as firstTime max(_time) as lastTime values(dest) as dest values(user) as user values(user_agent) as user_agent by src _time vendor_account vendor_product 
+  | stats count min(_time) as firstTime max(_time) as lastTime values(dest) as dest values(user) as user values(user_agent) as user_agent by src _time vendor_account vendor_product
   | where count > 20
-  | `security_content_ctime(firstTime)` 
-  | `security_content_ctime(lastTime)` 
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
   | `azure_ad_high_number_of_failed_authentications_from_ip_filter`
 how_to_implement: You must install the latest version of Splunk Add-on for Microsoft
   Cloud Services from Splunkbase (https://splunkbase.splunk.com/app/3110/#/details).
@@ -79,7 +78,7 @@ tags:
 tests:
 - name: True Positive Test
   attack_data:
-  - data: 
+  - data:
       https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1110.001/azure_ad_high_number_of_failed_authentications_for_user/azuread.log
     source: Azure AD
     sourcetype: azure:monitor:aad


### PR DESCRIPTION
### Details:

The CIM compliant user_agent field was not being parsed correctly as the `| rename properties.* as *` line renames the field before the `| rename properties.userAgent as user_agent` line is able to rename it.

Updated some minor issues with the risk message and known false positive fields stating that the `Azure AD High Number Of Failed Authentications For User` search bin's every 5 minutes.

Lastly, fixed the word minutes being present twice in the risk message of the `Azure AD High Number Of Failed Authentications From Ip` search.

### Checklist:

- [x] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [x] Validated SPL logic.
- [x] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.