### PR TITLE
Update Macro Usage

### DIFF
--- a/detections/application/suspicious_email_attachment_extensions.yml
+++ b/detections/application/suspicious_email_attachment_extensions.yml
@@ -1,7 +1,7 @@
 name: Suspicious Email Attachment Extensions
 id: 473bd65f-06ca-4dfe-a2b8-ba04ab4a0084
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-12-17'
 author: David Dorsey, Splunk
 status: experimental
 type: Anomaly
@@ -14,11 +14,16 @@ description: The following analytic detects emails containing attachments with s
   information, system compromise, or data exfiltration. Immediate review and analysis
   of the identified emails and attachments are crucial to mitigate these risks.
 data_source: []
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Email where All_Email.file_name="*" by All_Email.src_user,
-  All_Email.file_name All_Email.message_id | `security_content_ctime(firstTime)` |
-  `security_content_ctime(lastTime)` | `drop_dm_object_name("All_Email")` | `suspicious_email_attachments`
-  | `suspicious_email_attachment_extensions_filter`'
+  All_Email.file_name All_Email.message_id
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `drop_dm_object_name("All_Email")`
+  | lookup update=true is_suspicious_file_extension_lookup file_name OUTPUT suspicious
+  | search suspicious=true
+  | `suspicious_email_attachment_extensions_filter`
 how_to_implement: "You need to ingest data from emails. Specifically, the sender's
   address and the file names of any attachments must be mapped to the Email data model.\n
   **Splunk Phantom Playbook Integration**\nIf Splunk Phantom is also configured in

--- a/detections/endpoint/common_ransomware_notes.yml
+++ b/detections/endpoint/common_ransomware_notes.yml
@@ -1,7 +1,7 @@
 name: Common Ransomware Notes
 id: ada0f478-84a8-4641-a3f1-d82362d6bd71
-version: 12
-date: '2025-10-14'
+version: 13
+date: '2025-12-15'
 author: David Dorsey, Splunk
 status: production
 type: Hunting
@@ -14,14 +14,20 @@ description: The following analytic detects the creation of files with names com
   disruption, and financial impact due to ransom demands.
 data_source:
 - Sysmon EventID 11
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime values(Filesystem.user) as user values(Filesystem.dest) as dest values(Filesystem.file_path)
-  as file_path from datamodel=Endpoint.Filesystem by Filesystem.action Filesystem.dest
-  Filesystem.file_access_time Filesystem.file_create_time Filesystem.file_hash Filesystem.file_modify_time
-  Filesystem.file_name Filesystem.file_path Filesystem.file_acl Filesystem.file_size
-  Filesystem.process_guid Filesystem.process_id Filesystem.user Filesystem.vendor_product
-  | `drop_dm_object_name(Filesystem)` | `security_content_ctime(lastTime)` | `security_content_ctime(firstTime)`
-  | `ransomware_notes` | `common_ransomware_notes_filter`'
+  as file_path from datamodel=Endpoint.Filesystem
+  by Filesystem.action Filesystem.dest Filesystem.file_access_time Filesystem.file_create_time
+     Filesystem.file_hash Filesystem.file_modify_time
+     Filesystem.file_name Filesystem.file_path Filesystem.file_acl Filesystem.file_size
+     Filesystem.process_guid Filesystem.process_id Filesystem.user Filesystem.vendor_product
+  | `drop_dm_object_name(Filesystem)`
+  | `security_content_ctime(lastTime)`
+  | `security_content_ctime(firstTime)`
+  | lookup ransomware_notes_lookup ransomware_notes as file_name OUTPUT status as "Known Ransomware Notes"
+  | search "Known Ransomware Notes"=True
+  | `common_ransomware_notes_filter`
 how_to_implement: You must be ingesting data that records file-system activity from
   your hosts to populate the Endpoint Filesystem data-model node. This is typically
   populated via endpoint detection-and-response product, such as Carbon Black, or

--- a/detections/endpoint/csc_net_on_the_fly_compilation.yml
+++ b/detections/endpoint/csc_net_on_the_fly_compilation.yml
@@ -1,7 +1,7 @@
 name: CSC Net On The Fly Compilation
 id: ea73128a-43ab-11ec-9753-acde48001122
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-12-15'
 author: Teoderick Contreras, Splunk
 status: production
 type: Hunting
@@ -18,13 +18,16 @@ data_source:
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_csc` Processes.process
-  = "*/noconfig*" Processes.process = "*/fullpaths*" Processes.process = "*@*" by
-  Processes.action Processes.dest Processes.original_file_name Processes.parent_process
-  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
-  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
-  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
-  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name=csc.exe OR Processes.original_file_name=csc.exe)
+  Processes.process = "*/noconfig*"
+  Processes.process = "*/fullpaths*"
+  Processes.process = "*@*"
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
+     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
+     Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
+     Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
   | `csc_net_on_the_fly_compilation_filter`'
 how_to_implement: The detection is based on data that originates from Endpoint Detection

--- a/detections/endpoint/detect_prohibited_applications_spawning_cmd_exe.yml
+++ b/detections/endpoint/detect_prohibited_applications_spawning_cmd_exe.yml
@@ -1,7 +1,7 @@
 name: Detect Prohibited Applications Spawning cmd exe
 id: dcfd6b40-42f9-469d-a433-2e53f7486664
-version: 13
-date: '2025-05-02'
+version: 14
+date: '2025-12-15'
 author: Bhavin Patel, Splunk
 status: production
 type: Hunting
@@ -17,16 +17,25 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count values(Processes.process)
-  as process min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
-  where `process_cmd` by Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)` |search
-  [`prohibited_apps_launching_cmd_macro`] | `detect_prohibited_applications_spawning_cmd_exe_filter`'
+search: |
+  | tstats `security_content_summariesonly` count values(Processes.process)
+  as process min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where (Processes.process_name=cmd.exe OR Processes.original_file_name=Cmd.Exe)
+  by Processes.action Processes.dest Processes.original_file_name
+     Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
+     Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
+     Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
+     Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
+     Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  |search [
+      | inputlookup prohibited_apps_launching_cmd 
+      | rename prohibited_applications as parent_process_name
+      | eval parent_process_name="*" . parent_process_name
+      | table parent_process_name
+    ]
+  | `detect_prohibited_applications_spawning_cmd_exe_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/detect_psexec_with_accepteula_flag.yml
+++ b/detections/endpoint/detect_psexec_with_accepteula_flag.yml
@@ -1,7 +1,7 @@
 name: Detect PsExec With accepteula Flag
 id: 27c3a83d-cada-47c6-9042-67baf19d2574
-version: 13
-date: '2025-05-02'
+version: 14
+date: '2025-12-15'
 author: Bhavin Patel, Splunk
 status: production
 type: TTP
@@ -18,8 +18,14 @@ data_source:
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` values(Processes.process) as process
-  min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
-  where `process_psexec` Processes.process=*accepteula* by Processes.action Processes.dest
+  min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where
+  (
+    Processes.process_name IN ("psexec.exe", "psexec64.exe")
+    OR
+    Processes.original_file_name="psexec.c"
+  )
+  Processes.process=*accepteula*
+  by Processes.action Processes.dest
   Processes.original_file_name Processes.parent_process Processes.parent_process_exec
   Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
   Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid

--- a/detections/endpoint/detect_rclone_command_line_usage.yml
+++ b/detections/endpoint/detect_rclone_command_line_usage.yml
@@ -1,7 +1,7 @@
 name: Detect RClone Command-Line Usage
 id: 32e0baea-b3f1-11eb-a2ce-acde48001122
-version: 14
-date: '2025-10-14'
+version: 15
+date: '2025-12-15'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -22,7 +22,7 @@ data_source:
 search: |
   | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where
-  `process_rclone`
+  (Processes.original_file_name="rclone.exe" OR Processes.process_name="rclone.exe")
   Processes.process IN (
           "*copy*", "*mega*", "*pcloud*", "*ftp*",
           "*--config*", "*--progress*", "*--no-check-certificate*",

--- a/detections/endpoint/detect_regasm_with_no_command_line_arguments.yml
+++ b/detections/endpoint/detect_regasm_with_no_command_line_arguments.yml
@@ -1,7 +1,7 @@
 name: Detect Regasm with no Command Line Arguments
 id: c3bc1430-04e7-4178-835f-047d8e6e97df
-version: 11
-date: '2025-05-02'
+version: 12
+date: '2025-12-15'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -18,15 +18,20 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Processes
-  where `process_regasm` by _time span=1h Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | regex
-  process="(?i)(regasm\.exe.{0,4}$)" | `detect_regasm_with_no_command_line_arguments_filter`'
+search: |
+  | tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Processes where
+  (Processes.process_name=regasm.exe OR Processes.original_file_name=RegAsm.exe)
+  Processes.process IN ("*regasm","*regasm.exe", "*regasm.exe\"")
+  by Processes.action Processes.dest Processes.original_file_name
+     Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
+     Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
+     Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
+     Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
+     Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `detect_regasm_with_no_command_line_arguments_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/detect_regsvcs_with_no_command_line_arguments.yml
+++ b/detections/endpoint/detect_regsvcs_with_no_command_line_arguments.yml
@@ -1,7 +1,7 @@
 name: Detect Regsvcs with No Command Line Arguments
 id: 6b74d578-a02e-4e94-a0d1-39440d0bf254
-version: 11
-date: '2025-05-02'
+version: 12
+date: '2025-12-15'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -17,15 +17,20 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime FROM datamodel=Endpoint.Processes where `process_regsvcs` by Processes.action
-  Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | regex process="(?i)(regsvcs\.exe.{0,4}$)"| `detect_regsvcs_with_no_command_line_arguments_filter`'
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime FROM datamodel=Endpoint.Processes where
+  (Processes.process_name=regsvcs.exe OR Processes.original_file_name=RegSvcs.exe)
+  Processes.process IN ("*regsvcs","*regsvcs.exe", "*regsvcs.exe\"")
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
+     Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
+     Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
+     Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
+     Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `detect_regsvcs_with_no_command_line_arguments_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/domain_controller_discovery_with_nltest.yml
+++ b/detections/endpoint/domain_controller_discovery_with_nltest.yml
@@ -1,7 +1,7 @@
 name: Domain Controller Discovery with Nltest
 id: 41243735-89a7-4c83-bcdd-570aa78f00a1
-version: 8
-date: '2025-11-20'
+version: 9
+date: '2025-12-18'
 author: Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -17,8 +17,10 @@ data_source:
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_nltest` (Processes.process="*/dclist:*"
-  OR Processes.process="*/dsgetdc:*") by Processes.action Processes.dest Processes.original_file_name
+  as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name=nltest.exe OR Processes.original_file_name=nltestrk.exe)
+  (Processes.process="*/dclist:*" OR Processes.process="*/dsgetdc:*")
+  by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
   Processes.process Processes.process_exec Processes.process_guid Processes.process_hash

--- a/detections/endpoint/dump_lsass_via_procdump.yml
+++ b/detections/endpoint/dump_lsass_via_procdump.yml
@@ -1,7 +1,7 @@
 name: Dump LSASS via procdump
 id: 3742ebfe-64c2-11eb-ae93-0242ac130002
-version: 14
-date: '2025-10-22'
+version: 15
+date: '2025-12-15'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -25,7 +25,15 @@ search: |
           
   from datamodel=Endpoint.Processes where 
   
-  `process_procdump`
+  (
+    Processes.process_name IN (
+      "procdump.exe",
+      "procdump64.exe",
+      "procdump64a.exe"
+    )
+    OR
+    Processes.original_file_name=procdump
+  )
   Processes.process IN (*-ma*, *-mm*, "*-mp*", */ma*, */mm*, "*/mp*")
   Processes.process IN (* ls*, "* keyiso*", "* samss*")
   

--- a/detections/endpoint/esentutl_sam_copy.yml
+++ b/detections/endpoint/esentutl_sam_copy.yml
@@ -1,7 +1,7 @@
 name: Esentutl SAM Copy
 id: d372f928-ce4f-11eb-a762-acde48001122
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-12-15'
 author: Michael Haag, Splunk
 status: production
 type: Hunting
@@ -17,15 +17,21 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_esentutl` Processes.process
-  IN ("*ntds*", "*SAM*") by Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `esentutl_sam_copy_filter`'
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name=esentutl.exe OR Processes.original_file_name=esentutl.exe)
+  Processes.process IN ("*ntds*", "*SAM*")
+  by Processes.action Processes.dest Processes.original_file_name
+     Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
+     Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
+     Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
+     Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
+     Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `esentutl_sam_copy_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/network_discovery_using_route_windows_app.yml
+++ b/detections/endpoint/network_discovery_using_route_windows_app.yml
@@ -1,7 +1,7 @@
 name: Network Discovery Using Route Windows App
 id: dd83407e-439f-11ec-ab8e-acde48001122
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-12-15'
 author: Teoderick Contreras, Splunk
 status: production
 type: Hunting
@@ -17,15 +17,19 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_route` by Processes.action
-  Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `network_discovery_using_route_windows_app_filter`'
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name=route.exe OR Processes.original_file_name=route.exe)
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
+     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
+     Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
+     Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `network_discovery_using_route_windows_app_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/nltest_domain_trust_discovery.yml
+++ b/detections/endpoint/nltest_domain_trust_discovery.yml
@@ -1,7 +1,7 @@
 name: NLTest Domain Trust Discovery
 id: c3e05466-5f22-11eb-ae93-0242ac130002
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-12-18'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -18,8 +18,10 @@ data_source:
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_nltest` (Processes.process=*/domain_trusts*
-  OR Processes.process=*/all_trusts*) by Processes.action Processes.dest Processes.original_file_name
+  as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name=nltest.exe OR Processes.original_file_name=nltestrk.exe)
+  (Processes.process=*/domain_trusts* OR Processes.process=*/all_trusts*)
+  by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
   Processes.process Processes.process_exec Processes.process_guid Processes.process_hash

--- a/detections/endpoint/potential_system_network_configuration_discovery_activity.yml
+++ b/detections/endpoint/potential_system_network_configuration_discovery_activity.yml
@@ -1,7 +1,7 @@
 name: Potential System Network Configuration Discovery Activity
 id: 3f0b95e3-3195-46ac-bea3-84fb59e7fac5
-version: 4
-date: '2025-05-02'
+version: 5
+date: '2025-12-17'
 author: Bhavin Patel, Splunk
 status: production
 type: Anomaly
@@ -18,18 +18,46 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count values(Processes.process)
-  as process values(Processes.parent_process) as parent_process min(_time) as firstTime
-  max(_time) as lastTime from datamodel=Endpoint.Processes where NOT Processes.user
-  IN ("","unknown") by Processes.action Processes.dest Processes.original_file_name
+search: |
+  | tstats `security_content_summariesonly` 
+    count values(Processes.process) as process
+          values(Processes.parent_process) as parent_process
+          min(_time) as firstTime
+          max(_time) as lastTime
+  from datamodel=Endpoint.Processes where
+  
+  NOT Processes.user IN ("","unknown")
+  
+  by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
   Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
   Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product _time | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` | `drop_dm_object_name(Processes)` | search
-  `system_network_configuration_discovery_tools` | transaction dest connected=false
-  maxpause=5m | where eventcount>=5 | `potential_system_network_configuration_discovery_activity_filter`'
+  Processes.user Processes.user_id Processes.vendor_product _time
+  
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `drop_dm_object_name(Processes)`
+  | search process_name IN (
+            "arp.exe",
+            "dsquery.exe",
+            "hostname.exe",
+            "ipconfig.exe",
+            "nbstat.exe",
+            "net.exe",
+            "net1.exe",
+            "nltest.exe",
+            "netsh.exe",
+            "nslookup.exe",
+            "ping.exe",
+            "quser.exe",
+            "qwinsta.exe",
+            "telnet.exe",
+            "tracert.exe",
+          )
+  | transaction dest connected=false maxpause=5m
+  | where eventcount>=5
+  | `potential_system_network_configuration_discovery_activity_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/runas_execution_in_commandline.yml
+++ b/detections/endpoint/runas_execution_in_commandline.yml
@@ -1,7 +1,7 @@
 name: Runas Execution in CommandLine
 id: 4807e716-43a4-11ec-a0e7-acde48001122
-version: 8
-date: '2025-07-16'
+version: 9
+date: '2025-12-15'
 author: Teoderick Contreras, Splunk
 status: production
 type: Hunting
@@ -17,16 +17,22 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_runas` AND Processes.process
-  = "*/user:*" AND Processes.process = "*admin*" by Processes.action Processes.dest
-  Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `runas_execution_in_commandline_filter`'
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name="runas.exe" OR Processes.original_file_name="runas.exe")
+  Processes.process ="*/user:*"
+  Processes.process = "*admin*"
+  by Processes.action Processes.dest
+     Processes.original_file_name Processes.parent_process Processes.parent_process_exec
+     Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
+     Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
+     Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
+     Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `runas_execution_in_commandline_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/sdelete_application_execution.yml
+++ b/detections/endpoint/sdelete_application_execution.yml
@@ -1,7 +1,7 @@
 name: Sdelete Application Execution
 id: 31702fc0-2682-11ec-85c3-acde48001122
-version: 8
-date: '2025-07-29'
+version: 9
+date: '2025-12-15'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
@@ -20,7 +20,8 @@ data_source:
 search: '| tstats `security_content_summariesonly` values(Processes.process) as process
   values(Processes.parent_process) as parent_process values(Processes.process_id)
   as process_id count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
-  where `process_sdelete` by Processes.action Processes.dest Processes.original_file_name
+  where (Processes.process_name="sdelete.exe" OR Processes.original_file_name="sdelete.exe")
+  by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
   Processes.process Processes.process_exec Processes.process_guid Processes.process_hash

--- a/detections/endpoint/suspicious_copy_on_system32.yml
+++ b/detections/endpoint/suspicious_copy_on_system32.yml
@@ -1,7 +1,7 @@
 name: Suspicious Copy on System32
 id: ce633e56-25b2-11ec-9e76-acde48001122
-version: 11
-date: '2025-06-17'
+version: 12
+date: '2025-12-18'
 author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -24,13 +24,16 @@ search: |
   as lastTime from datamodel=Endpoint.Processes where
   Processes.parent_process_name IN (
     "cmd.exe", 
-    "powershell_ise.exe",
     "powershell.exe", 
     "pwsh.exe", 
     "sqlps.exe", 
     "sqltoolsps.exe"
   )
-  `process_copy` 
+  (
+    Processes.process_name IN ("copy.exe", "xcopy.exe")
+    OR
+    Processes.original_file_name IN ("copy.exe", "xcopy.exe")
+  )
   Processes.process IN (
     "* \"C:\\Windows\\System32\\*", 
     "* \'C:\\Windows\\System32\\*", 

--- a/detections/endpoint/suspicious_dllhost_no_command_line_arguments.yml
+++ b/detections/endpoint/suspicious_dllhost_no_command_line_arguments.yml
@@ -1,7 +1,7 @@
 name: Suspicious DLLHost no Command Line Arguments
 id: ff61e98c-0337-4593-a78f-72a676c56f26
-version: 10
-date: '2025-05-02'
+version: 11
+date: '2025-12-15'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -17,15 +17,19 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Processes
-  where `process_dllhost` by Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | regex
-  process="(?i)(dllhost\.exe.{0,4}$)" | `suspicious_dllhost_no_command_line_arguments_filter`'
+search: |
+  | tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Processes where
+  (Processes.process_name=dllhost.exe OR Processes.original_file_name=dllhost.exe)
+  Processes.process IN ("*dllhost","*dllhost.exe", "*dllhost.exe\"")
+  by Processes.action Processes.dest Processes.original_file_name
+     Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
+     Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
+     Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
+     Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
+     Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `suspicious_dllhost_no_command_line_arguments_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/suspicious_gpupdate_no_command_line_arguments.yml
+++ b/detections/endpoint/suspicious_gpupdate_no_command_line_arguments.yml
@@ -1,7 +1,7 @@
 name: Suspicious GPUpdate no Command Line Arguments
 id: f308490a-473a-40ef-ae64-dd7a6eba284a
-version: 9
-date: '2025-10-14'
+version: 10
+date: '2025-12-15'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -17,15 +17,19 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Processes
-  where `process_gpupdate` by Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | regex
-  process="(?i)(gpupdate\.exe.{0,4}$)" | `suspicious_gpupdate_no_command_line_arguments_filter`'
+search: |
+  | tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Processes where
+  (Processes.process_name=gpupdate.exe OR Processes.original_file_name=GPUpdate.exe)
+  Processes.process IN ("*gpupdate","*gpupdate.exe", "*gpupdate.exe\"")
+  by Processes.action Processes.dest Processes.original_file_name
+     Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
+     Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
+     Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
+     Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
+     Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `suspicious_gpupdate_no_command_line_arguments_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/suspicious_microsoft_workflow_compiler_usage.yml
+++ b/detections/endpoint/suspicious_microsoft_workflow_compiler_usage.yml
@@ -1,7 +1,7 @@
 name: Suspicious microsoft workflow compiler usage
 id: 9bbc62e8-55d8-11eb-ae93-0242ac130002
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-12-15'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -18,7 +18,7 @@ data_source:
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_microsoftworkflowcompiler`
+  as lastTime from datamodel=Endpoint.Processes where (Processes.process_name=microsoft.workflow.compiler.exe OR Processes.original_file_name=Microsoft.Workflow.Compiler.exe)
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
   Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
   Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec

--- a/detections/endpoint/system_info_gathering_using_dxdiag_application.yml
+++ b/detections/endpoint/system_info_gathering_using_dxdiag_application.yml
@@ -1,7 +1,7 @@
 name: System Info Gathering Using Dxdiag Application
 id: f92d74f2-4921-11ec-b685-acde48001122
-version: 6
-date: '2025-05-02'
+version: 7
+date: '2025-12-15'
 author: Teoderick Contreras, Splunk
 status: production
 type: Hunting
@@ -17,15 +17,18 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_dxdiag` AND Processes.process
-  = "* /t *" by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name=dxdiag.exe OR Processes.original_file_name=dxdiag.exe)
+  Processes.process = "* /t *"
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
   Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
   Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
   Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
   Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `system_info_gathering_using_dxdiag_application_filter`'
+  | `system_info_gathering_using_dxdiag_application_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/system_processes_run_from_unexpected_locations.yml
+++ b/detections/endpoint/system_processes_run_from_unexpected_locations.yml
@@ -1,7 +1,7 @@
 name: System Processes Run From Unexpected Locations
 id: a34aae96-ccf8-4aef-952c-3ea21444444d
-version: 12
-date: '2025-05-02'
+version: 13
+date: '2025-12-13'
 author: David Dorsey, Michael Haag, Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -16,18 +16,32 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime FROM datamodel=Endpoint.Processes where  NOT Processes.process_path IN ("C:\\$WINDOWS.~BT\\*", "C:\\$WinREAgent\\*", "C:\\Windows\\SoftwareDistribution\\*", "C:\\Windows\\System32\\*", "C:\\Windows\\SystemTemp\\*", "C:\\Windows\\SysWOW64\\*", "C:\\Windows\\uus\\*", "C:\\Windows\\WinSxS\\*") by Processes.action Processes.dest
-  Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+search: |
+  | tstats `security_content_summariesonly` 
+    count min(_time) as firstTime max(_time) as lastTime 
+    FROM datamodel=Endpoint.Processes where 
+    NOT Processes.process_path IN (
+      "*:\\$WINDOWS.~BT\\*",
+      "*:\\$WinREAgent\\*",
+      "*:\\Windows\\SoftwareDistribution\\*",
+      "*:\\Windows\\System32\\*",
+      "*:\\Windows\\SystemTemp\\*",
+      "*:\\Windows\\SysWOW64\\*",
+      "*:\\Windows\\uus\\*",
+      "*:\\Windows\\WinSxS\\*",
+    )
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
+     Processes.parent_process_name Processes.parent_process_path Processes.process
+     Processes.process_exec Processes.process_guid Processes.process_hash
+     Processes.process_id Processes.process_integrity_level Processes.process_name
+     Processes.process_path Processes.user Processes.user_id Processes.vendor_product
   | `drop_dm_object_name("Processes")`
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
-  | `is_windows_system_file_macro`
-  | `system_processes_run_from_unexpected_locations_filter`'
+  | lookup update=true is_windows_system_file filename as process_name OUTPUT systemFile
+  | search systemFile=true
+  | `system_processes_run_from_unexpected_locations_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/verclsid_clsid_execution.yml
+++ b/detections/endpoint/verclsid_clsid_execution.yml
@@ -1,7 +1,7 @@
 name: Verclsid CLSID Execution
 id: 61e9a56a-20fa-11ec-8ba3-acde48001122
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-12-15'
 author: Teoderick Contreras, Splunk
 status: production
 type: Hunting
@@ -17,17 +17,25 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` values(Processes.process) as process
+search: |
+  | tstats `security_content_summariesonly` values(Processes.process) as process
   values(Processes.parent_process) as parent_process values(Processes.process_id)
-  as process_id count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
-  where `process_verclsid` AND Processes.process="*/S*" Processes.process="*/C*" AND  Processes.process="*{*"
-  AND Processes.process="*}*" by Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `verclsid_clsid_execution_filter`'
+  as process_id count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name="verclsid.exe" OR Processes.original_file_name="verclsid.exe")
+  Processes.process="*/S*"
+  Processes.process="*/C*"
+  Processes.process="*{*"
+  Processes.process="*}*"
+  by Processes.action Processes.dest Processes.original_file_name
+     Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
+     Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
+     Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
+     Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
+     Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `verclsid_clsid_execution_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/wbadmin_delete_system_backups.yml
+++ b/detections/endpoint/wbadmin_delete_system_backups.yml
@@ -1,7 +1,7 @@
 name: WBAdmin Delete System Backups
 id: cd5aed7e-5cea-11eb-ae93-0242ac130002
-version: 8
-date: '2025-05-02'
+version: 9
+date: '2025-12-18'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -17,9 +17,19 @@ data_source:
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_wbadmin` AND Processes.process="*delete*"
-  AND (Processes.process="*catalog*" OR Processes.process="*backup*") by Processes.action
-  Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
+  as lastTime from datamodel=Endpoint.Processes where
+  (
+    Processes.process_name=wbadmin.exe
+    OR
+    Processes.original_file_name=WBADMIN.EXE
+  )
+  Processes.process="*delete*"
+  (
+    Processes.process="*catalog*"
+    OR
+    Processes.process="*backup*"
+  )
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
   Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
   Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
   Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name

--- a/detections/endpoint/windows_curl_download_to_suspicious_path.yml
+++ b/detections/endpoint/windows_curl_download_to_suspicious_path.yml
@@ -1,7 +1,7 @@
 name: Windows Curl Download to Suspicious Path
 id: c32f091e-30db-11ec-8738-acde48001122
-version: 17
-date: '2025-11-25'
+version: 18
+date: '2025-12-18'
 author: Michael Haag, Nasreddine Bencherchali, Splunk
 status: production
 type: TTP
@@ -22,7 +22,11 @@ data_source:
 search: |
   | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime from datamodel=Endpoint.Processes where
-  `process_curl`
+  (
+    Processes.process_name=curl.exe
+    OR
+    Processes.original_file_name=Curl.exe
+  )
   Processes.process IN ("*-O *","*--output*", "*--output-dir*")
   Processes.process IN (
         "*:\\PerfLogs\\*",

--- a/detections/endpoint/windows_curl_upload_to_remote_destination.yml
+++ b/detections/endpoint/windows_curl_upload_to_remote_destination.yml
@@ -1,7 +1,7 @@
 name: Windows Curl Upload to Remote Destination
 id: 42f8f1a2-4228-11ec-aade-acde48001122
-version: 13
-date: '2025-11-25'
+version: 14
+date: '2025-12-18'
 author: Michael Haag, Splunk
 status: production
 type: TTP

--- a/detections/endpoint/windows_curl_upload_to_remote_destination.yml
+++ b/detections/endpoint/windows_curl_upload_to_remote_destination.yml
@@ -18,17 +18,26 @@ data_source:
   - Windows Event Log Security 4688
   - CrowdStrike ProcessRollup2
   - Cisco Network Visibility Module Flow Data
-search:
-  '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_curl` Processes.process
-  IN ("*-T *","*--upload-file *", "*-d *", "*--data *", "*-F *") by Processes.action
-  Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `windows_curl_upload_to_remote_destination_filter`'
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name=curl.exe OR Processes.original_file_name=Curl.exe)
+  Processes.process IN (
+    "*-T *",
+    "*--upload-file *",
+    "*-d *",
+    "*--data *",
+    "*-F *"
+  )
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
+     Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
+     Processes.process Processes.process_exec Processes.process_guid Processes.process_hash Processes.process_id
+     Processes.process_integrity_level Processes.process_name Processes.process_path Processes.user Processes.user_id
+     Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `windows_curl_upload_to_remote_destination_filter`
 how_to_implement:
   The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related

--- a/detections/endpoint/windows_diskshadow_proxy_execution.yml
+++ b/detections/endpoint/windows_diskshadow_proxy_execution.yml
@@ -1,7 +1,7 @@
 name: Windows Diskshadow Proxy Execution
 id: 58adae9e-8ea3-11ec-90f6-acde48001122
-version: 6
-date: '2025-05-02'
+version: 7
+date: '2025-12-15'
 author: Lou Stella, Splunk
 status: production
 type: TTP
@@ -16,15 +16,20 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_diskshadow` (Processes.process=*-s*
-  OR Processes.process=*/s*) by Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `windows_diskshadow_proxy_execution_filter`'
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name=diskshadow.exe OR Processes.original_file_name=diskshadow.exe)
+  Processes.process IN (*-s*, */s*)
+  by Processes.action Processes.dest Processes.original_file_name
+     Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
+     Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
+     Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
+     Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
+     Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `windows_diskshadow_proxy_execution_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/windows_dotnet_binary_in_non_standard_path.yml
+++ b/detections/endpoint/windows_dotnet_binary_in_non_standard_path.yml
@@ -1,7 +1,7 @@
 name: Windows DotNet Binary in Non Standard Path
 id: fddf3b56-7933-11ec-98a6-acde48001122
-version: 9
-date: '2025-05-02'
+version: 10
+date: '2025-12-13'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -17,17 +17,31 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime FROM datamodel=Endpoint.Processes where NOT (Processes.process_path
-  IN ("*\\Windows\\ADWS\\*","*\\Windows\\SysWOW64*", "*\\Windows\\system32*", "*\\Windows\\NetworkController\\*",
-  "*\\Windows\\SystemApps\\*", "*\\WinSxS\\*", "*\\Windows\\Microsoft.NET\\*")) by
-  Processes.action Processes.dest Processes.original_file_name Processes.parent_process
-  Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
-  Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
-  Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
-  Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name("Processes")` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `is_net_windows_file_macro` | `windows_dotnet_binary_in_non_standard_path_filter`'
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime
+  FROM datamodel=Endpoint.Processes where
+  NOT Processes.process_path IN (
+        "*:\\Windows\\ADWS\\*",
+        "*:\\Windows\\Microsoft.NET\\*",
+        "*:\\Windows\\NetworkController\\*",
+        "*:\\Windows\\System32\\*",
+        "*:\\Windows\\SystemApps\\*",
+        "*:\\Windows\\SysWOW64\\*",
+        "*:\\Windows\\WinSxS\\*"
+      )
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
+     Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec
+     Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level
+     Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name("Processes")`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | lookup update=true is_net_windows_file filename as process_name OUTPUT netFile
+  | lookup update=true is_net_windows_file originalFileName as original_file_name OUTPUT netFile
+  | search netFile=true
+  | `windows_dotnet_binary_in_non_standard_path_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/windows_file_collection_via_copy_utilities.yml
+++ b/detections/endpoint/windows_file_collection_via_copy_utilities.yml
@@ -1,7 +1,7 @@
 name: Windows File Collection Via Copy Utilities
 id: dbdd556d-9da8-4c42-9980-8a3ffe25a758
-version: 1
-date: '2025-08-26'
+version: 2
+date: '2025-12-18'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly
@@ -10,8 +10,33 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes 
-  where `process_copy` Processes.process IN ("*.doc*","*.docx*","*.xls*","*.xlsx*","*.ppt*","*.pptx*","*.log*","*.txt*","*.db*","*.7z*","*.zip*","*.rar*","*.tar*","*.gz*","*.jpg*","*.gif*","*.png*","*.bmp*","*.pdf*","*.rtf*")
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime
+  from datamodel=Endpoint.Processes where
+  (
+    Processes.process_name IN ("copy.exe", "xcopy.exe")
+    OR
+    Processes.original_file_name IN ("copy.exe", "xcopy.exe")
+  )
+  Processes.process IN (
+    "*.7z*",
+    "*.bmp*",
+    "*.db*",
+    "*.doc*",
+    "*.gif*",
+    "*.gz*",
+    "*.jpg*",
+    "*.log*",
+    "*.pdf*",
+    "*.png*",
+    "*.ppt*",
+    "*.rar*",
+    "*.rtf*",
+    "*.tar*",
+    "*.txt*",
+    "*.xls*",
+    "*.zip*"
+  )
   by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
@@ -21,7 +46,7 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   | `drop_dm_object_name(Processes)`
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)` 
-  | `windows_file_collection_via_copy_utilities_filter`'
+  | `windows_file_collection_via_copy_utilities_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/windows_nirsoft_utilities.yml
+++ b/detections/endpoint/windows_nirsoft_utilities.yml
@@ -1,7 +1,7 @@
 name: Windows NirSoft Utilities
 id: 5b2f4596-7d4c-11ec-88a7-acde48001122
-version: 7
-date: '2025-05-02'
+version: 8
+date: '2025-12-13'
 author: Michael Haag, Splunk
 status: production
 type: Hunting
@@ -16,15 +16,21 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime FROM datamodel=Endpoint.Processes by Processes.action Processes.dest
-  Processes.original_file_name Processes.parent_process Processes.parent_process_exec
-  Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
-  Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
-  Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name
-  Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-  | `drop_dm_object_name("Processes")` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
-  | `is_nirsoft_software_macro` | `windows_nirsoft_utilities_filter`'
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime FROM datamodel=Endpoint.Processes
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
+     Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
+     Processes.parent_process_name Processes.parent_process_path Processes.process
+     Processes.process_exec Processes.process_guid Processes.process_hash Processes.process_id
+     Processes.process_integrity_level Processes.process_name Processes.process_path
+     Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name("Processes")`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | lookup update=true is_nirsoft_software filename as process_name OUTPUT nirsoftFile
+  | search nirsoftFile=true
+  | `windows_nirsoft_utilities_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/windows_office_product_spawned_uncommon_process.yml
+++ b/detections/endpoint/windows_office_product_spawned_uncommon_process.yml
@@ -1,7 +1,7 @@
 name: Windows Office Product Spawned Uncommon Process
 id: 55d8741c-fa32-4692-8109-410304961eb8
-version: 5
-date: '2025-09-18'
+version: 6
+date: '2025-12-15'
 author: Michael Haag, Teoderick Contreras, Splunk
 status: production
 type: TTP
@@ -17,17 +17,49 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_office_products_parent`
-  AND (`process_bitsadmin` OR `process_certutil` OR `process_cmd` OR `process_cscript`
-  OR `process_mshta` OR `process_powershell` OR `process_regsvr32` OR `process_rundll32`
-  OR `process_wmic` OR `process_wscript`) by Processes.action Processes.dest Processes.original_file_name
-  Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
-  Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
-  Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
-  Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)` | `windows_office_product_spawned_uncommon_process_filter`'
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where
+  `process_office_products_parent`
+  AND
+  (
+    Processes.process_name IN (
+      bitsadmin.exe,
+      certutil.exe,
+      cmd.exe,
+      cscript.exe,
+      mshta.exe,
+      powershell.exe,
+      pwsh.exe,
+      regsvr32.exe,
+      rundll32.exe,
+      wmic.exe,
+      wscript.exe
+    )
+    OR
+    Processes.original_file_name IN (
+      bitsadmin.exe,
+      CertUtil.exe,
+      Cmd.Exe,
+      cscript.exe,
+      MSHTA.EXE,
+      PowerShell.EXE,
+      pwsh.dll,
+      REGSVR32.EXE,
+      RUNDLL32.EXE,
+      wmic.exe,
+      wscript.exe
+    )
+  )
+  by Processes.action Processes.dest Processes.original_file_name
+     Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
+     Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
+     Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
+     Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
+     Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `windows_office_product_spawned_uncommon_process_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/windows_scheduled_task_created_via_xml.yml
+++ b/detections/endpoint/windows_scheduled_task_created_via_xml.yml
@@ -1,7 +1,7 @@
 name: Windows Scheduled Task Created Via XML
 id: 7e03b682-3965-4598-8e91-a60a40a3f7e4
-version: 10
-date: '2025-10-07'
+version: 11
+date: '2025-12-18'
 author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -20,7 +20,7 @@ search: |
 
   from datamodel=Endpoint.Processes where 
   
-  `process_schtasks`
+  (Processes.process_name=schtasks.exe OR Processes.original_file_name=schtasks.exe)
   Processes.process IN ("* /create *", "* -create *")
   Processes.process IN ("* /xml *", "* -xml *")
   

--- a/detections/endpoint/windows_schtasks_create_run_as_system.yml
+++ b/detections/endpoint/windows_schtasks_create_run_as_system.yml
@@ -1,7 +1,7 @@
 name: Windows Schtasks Create Run As System
 id: 41a0e58e-884c-11ec-9976-acde48001122
-version: 9
-date: '2025-10-31'
+version: 10
+date: '2025-12-18'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -19,9 +19,12 @@ data_source:
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where `process_schtasks` Processes.process="*/create
-  *" AND Processes.process="*/ru *" AND Processes.process="*system*" by Processes.action
-  Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
+  as lastTime from datamodel=Endpoint.Processes where
+  (Processes.process_name=schtasks.exe OR Processes.original_file_name=schtasks.exe)
+  Processes.process="*/create *"
+  Processes.process="*/ru *"
+  Processes.process="*system*"
+  by Processes.action Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
   Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name
   Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid
   Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name

--- a/detections/endpoint/windows_sensitive_registry_hive_dump_via_commandline.yml
+++ b/detections/endpoint/windows_sensitive_registry_hive_dump_via_commandline.yml
@@ -1,7 +1,7 @@
 name: Windows Sensitive Registry Hive Dump Via CommandLine
 id: 5aaff29d-0cce-405b-9ee8-5d06b49d045e
-version: 6
-date: '2025-06-02'
+version: 7
+date: '2025-12-15'
 author: Michael Haag, Patrick Bareiss, Nasreddine Bencherchali, Splunk
 status: production
 type: TTP
@@ -17,18 +17,38 @@ data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688
 - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Endpoint.Processes where ((`process_reg` Processes.process
-  IN ("*save*", "*export*")) OR (`process_regedit` Processes.process IN ("*/E *",
-  "*-E *"))) AND Processes.process IN ("*HKEY_LOCAL_MACHINE\\SAM*", "*HKEY_LOCAL_MACHINE\\System*", 
-  "*HKEY_LOCAL_MACHINE\\Security*", "*HKLM\\SAM*", "*HKLM\\System*", "*HKLM\\Security*") 
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
+  as lastTime from datamodel=Endpoint.Processes where
+  (
+    (
+      (Processes.process_name=reg.exe OR Processes.original_file_name=reg.exe)
+      Processes.process IN ("*save*", "*export*")
+    )
+    OR
+    (
+      (Processes.process_name=regedit.exe OR Processes.original_file_name=REGEDIT.exe)
+      Processes.process IN ("*/E *", "*-E *")
+    )
+  )
+  Processes.process IN (
+    "*HKEY_LOCAL_MACHINE\\SAM*",
+    "*HKEY_LOCAL_MACHINE\\Security*",
+    "*HKEY_LOCAL_MACHINE\\System*", 
+    "*HKLM\\SAM*",
+    "*HKLM\\Security*",
+    "*HKLM\\System*",
+  ) 
   by Processes.action Processes.dest Processes.original_file_name
   Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid
   Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
   Processes.process Processes.process_exec Processes.process_guid Processes.process_hash
   Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path
-  Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)`
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `windows_sensitive_registry_hive_dump_via_commandline_filter`'
+  Processes.user Processes.user_id Processes.vendor_product
+  | `drop_dm_object_name(Processes)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `windows_sensitive_registry_hive_dump_via_commandline_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,

--- a/detections/endpoint/windows_sqlcmd_execution.yml
+++ b/detections/endpoint/windows_sqlcmd_execution.yml
@@ -1,7 +1,7 @@
 name: Windows SQLCMD Execution
 id: 4e7c2f85-8f02-4bd2-a48b-5ec98a2c5f72
-version: 3
-date: '2025-09-16'
+version: 4
+date: '2025-12-15'
 author: Michael Haag, Splunk
 status: production
 type: Hunting
@@ -12,7 +12,7 @@ data_source:
 - CrowdStrike ProcessRollup2
 search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime 
     from datamodel=Endpoint.Processes 
-    where `process_sqlcmd`
+    where (Processes.process_name=sqlcmd.exe OR Processes.original_file_name=sqlcmd.exe)
     by Processes.dest Processes.user Processes.parent_process_name Processes.process_name 
     Processes.process Processes.process_id Processes.parent_process_id
     | `drop_dm_object_name(Processes)`

--- a/detections/endpoint/windows_wbadmin_file_recovery_from_backup.yml
+++ b/detections/endpoint/windows_wbadmin_file_recovery_from_backup.yml
@@ -1,7 +1,7 @@
 name: Windows WBAdmin File Recovery From Backup
 id: 0175f0b7-728d-4038-bbf1-1c30d6ee3d31
-version: 1
-date: '2025-10-15'
+version: 2
+date: '2025-12-18'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -21,7 +21,7 @@ search: |
           
   from datamodel=Endpoint.Processes where 
   
-  `process_wbadmin`
+  (Processes.process_name=wbadmin.exe OR Processes.original_file_name=WBADMIN.EXE)
   Processes.process = "*start*"
   Processes.process = "*recovery*"
   Processes.process = "*itemtype:file*" 

--- a/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
+++ b/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
@@ -1,6 +1,6 @@
 name: Detect hosts connecting to dynamic domain providers
 id: a1e761ac-1344-4dbd-88b2-3f34c912d359
-version: 11
+version: 9
 date: '2025-12-18'
 author: Bhavin Patel, Splunk
 status: production

--- a/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
+++ b/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
@@ -1,7 +1,7 @@
 name: Detect hosts connecting to dynamic domain providers
 id: a1e761ac-1344-4dbd-88b2-3f34c912d359
-version: 10
-date: '2025-12-13'
+version: 11
+date: '2025-12-18'
 author: Bhavin Patel, Splunk
 status: production
 type: TTP

--- a/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
+++ b/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
@@ -1,7 +1,7 @@
 name: Detect hosts connecting to dynamic domain providers
 id: a1e761ac-1344-4dbd-88b2-3f34c912d359
-version: 8
-date: '2025-05-02'
+version: 10
+date: '2025-12-13'
 author: Bhavin Patel, Splunk
 status: production
 type: TTP
@@ -15,10 +15,18 @@ description: The following analytic identifies DNS queries from internal hosts t
   access to the network.
 data_source:
 - Sysmon EventID 22
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime from
-  datamodel=Network_Resolution by DNS.answer DNS.answer_count DNS.query DNS.query_count
-  DNS.reply_code_id DNS.src DNS.vendor_product | `drop_dm_object_name("DNS")` | `security_content_ctime(firstTime)`
-  | `dynamic_dns_providers` | `detect_hosts_connecting_to_dynamic_domain_providers_filter`'
+search: |
+  | tstats `security_content_summariesonly` count min(_time) as firstTime
+    from datamodel=Network_Resolution
+    by DNS.answer DNS.answer_count DNS.query DNS.query_count
+       DNS.reply_code_id DNS.src DNS.vendor_product
+  | `drop_dm_object_name("DNS")`
+  | `security_content_ctime(firstTime)`
+  | lookup update=true dynamic_dns_providers_default dynamic_dns_domains as query OUTPUTNEW isDynDNS_default
+  | lookup update=true dynamic_dns_providers_local dynamic_dns_domains as query OUTPUTNEW isDynDNS_local
+  | eval isDynDNS = coalesce(isDynDNS_local,isDynDNS_default)
+  |fields - isDynDNS_default, isDynDNS_local| search isDynDNS=True
+  | `detect_hosts_connecting_to_dynamic_domain_providers_filter`
 how_to_implement: "First, you'll need to ingest data from your DNS operations. This\
   \ can be done by ingesting logs from your server or data, collected passively by\
   \ Splunk Stream or a similar solution. Specifically, data that contains the domain\

--- a/detections/web/monitor_web_traffic_for_brand_abuse.yml
+++ b/detections/web/monitor_web_traffic_for_brand_abuse.yml
@@ -1,7 +1,7 @@
 name: Monitor Web Traffic For Brand Abuse
 id: 134da869-e264-4a8f-8d7e-fcd0ec88f301
-version: 5
-date: '2025-05-02'
+version: 6
+date: '2025-12-13'
 author: David Dorsey, Splunk
 status: experimental
 type: TTP
@@ -14,9 +14,17 @@ description: The following analytic identifies web requests to domains that clos
   malicious, attackers could deceive users, steal credentials, or distribute malware,
   leading to significant reputational and financial damage.
 data_source: []
-search: '| tstats `security_content_summariesonly` values(Web.url) as urls min(_time)
-  as firstTime from datamodel=Web by Web.src | `drop_dm_object_name("Web")` | `security_content_ctime(firstTime)`
-  | `brand_abuse_web` | `monitor_web_traffic_for_brand_abuse_filter`'
+search: |
+  | tstats `security_content_summariesonly`
+    values(Web.url) as urls 
+    min(_time) as firstTime 
+    from datamodel=Web
+    by Web.src
+  | `drop_dm_object_name("Web")`
+  | `security_content_ctime(firstTime)`
+  | lookup update=true brandMonitoring_lookup domain as urls OUTPUT domain_abuse
+  | search domain_abuse=true
+  | `monitor_web_traffic_for_brand_abuse_filter`
 how_to_implement: You need to ingest data from your web traffic. This can be accomplished
   by indexing data from a web proxy, or using a network traffic analysis tool, such
   as Bro or Splunk Stream. You also need to have run the search "ESCU - DNSTwist Domain

--- a/macros/process_powershell.yml
+++ b/macros/process_powershell.yml
@@ -1,3 +1,3 @@
-definition: (Processes.process_name=pwsh.exe OR Processes.process_name=powershell.exe OR Processes.process_name=powershell_ise.exe OR Processes.original_file_name=pwsh.dll OR Processes.original_file_name=PowerShell.EXE OR Processes.original_file_name=powershell_ise.EXE)
+definition: (Processes.process_name=pwsh.exe OR Processes.process_name=powershell.exe OR Processes.original_file_name=pwsh.dll OR Processes.original_file_name=PowerShell.EXE)
 description: Matches the process with its original file name, data for this macro came from https://strontic.github.io/
 name: process_powershell


### PR DESCRIPTION
## Summary

This PR removes single use macros from searches. AKA macros that are only used by one or 2 searches.

The reason for this is that often time these macros hide the logic of the rules and lead to and additional step of resolving the macro which can be tedious when working with a large detection set such as the one here in ESCU.

Macros that have been touched in this PR are mostly:

- Lookup macro that hid the lookup logic and were used by a single search.
- Process based macros that abstracted the process being used as markers.
- Other macros that were used by a single search and hiding some logic away.

What did not get removed are:

- Single use macros that are used as a way to adapt the search to customer envs. These for example include defining a list of firewall zones, or define a time range, etc. These are there to avoid modifying the search directly which could lead to overrides in future updates or in the case of cloning forgetting to update the logic. (this will not be an issue once versioning is introduced).
- Macros that hid some large functionality - This were speared from this PR until further discussion.
- Sourcetype / Index macros were also left untouched due their obvious need.

Note: Macros were not deleted to avoid breaking changes with people who cloned the detections and are still using them. Similar to analytics. These will be deprecated in some future.

Below is the full list of changes 

## Updated Analytics

- `Suspicious Email Attachment Extensions` - Removed macro that was hiding a lookup
- `Common Ransomware Notes` - Removed macro that was hiding a lookup
- `CSC Net On The Fly Compilation` - Removed macro that was hiding process names
- `Detect Prohibited Applications Spawning cmd exe` - Removed macro that was hiding a lookup
- `Detect PsExec With accepteula Flag` - Removed macro that was hiding process names
- `Detect RClone Command-Line Usage` - Removed macro that was hiding process names
- `Domain Controller Discovery with Nltest` - Removed macro `process_nltest` and replaced by direct search
- `NLTest Domain Trust Discovery` - Removed macro `process_nltest` and replaced by direct search
- `Esentutl SAM Copy` - Removed macro `process_esentutl` and replaced by direct search
- `Network Discovery Using Route Windows App` - Removed macro `process_route` and replaced by direct search
- `Detect Regasm with no Command Line Arguments` - Removed macro `process_regasm` and replaced by direct search, and moved the regex search to tstats for faster results.
- `Detect Regsvcs with No Command Line Arguments` - Removed macro `process_regsvcs` and replaced by direct search, and moved the regex search to tstats for faster results.
- `Dump LSASS via procdump` - Removed macro `process_procdump` and replaced by direct search, and added `procdump64a.exe`
- `Potential System Network Configuration Discovery Activity` - Removed macro `system_network_configuration_discovery_tools` and added `net1.exe`
- `Runas Execution in CommandLine` 
- `Sdelete Application Execution` - Removed `process_sdelete`
- `Windows WBAdmin File Recovery From Backup` - Removed `process_wbadmin`
- `Windows SQLCMD Execution` - Removed `process_sqlcmd`
- `Suspicious Copy on System32` - Removed macro `process_copy` and `powershell_ise.exe` from the list as it does not make sense.
- `Suspicious DLLHost no Command Line Arguments` - Removed macro `process_dllhost` and replaced by direct search, and moved the regex search to tstats for faster results.
- `Windows Sensitive Registry Hive Dump Via CommandLine` - Removed `process_reg`
- ` Detect hosts connecting to dynamic domain providers` - Removed `dynamic_dns_providers`
- `Monitor Web Traffic For Brand Abuse` - Removed `brand_abuse_web`
- `Windows File Collection Via Copy Utilities` - Removed `process_copy` and overlapping coverage from the list of extension.
- `Windows NirSoft Utilities` - Removed `is_nirsoft_software_macro`
- `Windows Office Product Spawned Uncommon Process` - Removed all process macro usage
- `Windows Scheduled Task Created Via XML` - Removed `process_schtasks`
- `Windows Schtasks Create Run As System` - Removed `process_schtasks`
- `Windows Curl Upload to Remote Destination` - Removed `process_curl`
- `Windows Curl Download to Suspicious Path` - Removed `process_curl`
- `WBAdmin Delete System Backups` - Removed `process_wbadmin`
- `Windows Diskshadow Proxy Execution` - Removed `process_diskshadow`
- `Windows DotNet Binary in Non Standard Path` - Removed `is_net_windows_file_macro`
- `Verclsid CLSID Execution` - Removed `process_verclsid`
- `System Processes Run From Unexpected Locations` - Removed `system_processes_run_from_unexpected_locations_filter`
- `System Info Gathering Using Dxdiag Application` - Removed `process_dxdiag`
- `Suspicious microsoft workflow compiler usage` - Removed `process_microsoftworkflowcompiler`
- `Suspicious GPUpdate no Command Line Arguments` - Removed `process_gpupdate`

## Updated Macros

- `process_powershell` - Removed `powershell_ise.exe` from the list.