### PR TITLE
Housekeeping re: response templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @patel-bhavin @ljstella @nasbench
+/response_templates/ @kbouchardherjavecgroup @ccl0utier

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,29 +1,32 @@
 Detections:
-- changed-files:
-  - any-glob-to-any-file: 
-    - detections/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - detections/**
 
 Stories:
-- changed-files:
-  - any-glob-to-any-file: stories/*
+  - changed-files:
+      - any-glob-to-any-file: stories/*
 
 Playbooks:
-- changed-files:
-  - any-glob-to-any-file: playbooks/*
+  - changed-files:
+      - any-glob-to-any-file: playbooks/*
 
 Macros:
-- changed-files:
-  - any-glob-to-any-file: macros/*
+  - changed-files:
+      - any-glob-to-any-file: macros/*
 
 Lookups:
-- changed-files:
-  - any-glob-to-any-file: lookups/*
+  - changed-files:
+      - any-glob-to-any-file: lookups/*
 
 Datasource:
-- changed-files:
-  - any-glob-to-any-file: data_sources/*
+  - changed-files:
+      - any-glob-to-any-file: data_sources/*
 
 Baselines:
   - changed-files:
-    - any-glob-to-any-file: baselines/*
+      - any-glob-to-any-file: baselines/*
 
+Response Templates:
+  - changed-files:
+      - any-glob-to-any-file: response_templates/*


### PR DESCRIPTION
### Details

- New labeler setting for response templates
- Codeowners for reviews

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/9.3.2411/manage-apps-and-add-ons-in-splunk-cloud-platform/manage-private-apps-on-your-splunk-cloud-platform-deployment#ariaid-title7) but the short version is that any changes to lookup files need to bump the the date and version in the associated YAML file.
