### PR TITLE
Add description and fix template names for response plans

### DIFF
--- a/.github/workflows/response_templates/mcopenapi_public.yml
+++ b/.github/workflows/response_templates/mcopenapi_public.yml
@@ -2859,7 +2859,6 @@ components:
           format: int64
           minimum: 1
           maximum: 9999999999999
-          default: 1
           example: 2
         update_time:
           type: number

--- a/.github/workflows/response_templates/mcopenapi_public.yml
+++ b/.github/workflows/response_templates/mcopenapi_public.yml
@@ -2859,12 +2859,17 @@ components:
           format: int64
           minimum: 1
           maximum: 9999999999999
+          default: 1
           example: 2
         update_time:
           type: number
           format: double
           example: 1690743671.0881049633
-      example: { "version": 2, "update_time": 1690743671.0881049633 }
+        description:
+          type: string
+          description: Description of the response template version.
+          example: "This is version 2 of the response template."
+      example: { "version": 2, "update_time": 1690743671.0881049633, "description": "This is version 2 of the response template." }
     ResponseTemplateManifest:
       type: object
       description: Response template manifest.

--- a/.github/workflows/response_templates/template_script.py
+++ b/.github/workflows/response_templates/template_script.py
@@ -39,9 +39,9 @@ def generate_manifest(directory, prefix, output_dir):
                 with open(file, 'r') as in_file:
                     content = in_file.read()
                     curr_template = json.loads(content)
-                    version = curr_template.get("version", 1)
+                    version = curr_template.get("version")
                     update_time = curr_template.get("update_time")
-                    description = curr_template.get("description", "")
+                    description = curr_template.get("description")
                     curr_template_name = curr_template.get("name", template_name)
                     curr_metadata = {
                         "version": version,

--- a/.github/workflows/response_templates/template_script.py
+++ b/.github/workflows/response_templates/template_script.py
@@ -32,21 +32,25 @@ def generate_manifest(directory, prefix, output_dir):
         template_mapping = _get_template_mapping(directory)
         for template_name, template_list in sorted(template_mapping.items(), key=lambda x: x[0]):
             out_template_name = f"{template_name}.json"
+            curr_template_name = template_name
 
             templates_version= []
             for _, file in template_list:
                 with open(file, 'r') as in_file:
                     content = in_file.read()
                     curr_template = json.loads(content)
-                    version = curr_template.get("version", "1.0")
+                    version = curr_template.get("version", 1)
                     update_time = curr_template.get("update_time")
+                    description = curr_template.get("description", "")
+                    curr_template_name = curr_template.get("name", template_name)
                     curr_metadata = {
                         "version": version,
                         "update_time": update_time,
+                        "description": description,
                     }
                     templates_version.append(curr_metadata)
             response_templates.append({
-                "name": template_name,
+                "name": curr_template_name,
                 "versions": templates_version,
                 "link": f"{prefix}{out_template_name}"
             })


### PR DESCRIPTION
### Details
1. Add description to the template manifest
2. Use the actual response template name instead of the file name, since the file name doesn't contain spaces
3. Remove any defaults that are set by the script

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [x] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/9.3.2411/manage-apps-and-add-ons-in-splunk-cloud-platform/manage-private-apps-on-your-splunk-cloud-platform-deployment#ariaid-title7) but the short version is that any changes to lookup files need to bump the the date and version in the associated YAML file.
