### PR TITLE
v5.19.0 Integration Testing Failures

### DIFF
--- a/detections/endpoint/linux_auditd_preload_hijack_via_preload_file.yml
+++ b/detections/endpoint/linux_auditd_preload_hijack_via_preload_file.yml
@@ -67,7 +67,8 @@ drilldown_searches:
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
   - name: View risk events for the last 7 days for - "$dest$"
-    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    search:
+      '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
       starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
       values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
       as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
@@ -76,7 +77,8 @@ drilldown_searches:
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
 rba:
-  message: A [$type$] event has occurred on host - [$dest$] to modify the preload
+  message:
+    A [$nametype$] event has occurred on host - [$dest$] to modify the preload
     file.
   risk_objects:
     - field: dest
@@ -100,7 +102,6 @@ tags:
 tests:
   - name: True Positive Test
     attack_data:
-    - data:
-        https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1574.006/auditd_path_preload_file/path_preload.log
-      source: auditd
-      sourcetype: auditd
+      - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1574.006/auditd_path_preload_file/path_preload.log
+        source: auditd
+        sourcetype: auditd

--- a/detections/endpoint/linux_auditd_unix_shell_configuration_modification.yml
+++ b/detections/endpoint/linux_auditd_unix_shell_configuration_modification.yml
@@ -18,7 +18,7 @@ search: |
   `linux_auditd`
   (type=PATH OR type=CWD)
   | rex "msg=audit\([^)]*:(?<audit_id>\d+)\)"
-  
+
   | stats
     values(type) as types
     values(name) as names
@@ -26,7 +26,7 @@ search: |
     values(cwd) as cwd_list
     values(_time) as event_times
     by audit_id, host
-  
+
   | eval current_working_directory = coalesce(mvindex(cwd_list, 0), "N/A")
   | eval candidate_paths = mvmap(names, if(match(names, "^/"), names, current_working_directory + "/" + names))
   | eval matched_paths = mvfilter(match(candidate_paths, "/etc/profile|/etc/shells|/etc/profile\\.d/.*|/etc/bash\\.bashrc.*|/etc/bashrc|.*/zsh/zprofile|.*/zsh/zshrc|.*/zsh/zlogin|.*/zsh/zlogout|/etc/csh\\.cshrc.*|/etc/csh\\.login.*|/root/\\.bashrc.*|/root/\\.bash_profile.*|/root/\\.profile.*|/root/\\.zshrc.*|/root/\\.zprofile.*|/home/.*/\\.bashrc.*|/home/.*/\\.zshrc.*|/home/.*/\\.bash_profile.*|/home/.*/\\.zprofile.*|/home/.*/\\.profile.*|/home/.*/\\.bash_login.*|/home/.*/\\.bash_logout.*|/home/.*/\\.zlogin.*|/home/.*/\\.zlogout.*"))
@@ -35,7 +35,7 @@ search: |
   | eval e_time = mvindex(event_times, 0)
   | where match_count > 0
   | rename host as dest
-  
+
   | stats count min(e_time) as firstTime max(e_time) as lastTime
     values(nametype) as nametype
     by current_working_directory
@@ -43,7 +43,7 @@ search: |
        match_count
        dest
        audit_id
-  
+
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `linux_auditd_unix_shell_configuration_modification_filter`
@@ -69,7 +69,8 @@ drilldown_searches:
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
   - name: View risk events for the last 7 days for - "$dest$"
-    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    search:
+      '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
       starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
       values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
       as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
@@ -78,7 +79,8 @@ drilldown_searches:
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
 rba:
-  message: A [$type$] event occurred on host - [$dest$] to modify the unix shell configuration
+  message:
+    A [$nametype$] event occurred on host - [$dest$] to modify the unix shell configuration
     file.
   risk_objects:
     - field: dest
@@ -102,7 +104,6 @@ tags:
 tests:
   - name: True Positive Test
     attack_data:
-    - data:
-        https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1546.004/linux_auditd_unix_shell_mod_config//linux_path_profile_d.log
-      source: auditd
-      sourcetype: auditd
+      - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1546.004/linux_auditd_unix_shell_mod_config//linux_path_profile_d.log
+        source: auditd
+        sourcetype: auditd

--- a/detections/endpoint/linux_suspicious_react_or_next_js_child_process.yml
+++ b/detections/endpoint/linux_suspicious_react_or_next_js_child_process.yml
@@ -122,7 +122,8 @@ drilldown_searches:
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
   - name: View risk events for the last 7 days for - "$dest$"
-    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    search:
+      '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
       starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
       values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
       as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
@@ -131,7 +132,7 @@ drilldown_searches:
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
 rba:
-  message: |
+  message:
     A Node-based server process ($parent_process_name$) on Linux spawned the
     child process $process_name$ with command-line $process$ on host $dest$ by user $user$, which may
     indicate remote code execution via React Server Components (CVE-2025-55182 /

--- a/detections/endpoint/windows_suspicious_react_or_next_js_child_process.yml
+++ b/detections/endpoint/windows_suspicious_react_or_next_js_child_process.yml
@@ -113,7 +113,8 @@ drilldown_searches:
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
   - name: View risk events for the last 7 days for - "$dest$"
-    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+    search:
+      '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
       starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
       values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
       as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
@@ -122,8 +123,7 @@ drilldown_searches:
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
 rba:
-  message: |
-    A Node-based server process ($parent_process_name$) spawned the child
+  message: A Node-based server process ($parent_process_name$) spawned the child
     process $process_name$ with command-line $process$ on host $dest$ by user $user$, which may indicate
     remote code execution via React Server Components (CVE-2025-55182 /
     React2Shell) or abuse of a similar Node.js RCE vector.


### PR DESCRIPTION
### Details

Integration testing failures for v5.19.0

First commit: We changed these fields, fields didn't get updated in the risk message.

Second commit: Pending


### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/9.3.2411/manage-apps-and-add-ons-in-splunk-cloud-platform/manage-private-apps-on-your-splunk-cloud-platform-deployment#ariaid-title7) but the short version is that any changes to lookup files need to bump the the date and version in the associated YAML file.
