### PR TITLE
Add CastleRAT and LokiBot Snort IDs

### DIFF
--- a/detections/network/cisco_secure_firewall___intrusion_events_by_threat_activity.yml
+++ b/detections/network/cisco_secure_firewall___intrusion_events_by_threat_activity.yml
@@ -31,7 +31,6 @@ description: |
   * Remcos
   * Snake
   * Static Tundra
-  * Static Tundra
   * Xworm
 
   To add or update threat actors, update the cisco_snort_ids_to_threat_mapping.csv lookup file with new or modified threat names and associated Snort signature IDs.

--- a/detections/network/cisco_secure_firewall___intrusion_events_by_threat_activity.yml
+++ b/detections/network/cisco_secure_firewall___intrusion_events_by_threat_activity.yml
@@ -1,25 +1,27 @@
 name: Cisco Secure Firewall - Intrusion Events by Threat Activity
 id: b71e57e8-c571-4ff1-ae13-bc4384a9e891
-version: 4  
-date: '2025-09-25'
+version: 5
+date: '2025-12-08'
 author: Bhavin Patel, Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
 description: |
-  This analytic detects intrusion events from known threat activity using Cisco Secure Firewall Intrusion Events. 
-  It leverages Cisco Secure Firewall Threat Defense IntrusionEvent logs to identify cases where one or multiple Snort signatures 
-  associated with a known threat or threat actor activity have been triggered within a one-hour time window. The detection uses a 
-  lookup table (cisco_snort_ids_to_threat_mapping) to map Snort signature IDs to known threat actors and their techniques. 
-  When multiple signatures associated with the same threat actor are triggered within the time window, and the count of 
-  unique signatures matches or exceeds the expected number of signatures for that threat technique, an alert is generated. 
-  This helps identify potential coordinated threat activity in your network environment by correlating related intrusion 
+  This analytic detects intrusion events from known threat activity using Cisco Secure Firewall Intrusion Events.
+  It leverages Cisco Secure Firewall Threat Defense IntrusionEvent logs to identify cases where one or multiple Snort signatures
+  associated with a known threat or threat actor activity have been triggered within a one-hour time window. The detection uses a
+  lookup table (cisco_snort_ids_to_threat_mapping) to map Snort signature IDs to known threat actors and their techniques.
+  When multiple signatures associated with the same threat actor are triggered within the time window, and the count of
+  unique signatures matches or exceeds the expected number of signatures for that threat technique, an alert is generated.
+  This helps identify potential coordinated threat activity in your network environment by correlating related intrusion
   events that occur in close temporal proximity.
 
   Currently, this detection will alert on the following threat actors or malware families as defined in the cisco_snort_ids_to_threat_mapping lookup:
+
   * ArcaneDoor
   * Static Tundra
   * AgentTesla
   * Amadey
+  * CastleRAT
   * AsyncRAT
   * Chafer
   * DCRAT
@@ -28,6 +30,7 @@ description: |
   * Quasar
   * Remcos
   * Snake
+  * Static Tundra
   * Xworm
 
   To add or update threat actors, update the cisco_snort_ids_to_threat_mapping.csv lookup file with new or modified threat names and associated Snort signature IDs.
@@ -80,7 +83,7 @@ rba:
     - field: signature
       type: signature
 tags:
-  analytic_story: 
+  analytic_story:
     - Cisco Secure Firewall Threat Defense Analytics
     - ArcaneDoor
   asset_type: Network

--- a/detections/network/cisco_secure_firewall___intrusion_events_by_threat_activity.yml
+++ b/detections/network/cisco_secure_firewall___intrusion_events_by_threat_activity.yml
@@ -17,12 +17,11 @@ description: |
 
   Currently, this detection will alert on the following threat actors or malware families as defined in the cisco_snort_ids_to_threat_mapping lookup:
 
-  * ArcaneDoor
-  * Static Tundra
   * AgentTesla
   * Amadey
-  * CastleRAT
+  * ArcaneDoor
   * AsyncRAT
+  * CastleRAT
   * Chafer
   * DCRAT
   * Lumma Stealer
@@ -30,6 +29,7 @@ description: |
   * Quasar
   * Remcos
   * Snake
+  * Static Tundra
   * Static Tundra
   * Xworm
 

--- a/detections/network/cisco_secure_firewall___intrusion_events_by_threat_activity.yml
+++ b/detections/network/cisco_secure_firewall___intrusion_events_by_threat_activity.yml
@@ -24,6 +24,7 @@ description: |
   * CastleRAT
   * Chafer
   * DCRAT
+  * LokiBot
   * Lumma Stealer
   * Nobelium
   * Quasar

--- a/lookups/cisco_snort_ids_to_threat_mapping.csv
+++ b/lookups/cisco_snort_ids_to_threat_mapping.csv
@@ -31,6 +31,7 @@ DCRAT,64370,MALWARE-OTHER,Win.Trojan.DcRat variant download attempt
 DCRAT,64371,MALWARE-OTHER,Win.Trojan.DcRat variant download attempt
 DCRAT,64372,MALWARE-CNC,Win.Trojan.DcRat variant communication attempt
 DCRAT,64373,MALWARE-CNC,Win.Trojan.DcRat variant communication attempt
+LokiBot,65502,MALWARE-CNC,Win.Trojan.LokiBot variant outbound connection attempt
 Lumma Stealer,62709,MALWARE-CNC,Win.Malware.Lumma variant outbound connection
 Lumma Stealer,62710,MALWARE-OTHER,Win.Malware.Lumma variant download attempt
 Lumma Stealer,62711,MALWARE-OTHER,Win.Malware.Lumma variant download attempt

--- a/lookups/cisco_snort_ids_to_threat_mapping.csv
+++ b/lookups/cisco_snort_ids_to_threat_mapping.csv
@@ -18,6 +18,7 @@ Amadey,60570,MALWARE-TOOLS,Win.Trojan.Amadey malware tools download attempt
 Amadey,60571,MALWARE-TOOLS,Win.Trojan.Amadey malware tools download attempt
 Amadey,60572,MALWARE-TOOLS,Win.Trojan.Amadey malware tools download attempt
 AsyncRAT,58773,MALWARE-CNC,Rat.Trojan.AsyncRAT variant cnc connection
+CastleRAT,65548,MALWARE-CNC,Win.Trojan.CastleRAT variant outbound IP geolocation lookup attempt
 Chafer,45972,MALWARE-CNC,Win.Trojan.Chafer malicious communication attempt
 Chafer,45973,MALWARE-CNC,Win.Trojan.Chafer malicious communication attempt
 DCRAT,58356,MALWARE-CNC,Win.Trojan.DCRAT variant outbound connection

--- a/lookups/cisco_snort_ids_to_threat_mapping.csv
+++ b/lookups/cisco_snort_ids_to_threat_mapping.csv
@@ -1,6 +1,4 @@
 threat,signature_id,category,message
-ArcaneDoor,46897,SERVER-WEBAPP,Cisco Adaptive Security Appliance directory traversal attempt
-ArcaneDoor,65340,SERVER-WEBAPP,Cisco Adaptive Security Appliance WebVPN buffer overflow attempt
 AgentTesla,40238,MALWARE-CNC,Win.Keylogger.AgentTesla variant outbound connection
 AgentTesla,52246,INDICATOR-COMPROMISE,AgentTesla variant outbound connection attempt
 AgentTesla,52612,MALWARE-CNC,Win.Trojan.AgentTesla variant outbound connection detected
@@ -17,6 +15,8 @@ Amadey,57204,MALWARE-CNC,Win.Trojan.Amadey outbound connection attempt
 Amadey,60570,MALWARE-TOOLS,Win.Trojan.Amadey malware tools download attempt
 Amadey,60571,MALWARE-TOOLS,Win.Trojan.Amadey malware tools download attempt
 Amadey,60572,MALWARE-TOOLS,Win.Trojan.Amadey malware tools download attempt
+ArcaneDoor,46897,SERVER-WEBAPP,Cisco Adaptive Security Appliance directory traversal attempt
+ArcaneDoor,65340,SERVER-WEBAPP,Cisco Adaptive Security Appliance WebVPN buffer overflow attempt
 AsyncRAT,58773,MALWARE-CNC,Rat.Trojan.AsyncRAT variant cnc connection
 CastleRAT,65548,MALWARE-CNC,Win.Trojan.CastleRAT variant outbound IP geolocation lookup attempt
 Chafer,45972,MALWARE-CNC,Win.Trojan.Chafer malicious communication attempt
@@ -95,12 +95,12 @@ snake,53107,MALWARE-OTHER,Win.Trojan.Snake malicious executable download attempt
 snake,64072,MALWARE-CNC,Win.KeyLogger.Snake outbound connection
 snake,64073,MALWARE-OTHER,Win.KeyLogger.Snake download attempt
 Snake,7717,MALWARE-BACKDOOR,snake trojan runtime detection
-Static Tundra,46468,SERVER-OTHER,Cisco Smart Install invalid init discovery message denial of service attempt
-Static Tundra,46096,SERVER-OTHER,Cisco Smart Install init discovery message stack buffer overflow attempt
 Static Tundra,41722,SERVER-OTHER,Cisco Talos rules for Smart Install protocol abuse detection
 Static Tundra,41723,SERVER-OTHER,Cisco Talos rules for Smart Install protocol abuse detection
 Static Tundra,41724,SERVER-OTHER,Cisco Talos rules for Smart Install protocol abuse detection
 Static Tundra,41725,SERVER-OTHER,Cisco Talos rules for Smart Install protocol abuse detection
+Static Tundra,46096,SERVER-OTHER,Cisco Smart Install init discovery message stack buffer overflow attempt
+Static Tundra,46468,SERVER-OTHER,Cisco Smart Install invalid init discovery message denial of service attempt
 Xworm,62772,MALWARE-OTHER,Win.Trojan.Xworm download attempt
 Xworm,62773,MALWARE-OTHER,Win.Trojan.Xworm download attempt
 Xworm,62774,MALWARE-OTHER,Win.Trojan.Xworm download attempt

--- a/lookups/cisco_snort_ids_to_threat_mapping.yml
+++ b/lookups/cisco_snort_ids_to_threat_mapping.yml
@@ -1,6 +1,6 @@
 name: cisco_snort_ids_to_threat_mapping
-date: 2025-09-24
-version: 3
+date: 2025-12-08
+version: 4
 id: f08ae6ce-d7a8-423e-a778-be7178a719f9
 author: Bhavin Patel, Nasreddine Bencherchali, Splunk Threat Research Team
 lookup_type: csv


### PR DESCRIPTION
This PR updates the snort threat IDs lookup by adding the released CastleRAT and LokiBot snort rules.