### PR TITLE
Add Snort/IOS Correlation and Other Things

### DIFF
--- a/data_sources/cisco_secure_firewall_threat_defense_connection_event.yml
+++ b/data_sources/cisco_secure_firewall_threat_defense_connection_event.yml
@@ -109,7 +109,7 @@ fields:
 - vendor_product
 - WebApplication
 output_fields:
-- src_ip
+- src
 - dest
 - dest_port
 - transport

--- a/data_sources/cisco_secure_firewall_threat_defense_file_event.yml
+++ b/data_sources/cisco_secure_firewall_threat_defense_file_event.yml
@@ -84,7 +84,7 @@ fields:
 - vendor_product
 - WebApplication
 output_fields:
-- src_ip
+- src
 - dest
 - dest_port
 - FileDirection

--- a/data_sources/cisco_secure_firewall_threat_defense_intrusion_event.yml
+++ b/data_sources/cisco_secure_firewall_threat_defense_intrusion_event.yml
@@ -149,7 +149,7 @@ fields:
 - transport
 - vendor_product
 output_fields:
-- src_ip
+- src
 - dest
 - dest_port
 - signature

--- a/detections/network/cisco_privileged_account_creation_with_http_command_execution.yml
+++ b/detections/network/cisco_privileged_account_creation_with_http_command_execution.yml
@@ -1,0 +1,88 @@
+name: Cisco Privileged Account Creation with HTTP Command Execution
+id: 2c9d4f5a-8b6e-4c7f-9d8e-1a2b3c4d5e6f
+version: 1
+date: '2026-01-06'
+author: Nasreddine Bencherchali, Splunk
+status: production
+type: Correlation
+description: |
+  This analytic correlates risk events between privileged account creation on Cisco IOS devices and HTTP requests to privileged execution paths such as `/level/15/exec/-/*`.
+  APT actors have been observed creating privileged accounts and then running commands on routers via HTTP GET or POST requests that target privileged execution paths.
+  These requests allow attackers to execute commands with the highest privilege level (15) on Cisco devices without requiring interactive SSH access.
+  This correlation identifies when both "Cisco IOS Suspicious Privileged Account Creation" and "Privileged Command Execution via HTTP" Snort detections fire for the same network device.
+  This behavior indicates an attacker leveraging the newly created account to execute commands remotely via HTTP.
+data_source: []
+search: |
+  | tstats `security_content_summariesonly`
+    min(_time) as firstTime
+    max(_time) as lastTime
+    sum(All_Risk.calculated_risk_score) as risk_score
+    count(All_Risk.calculated_risk_score) as risk_event_count
+
+    values(All_Risk.annotations.mitre_attack.mitre_tactic_id) as annotations.mitre_attack.mitre_tactic_id
+    dc(All_Risk.annotations.mitre_attack.mitre_tactic_id) as mitre_tactic_id_count
+
+    values(All_Risk.annotations.mitre_attack.mitre_technique_id) as annotations.mitre_attack.mitre_technique_id
+    dc(All_Risk.annotations.mitre_attack.mitre_technique_id) as mitre_technique_id_count
+
+    values(All_Risk.tag) as tag
+    values(source) as source
+    dc(source) as source_count
+
+    values(contributing_events_search)
+
+    values(All_Risk.threat_object)
+
+    from datamodel=Risk.All_Risk where
+
+    source IN (
+      "*Cisco IOS Suspicious Privileged Account Creation*",
+      "*Cisco Secure Firewall - Privileged Command Execution via HTTP*"
+    )
+    by All_Risk.normalized_risk_object
+  | `drop_dm_object_name(All_Risk)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | where source_count >= 2
+  | `cisco_privileged_account_creation_with_http_command_execution_filter`
+how_to_implement: |
+  This correlation search requires that the following detections are enabled and generating risk events - "Cisco IOS Suspicious Privileged Account Creation" and "Cisco Secure Firewall - Privileged Command Execution via HTTP". These detections must be configured to generate risk on the same risk object field (the network device IP). The search correlates risk events within a 24-hour time window. Ensure that both Cisco IOS logs (sourcetype "cisco:ios") and Cisco Secure Firewall Threat Defense Intrusion Event logs are being ingested and that the underlying detections are properly configured.
+known_false_positives: |
+  No false positives have been identified yet.
+references:
+  - https://www.cisa.gov/news-events/cybersecurity-advisories/aa25-239a
+drilldown_searches:
+  - name: View the detection results for - "$risk_object$"
+    search: '%original_detection_search% | search  risk_object = "$risk_object$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$risk_object$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$risk_object$")
+      starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+      values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+      as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+      as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+      | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+tags:
+  analytic_story:
+    - Cisco Secure Firewall Threat Defense Analytics
+    - Salt Typhoon
+  asset_type: Network
+  mitre_attack_id:
+    - T1021.004
+    - T1136
+    - T1078
+  product:
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
+  security_domain: network
+tests:
+  - name: True Positive Test
+    attack_data:
+    - data:
+        https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/emerging_threats/SaltTyphoon/salttyphoon_correlation.log
+      source: not_applicable
+      sourcetype: stash

--- a/detections/network/cisco_privileged_account_creation_with_suspicious_ssh_activity.yml
+++ b/detections/network/cisco_privileged_account_creation_with_suspicious_ssh_activity.yml
@@ -1,0 +1,99 @@
+name: Cisco Privileged Account Creation with Suspicious SSH Activity
+id: 7f8e2b4c-9a3d-4e1f-8c5b-6d7e8f9a0b1c
+version: 1
+date: '2026-01-06'
+author: Nasreddine Bencherchali, Splunk
+status: production
+type: Correlation
+description: |
+  This analytic detects a correlation between privileged account creation on Cisco IOS devices and subsequent inbound SSH connections to non-standard ports or sshd_operns by correlating risk events
+  This correlation identifies when both "Cisco IOS Suspicious Privileged Account Creation" and SSH-related Snort detections ("SSH Connection to sshd_operns" or "SSH Connection to Non-Standard Port") fire for the same network device.
+  This behavior is highly indicative of persistence establishment following initial compromise.
+data_source: []
+search: |
+  | tstats `security_content_summariesonly`
+    min(_time) as firstTime
+    max(_time) as lastTime
+
+    sum(All_Risk.calculated_risk_score) as risk_score
+    count(All_Risk.calculated_risk_score) as risk_event_count
+
+    values(All_Risk.annotations.mitre_attack.mitre_tactic_id) as annotations.mitre_attack.mitre_tactic_id
+    dc(All_Risk.annotations.mitre_attack.mitre_tactic_id) as mitre_tactic_id_count
+
+    values(All_Risk.annotations.mitre_attack.mitre_technique_id) as annotations.mitre_attack.mitre_technique_id
+    dc(All_Risk.annotations.mitre_attack.mitre_technique_id) as mitre_technique_id_count
+
+    values(All_Risk.tag) as tag
+    values(source) as source
+    dc(source) as source_count
+    
+    values(contributing_events_search)
+
+    values(All_Risk.threat_object)
+
+    from datamodel=Risk.All_Risk where
+
+    source IN (
+      "*Cisco IOS Suspicious Privileged Account Creation*",
+      "*Cisco Secure Firewall - SSH Connection to sshd_operns*",
+      "*Cisco Secure Firewall - SSH Connection to Non-Standard Port*"
+    )
+    by All_Risk.normalized_risk_object
+  | `drop_dm_object_name(All_Risk)`
+  | eval has_account_creation=if(
+                                  match(source, "Cisco IOS Suspicious Privileged Account Creation"),
+                                  1, 0
+                                )
+  | eval has_ssh_detection=if(
+                                match(source, "SSH Connection to sshd_operns")
+                                OR
+                                match(source, "SSH Connection to Non-Standard Port"),
+                                1, 0
+                              )
+  | where has_account_creation=1
+          AND
+          has_ssh_detection=1
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `cisco_privileged_account_creation_with_suspicious_ssh_activity_filter`
+how_to_implement: |
+  This correlation search requires that the following detections are enabled and generating risk events - "Cisco IOS Suspicious Privileged Account Creation", "Cisco Secure Firewall - SSH Connection to sshd_operns", and "Cisco Secure Firewall - SSH Connection to Non-Standard Port". These detections must be configured to generate risk on the same risk object field (the network device IP). The search correlates risk events within a 24-hour time window. Ensure that both Cisco IOS logs (sourcetype "cisco:ios") and Cisco Secure Firewall Threat Defense Intrusion Event logs are being ingested and that the underlying detections are properly configured.
+known_false_positives: |
+  No false positives have been identified yet.
+references:
+  - https://www.cisa.gov/news-events/cybersecurity-advisories/aa25-239a
+drilldown_searches:
+  - name: View the detection results for - "$normalized_risk_object$"
+    search: '%original_detection_search% | search  normalized_risk_object = "$normalized_risk_object$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$normalized_risk_object$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$normalized_risk_object$")
+      starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+      values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+      as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+      as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+      | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+tags:
+  analytic_story:
+    - Cisco Secure Firewall Threat Defense Analytics
+    - Salt Typhoon
+  mitre_attack_id:
+    - T1136
+    - T1078
+    - T1021.004
+  product:
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
+  security_domain: network
+tests:
+  - name: True Positive Test
+    attack_data:
+    - data:
+        https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/emerging_threats/SaltTyphoon/salttyphoon_correlation.log
+      source: not_applicable
+      sourcetype: stash

--- a/detections/network/cisco_privileged_account_creation_with_suspicious_ssh_activity.yml
+++ b/detections/network/cisco_privileged_account_creation_with_suspicious_ssh_activity.yml
@@ -81,10 +81,11 @@ tags:
   analytic_story:
     - Cisco Secure Firewall Threat Defense Analytics
     - Salt Typhoon
+  asset_type: Network
   mitre_attack_id:
+    - T1021.004
     - T1136
     - T1078
-    - T1021.004
   product:
     - Splunk Enterprise
     - Splunk Enterprise Security

--- a/detections/network/cisco_secure_firewall___binary_file_type_download.yml
+++ b/detections/network/cisco_secure_firewall___binary_file_type_download.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Binary File Type Download
 id: 24b2c2e3-2ff7-4a23-b814-87f8a62028cd
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -21,10 +21,10 @@ search: |
           values(ClientApplication) as ClientApplication
           values(file_hash) as file_hash
           values(SHA_Disposition) as SHA_Disposition
-          by FileDirection FileType src_ip dest app file_name ThreatName dest_port Description
+          by FileDirection FileType src dest app file_name ThreatName dest_port Description
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
-  | table firstTime lastTime src_ip dest dest_port FileDirection FileType Description uri file_name file_hash app ClientApplication SHA_Disposition ThreatName
+  | table firstTime lastTime src dest dest_port FileDirection FileType Description uri file_name file_hash app ClientApplication SHA_Disposition ThreatName
   | `cisco_secure_firewall___binary_file_type_download_filter`
 how_to_implement: |
   This search requires Cisco Secure Firewall Threat Defense Logs, which
@@ -39,12 +39,12 @@ known_false_positives: IT admins or developers may legitimately download executa
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -52,9 +52,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: The host $src_ip$ downloaded a file $file_name$ of type $FileType$ from $dest$.
+  message: The host $src$ downloaded a file $file_name$ of type $FileType$ from $dest$.
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 30
   threat_objects:

--- a/detections/network/cisco_secure_firewall___bits_network_activity.yml
+++ b/detections/network/cisco_secure_firewall___bits_network_activity.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Bits Network Activity
 id: b08e69d4-b42d-494c-bd30-abaaa3571ba4
-version: 3
-date: '2025-07-10'
+version: 4
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -10,7 +10,7 @@ data_source:
 - Cisco Secure Firewall Threat Defense Connection Event
 search: |
   `cisco_secure_firewall` EventType=ConnectionEvent action IN ("Trust", "Allow", "allowed") ClientApplication="BITS" AND NOT url IN ("*://msedge.b.tlu.dl*")
-  | stats count min(_time) as firstTime max(_time) as lastTime by src_ip, dest, dest_port, transport, rule, url, EVE_Process, ClientApplication, ClientApplicationVersion, action
+  | stats count min(_time) as firstTime max(_time) as lastTime by src, dest, dest_port, transport, rule, url, EVE_Process, ClientApplication, ClientApplicationVersion, action
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 
   | `cisco_secure_firewall___bits_network_activity_filter`
@@ -30,12 +30,12 @@ known_false_positives: |
 references:
 - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -43,9 +43,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: $src_ip$ downloaded a file from $url$ via BITS Service
+  message: $src$ downloaded a file from $url$ via BITS Service
   risk_objects:
-  - field: src_ip
+  - field: src
     type: system
     score: 25
   - field: dest

--- a/detections/network/cisco_secure_firewall___blacklisted_ssl_certificate_fingerprint.yml
+++ b/detections/network/cisco_secure_firewall___blacklisted_ssl_certificate_fingerprint.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Blacklisted SSL Certificate Fingerprint
 id: c43f7b49-2dab-4e76-892e-7f971c2f20f1
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: TTP
@@ -20,7 +20,7 @@ search: |
           values(url) as url
           values(Listingreason) as Reasons
           values(Listingdate) as "SSL Cert Listing Dates"
-          count by SSL_CertFingerprint src_ip transport action
+          count by SSL_CertFingerprint src transport action
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___blacklisted_ssl_certificate_fingerprint_filter`
@@ -38,12 +38,12 @@ known_false_positives: Certain SSL certificates may be flagged in threat intelli
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -51,9 +51,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Suspicious SSL certificate fingerprint - [$SSL_CertFingerprint$] used in connections [ListingReason - $Reasons$] from $src_ip$
+  message: Suspicious SSL certificate fingerprint - [$SSL_CertFingerprint$] used in connections [ListingReason - $Reasons$] from $src$
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 20
   threat_objects:

--- a/detections/network/cisco_secure_firewall___blocked_connection.yml
+++ b/detections/network/cisco_secure_firewall___blocked_connection.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Blocked Connection
 id: 17e9b764-3a2b-4d36-9751-32d13ce4718b
-version: 3
-date: '2025-07-10'
+version: 4
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -11,7 +11,7 @@ data_source:
 - Cisco Secure Firewall Threat Defense Connection Event
 search: |
   `cisco_secure_firewall` EventType=ConnectionEvent action IN ("Block with reset", "Block", "blocked")
-  | stats count min(_time) as firstTime max(_time) as lastTime by src_ip, dest, dest_port, transport, rule, url, EVE_Process, action
+  | stats count min(_time) as firstTime max(_time) as lastTime by src, dest, dest_port, transport, rule, url, EVE_Process, action
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 
   | `cisco_secure_firewall___blocked_connection_filter`
@@ -28,12 +28,12 @@ known_false_positives: Blocked connection events are generated via an Access Con
 references:
 - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -41,9 +41,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: A connection request from $src_ip$ to $dest$ has been blocked according to the configured firewall rule $rule$
+  message: A connection request from $src$ to $dest$ has been blocked according to the configured firewall rule $rule$
   risk_objects:
-  - field: src_ip
+  - field: src
     type: system
     score: 25
   threat_objects:

--- a/detections/network/cisco_secure_firewall___citrix_netscaler_memory_overread_attempt.yml
+++ b/detections/network/cisco_secure_firewall___citrix_netscaler_memory_overread_attempt.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Citrix NetScaler Memory Overread Attempt
 id: 93db24a0-fd21-45d7-9daf-84afd5a8cca2
-version: 1
-date: '2025-07-17'
+version: 2
+date: '2026-06-01'
 author: Michael Haag, Nasreddine Bencherchali, Splunk, Talos NTDR
 status: production
 type: TTP
@@ -24,12 +24,12 @@ search: |
           values(MitreAttackGroups) as MitreAttackGroups
           values(InlineResult) as InlineResult
           values(InlineResultReason) as InlineResultReason
-          values(src_ip) as src_ip
+          values(src) as src
           values(dest_port) as dest_port
           values(rule) as rule
           values(transport) as transport
           values(app) as app
-          by dest_ip
+          by dest
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___citrix_netscaler_memory_overread_attempt_filter`
@@ -54,22 +54,22 @@ references:
   - https://labs.watchtowr.com/how-much-more-must-we-bleed-citrix-netscaler-memory-disclosure-citrixbleed-2-cve-2025-5777/
   - https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2025/CVE-2025-5777.yaml
 drilldown_searches:
-  - name: View the detection results for - "$src_ip$" and "$dest_ip$"
-    search: '%original_detection_search% | search src_ip="$src_ip$" dest_ip="$dest_ip$"'
+  - name: View the detection results for - "$src$" and "$dest$"
+    search: '%original_detection_search% | search src="$src$" dest="$dest$"'
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
-  - name: View risk events for the last 7 days for - "$src_ip$" and "$dest_ip$"
-    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$", "$dest_ip$") starthoursago=168 | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  - name: View risk events for the last 7 days for - "$src$" and "$dest$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$", "$dest$") starthoursago=168 | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
 rba:
-  message: Potential exploitation of CVE-2025-5777 from $src_ip$
+  message: Potential exploitation of CVE-2025-5777 from $src$
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 85
   threat_objects:
-    - field: src_ip
+    - field: src
       type: system
 tags:
   analytic_story:

--- a/detections/network/cisco_secure_firewall___communication_over_suspicious_ports.yml
+++ b/detections/network/cisco_secure_firewall___communication_over_suspicious_ports.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Communication Over Suspicious Ports
 id: d85c05c8-42c0-4e4a-87e7-4e1bb3e844e3
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -15,7 +15,7 @@ search: |
         values(src_port) as src_port
         values(url) as url
         values(rule) as rule
-        count by src_ip, dest, dest_port, transport, action
+        count by src, dest, dest_port, transport, action
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___communication_over_suspicious_ports_filter`
@@ -36,12 +36,12 @@ known_false_positives: |
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -49,9 +49,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Suspicious communication detected from $src_ip$ to $dest$ over port $dest_port$.
+  message: Suspicious communication detected from $src$ to $dest$ over port $dest_port$.
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 20
   threat_objects:

--- a/detections/network/cisco_secure_firewall___connection_to_file_sharing_domain.yml
+++ b/detections/network/cisco_secure_firewall___connection_to_file_sharing_domain.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Connection to File Sharing Domain
 id: f7e5e792-d907-46c1-a58e-4ff974dc462a
-version: 4
-date: '2025-10-14'
+version: 5
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -18,7 +18,7 @@ search: |
     Values(rule) as rule
     Values(url) as url
     Values(EVE_Process) as EVE_Process
-    by src_ip, transport, action
+    by src, transport, action
   | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 
   | `cisco_secure_firewall___connection_to_file_sharing_domain_filter`
@@ -38,12 +38,12 @@ known_false_positives: |
 references:
 - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -51,9 +51,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: The host $src_ip$ initiated a connection to the file sharing or pastebin domain $url$.
+  message: The host $src$ initiated a connection to the file sharing or pastebin domain $url$.
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 30
   threat_objects:

--- a/detections/network/cisco_secure_firewall___file_download_over_uncommon_port.yml
+++ b/detections/network/cisco_secure_firewall___file_download_over_uncommon_port.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - File Download Over Uncommon Port
 id: f26445a8-a6a2-4855-bec0-0c39e52e5b8f
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -18,10 +18,10 @@ search: |
           values(ClientApplication) as ClientApplication
           values(file_hash) as file_hash 
           values(SHA_Disposition) as SHA_Disposition 
-          by FileDirection FileType app ThreatName dest_port Description src_ip dest
+          by FileDirection FileType app ThreatName dest_port Description src dest
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
-  | table firstTime lastTime src_ip dest dest_port FileDirection FileType Description uri ClientApplication file_name file_hash SHA_Disposition ThreatName
+  | table firstTime lastTime src dest dest_port FileDirection FileType Description uri ClientApplication file_name file_hash SHA_Disposition ThreatName
   | `cisco_secure_firewall___file_download_over_uncommon_port_filter`
 how_to_implement: |
   This search requires Cisco Secure Firewall Threat Defense Logs, which
@@ -36,12 +36,12 @@ known_false_positives: Some legitimate applications may download files over cust
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -49,9 +49,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: The host $src_ip$ downloaded a file $file_name$ of type $FileType$ from $dest$ over the uncommon port $dest_port$
+  message: The host $src$ downloaded a file $file_name$ of type $FileType$ from $dest$ over the uncommon port $dest_port$
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 30
   threat_objects:

--- a/detections/network/cisco_secure_firewall___high_eve_threat_confidence.yml
+++ b/detections/network/cisco_secure_firewall___high_eve_threat_confidence.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - High EVE Threat Confidence
 id: 8c15183e-2e70-4db4-86c3-88f8d9129b66
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -14,7 +14,7 @@ search: |
   | stats count min(_time) as firstTime max(_time) as lastTime
       Values(rule) as rule
       Values(url) as url
-      by EVE_Process, EVE_ThreatConfidencePct, src_ip, dest, dest_port, transport, action
+      by EVE_Process, EVE_ThreatConfidencePct, src, dest, dest_port, transport, action
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___high_eve_threat_confidence_filter`
@@ -34,12 +34,12 @@ known_false_positives: |
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -47,9 +47,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: High threat confidence ($EVE_ThreatConfidencePct$%) from $EVE_Process$ on $src_ip$"
+  message: High threat confidence ($EVE_ThreatConfidencePct$%) from $EVE_Process$ on $src$"
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 20
   threat_objects:

--- a/detections/network/cisco_secure_firewall___high_priority_intrusion_classification.yml
+++ b/detections/network/cisco_secure_firewall___high_priority_intrusion_classification.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - High Priority Intrusion Classification
 id: ec99bb81-c31b-4837-8c7d-1b32aa70b337
-version: 1
-date: '2025-04-28'
+version: 2
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: TTP
@@ -34,7 +34,7 @@ search: |
           values(rule) as rule 
           values(transport) as transport 
           values(app) as app
-          by src_ip, dest_ip, signature, class_desc
+          by src, dest, signature, class_desc
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___high_priority_intrusion_classification_filter`
@@ -51,12 +51,12 @@ known_false_positives: Some intrusion events that are linked to these classifica
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$dest_ip$" and "$src_ip$"
-  search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'
+- name: View the detection results for - "$dest$" and "$src$"
+  search: '%original_detection_search% | search  dest = "$dest$" and src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -64,15 +64,15 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: A high priority intrusion event with classification ($class_desc$) was detected from $src_ip$ to $dest_ip$, indicating potential suspicious activity.
+  message: A high priority intrusion event with classification ($class_desc$) was detected from $src$ to $dest$, indicating potential suspicious activity.
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 25
   threat_objects:
     - field: signature
       type: signature
-    - field: src_ip
+    - field: src
       type: ip_address
 tags:
   analytic_story: 

--- a/detections/network/cisco_secure_firewall___high_volume_of_intrusion_events_per_host.yml
+++ b/detections/network/cisco_secure_firewall___high_volume_of_intrusion_events_per_host.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - High Volume of Intrusion Events Per Host
 id: 9f2295a0-0dcb-4a5f-b013-8a6f2a3c11f6
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -17,7 +17,7 @@ search: |
           values(dest) as dest
           values(dest_port) as dest_port
           min(_time) as firstTime max(_time) as lastTime 
-          by src_ip class_desc MitreAttackGroups InlineResult InlineResultReason rule transport app
+          by src class_desc MitreAttackGroups InlineResult InlineResultReason rule transport app
   | where TotalEvents >= 15
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
@@ -36,12 +36,12 @@ known_false_positives: |
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -49,9 +49,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: A high number [$TotalEvents$] of Snort intrusion detections for [$signature$] were triggered by [$src_ip$] in a 30-minute time window.
+  message: A high number [$TotalEvents$] of Snort intrusion detections for [$signature$] were triggered by [$src$] in a 30-minute time window.
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 40
   threat_objects:

--- a/detections/network/cisco_secure_firewall___intrusion_events_by_threat_activity.yml
+++ b/detections/network/cisco_secure_firewall___intrusion_events_by_threat_activity.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Intrusion Events by Threat Activity
 id: b71e57e8-c571-4ff1-ae13-bc4384a9e891
-version: 5
-date: '2025-12-08'
+version: 6
+date: '2026-06-01'
 author: Bhavin Patel, Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -38,13 +38,13 @@ data_source:
   - Cisco Secure Firewall Threat Defense Intrusion Event
 search: |
   `cisco_secure_firewall` EventType=IntrusionEvent
-  | stats count AS total_alerts, dc(signature_id) AS sig_count, values(SnortRuleGroups) AS snort_rule_groups, values(connection_id) AS connection_id, values(rule) AS rule, values(dest_port) AS dest_port, values(transport) AS transport, values(app) AS app, values(signature) AS signature, values(src_ip) AS src_ip BY _time dest_ip signature_id
+  | stats count AS total_alerts, dc(signature_id) AS sig_count, values(SnortRuleGroups) AS snort_rule_groups, values(connection_id) AS connection_id, values(rule) AS rule, values(dest_port) AS dest_port, values(transport) AS transport, values(app) AS app, values(signature) AS signature, values(src) AS src BY _time dest signature_id
   | lookup cisco_snort_ids_to_threat_mapping signature_id OUTPUT threat, category, message
   | where isnotnull(threat)
   | bin _time span=1d
-  | stats count AS Total_Alerts, dc(signature_id) AS sig_count, values(signature_id) AS signature_id, values(category) AS category, values(message) AS message, values(snort_rule_groups) AS snort_rule_groups, values(connection_id) AS connection_id, values(rule) AS rule, values(dest_port) AS dest_port, values(transport) AS transport, values(app) AS app, values(signature) AS signature, values(src_ip) AS src_ip BY _time dest_ip threat
+  | stats count AS Total_Alerts, dc(signature_id) AS sig_count, values(signature_id) AS signature_id, values(category) AS category, values(message) AS message, values(snort_rule_groups) AS snort_rule_groups, values(connection_id) AS connection_id, values(rule) AS rule, values(dest_port) AS dest_port, values(transport) AS transport, values(app) AS app, values(signature) AS signature, values(src) AS src BY _time dest threat
   | lookup threat_snort_count threat OUTPUT description, distinct_count_snort_ids
-  | table _time, dest_ip, src_ip, threat, category, message, description, signature_id, signature, snort_rule_groups, sig_count, distinct_count_snort_ids, connection_id, rule, dest_port, transport, app
+  | table _time, dest, src, threat, category, message, description, signature_id, signature, snort_rule_groups, sig_count, distinct_count_snort_ids, connection_id, rule, dest_port, transport, app
   | where sig_count >= distinct_count_snort_ids
   | `cisco_secure_firewall___intrusion_events_by_threat_activity_filter`
 how_to_implement: |
@@ -61,12 +61,12 @@ references:
   - https://www.cisco.com/c/en/us/products/security/firewalls/index.html
   - https://blog.talosintelligence.com/static-tundra/
 drilldown_searches:
-- name: View the detection results for - "$dest_ip$"
-  search: '%original_detection_search% | search  dest_ip = "$dest_ip$"'
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest_ip$""
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$dest$""
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -74,9 +74,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Potential $threat$ activity detected on $dest_ip$ originating from $src_ip$.
+  message: Potential $threat$ activity detected on $dest$ originating from $src$.
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 50
   threat_objects:

--- a/detections/network/cisco_secure_firewall___lumma_stealer_activity.yml
+++ b/detections/network/cisco_secure_firewall___lumma_stealer_activity.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Lumma Stealer Activity
 id: 96bce783-c22e-4e48-8cf1-3eb2794c5083
-version: 1
-date: '2025-04-28'
+version: 2
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk, Talos NTDR
 status: production
 type: TTP
@@ -22,14 +22,14 @@ search: |
           values(MitreAttackGroups) as MitreAttackGroups 
           values(InlineResult) as InlineResult 
           values(InlineResultReason) as InlineResultReason 
-          values(dest_ip) as dest_ip 
+          values(dest) as dest 
           values(dest_port) as dest_port 
           values(rule) as rule 
           values(transport) as transport 
           values(app) as app 
           min(_time) as firstTime 
           max(_time) as lastTime 
-          by src_ip
+          by src
   | where unique_signature_count >= 3
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
@@ -47,12 +47,12 @@ known_false_positives: False positives should be very unlikely.
 references:
   - https://malpedia.caad.fkie.fraunhofer.de/details/win.lumma
 drilldown_searches:
-- name: View the detection results for - "$dest_ip$" and "$src_ip$"
-  search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'
+- name: View the detection results for - "$dest$" and "$src$"
+  search: '%original_detection_search% | search  dest = "$dest$" and src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -60,15 +60,15 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Lumma Stealer Activity on host $dest_ip$ origniating from $src_ip$
+  message: Lumma Stealer Activity on host $dest$ origniating from $src$
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 25
   threat_objects:
     - field: signature
       type: signature
-    - field: src_ip
+    - field: src
       type: ip_address
 tags:
   analytic_story: 

--- a/detections/network/cisco_secure_firewall___lumma_stealer_download_attempt.yml
+++ b/detections/network/cisco_secure_firewall___lumma_stealer_download_attempt.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Lumma Stealer Download Attempt
 id: 66f22f52-fbae-4be7-a263-561dacb63613
-version: 1
-date: '2025-04-26'
+version: 2
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk, Talos NTDR
 status: production
 type: Anomaly
@@ -14,7 +14,7 @@ search: |
   `cisco_secure_firewall` EventType=IntrusionEvent signature_id IN (62710, 62711, 62712, 62713, 62714, 62715, 62716, 62717, 64810, 64811)
   | fillnull
   | stats min(_time) as firstTime max(_time) as lastTime 
-          by src_ip dest_ip dest_port transport signature_id signature class_desc MitreAttackGroups rule InlineResult InlineResultReason app
+          by src dest dest_port transport signature_id signature class_desc MitreAttackGroups rule InlineResult InlineResultReason app
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___lumma_stealer_download_attempt_filter`
@@ -31,12 +31,12 @@ known_false_positives: False positives should be unlikely.
 references:
   - https://malpedia.caad.fkie.fraunhofer.de/details/win.lumma
 drilldown_searches:
-- name: View the detection results for - "$dest_ip$" and "$src_ip$"
-  search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'
+- name: View the detection results for - "$dest$" and "$src$"
+  search: '%original_detection_search% | search  dest = "$dest$" and src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -44,15 +44,15 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Lumma Stealer Download Attempt detected on host $dest_ip$ origniating from $src_ip$
+  message: Lumma Stealer Download Attempt detected on host $dest$ origniating from $src$
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 25
   threat_objects:
     - field: signature
       type: signature
-    - field: src_ip
+    - field: src
       type: ip_address
 tags:
   analytic_story: 

--- a/detections/network/cisco_secure_firewall___lumma_stealer_outbound_connection_attempt.yml
+++ b/detections/network/cisco_secure_firewall___lumma_stealer_outbound_connection_attempt.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Lumma Stealer Outbound Connection Attempt
 id: 66f22f52-fbae-4be7-a263-561dacb63612
-version: 1
-date: '2025-04-26'
+version: 2
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk, Talos NTDR
 status: production
 type: Anomaly
@@ -14,7 +14,7 @@ search: |
   `cisco_secure_firewall` EventType=IntrusionEvent signature_id IN (64797, 64798, 64799, 64800, 64801, 64167, 64168, 64169, 62709)
   | fillnull
   | stats min(_time) as firstTime max(_time) as lastTime 
-          by src_ip dest_ip dest_port transport signature_id signature class_desc MitreAttackGroups rule InlineResult InlineResultReason app
+          by src dest dest_port transport signature_id signature class_desc MitreAttackGroups rule InlineResult InlineResultReason app
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___lumma_stealer_outbound_connection_attempt_filter`
@@ -31,12 +31,12 @@ known_false_positives: False positives should be unlikely.
 references:
   - https://malpedia.caad.fkie.fraunhofer.de/details/win.lumma
 drilldown_searches:
-- name: View the detection results for - "$dest_ip$" and "$src_ip$"
-  search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'
+- name: View the detection results for - "$dest$" and "$src$"
+  search: '%original_detection_search% | search  dest = "$dest$" and src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -44,15 +44,15 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Lumma Stealer Outbound Connection Attempt detected on host $dest_ip$ origniating from $src_ip$
+  message: Lumma Stealer Outbound Connection Attempt detected on host $dest$ origniating from $src$
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 25
   threat_objects:
     - field: signature
       type: signature
-    - field: src_ip
+    - field: src
       type: ip_address
 tags:
   analytic_story: 

--- a/detections/network/cisco_secure_firewall___malware_file_downloaded.yml
+++ b/detections/network/cisco_secure_firewall___malware_file_downloaded.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Malware File Downloaded
 id: 3cc93f52-5aa6-4b7f-83b9-3430b1436813
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -16,10 +16,10 @@ search: |
           values(uri) as uri
           values(ClientApplication) as ClientApplication
           values(file_hash) as file_hash
-          by FileDirection dest src_ip dest_port FileType app file_name ThreatName Description
+          by FileDirection dest src dest_port FileType app file_name ThreatName Description
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
-  | table firstTime lastTime src_ip dest dest_port FileDirection FileType Description uri file_name file_hash app ClientApplication ThreatName SHA_Disposition
+  | table firstTime lastTime src dest dest_port FileDirection FileType Description uri file_name file_hash app ClientApplication ThreatName SHA_Disposition
   | `cisco_secure_firewall___malware_file_downloaded_filter`
 how_to_implement: |
   This search requires Cisco Secure Firewall Threat Defense Logs, which
@@ -34,12 +34,12 @@ known_false_positives: Malicious verdicts could be outdated or incorrect due to 
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -47,9 +47,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: File with Malware disposition downloaded from $dest$ over port $dest_port$ by $src_ip$
+  message: File with Malware disposition downloaded from $dest$ over port $dest_port$ by $src$
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 30
   threat_objects:

--- a/detections/network/cisco_secure_firewall___oracle_e_business_suite_correlation.yml
+++ b/detections/network/cisco_secure_firewall___oracle_e_business_suite_correlation.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Oracle E-Business Suite Correlation
 id: 9e995d21-6870-43de-acd9-76f372bcf323
-version: 1
-date: '2025-10-23'
+version: 2
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk, Talos NTDR
 status: production
 type: TTP
@@ -32,7 +32,7 @@ search: |
           sum(eval(signature_id==65454)) as sig_template_preview
           sum(eval(signature_id==65455)) as sig_sync_servlet
           sum(eval(signature_id IN (65377,65378,65413,65414,65415,65456))) as sig_exploit_activity
-    by src_ip dest_ip
+    by src dest
   | where (
             (
               sig_exploit_activity >= 1 
@@ -71,12 +71,12 @@ references:
   - https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
   - https://cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
 drilldown_searches:
-- name: View the detection results for - "$dest_ip$" and "$src_ip$"
-  search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'
+- name: View the detection results for - "$dest$" and "$src$"
+  search: '%original_detection_search% | search  dest = "$dest$" and src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -84,15 +84,15 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Multiple Oracle E-Business Suite exploitation signatures $signature_id$ detected from source IP $src_ip$ to destination IP $dest_ip$
+  message: Multiple Oracle E-Business Suite exploitation signatures $signature_id$ detected from source IP $src$ to destination IP $dest$
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 25
   threat_objects:
     - field: signature
       type: signature
-    - field: src_ip
+    - field: src
       type: ip_address
 tags:
   analytic_story: 

--- a/detections/network/cisco_secure_firewall___oracle_e_business_suite_exploitation.yml
+++ b/detections/network/cisco_secure_firewall___oracle_e_business_suite_exploitation.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Oracle E-Business Suite Exploitation
 id: 1c077b8a-95a3-4692-980d-c72fc50e9930
-version: 1
-date: '2025-04-26'
+version: 2
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk, Talos NTDR
 status: production
 type: TTP
@@ -30,7 +30,7 @@ search: |
           values(app) as app 
           min(_time) as firstTime 
           max(_time) as lastTime 
-    by src_ip dest_ip
+    by src dest
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___oracle_e_business_suite_exploitation_filter`
@@ -50,12 +50,12 @@ references:
   - https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/
   - https://cloud.google.com/blog/topics/threat-intelligence/oracle-ebusiness-suite-zero-day-exploitation
 drilldown_searches:
-- name: View the detection results for - "$dest_ip$" and "$src_ip$"
-  search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'
+- name: View the detection results for - "$dest$" and "$src$"
+  search: '%original_detection_search% | search  dest = "$dest$" and src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -63,15 +63,15 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Network activity associated with Oracle E-Business Suite exploitation detected from source IP $src_ip$ to destination IP $dest_ip$.
+  message: Network activity associated with Oracle E-Business Suite exploitation detected from source IP $src$ to destination IP $dest$.
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 25
   threat_objects:
     - field: signature
       type: signature
-    - field: src_ip
+    - field: src
       type: ip_address
 tags:
   analytic_story:

--- a/detections/network/cisco_secure_firewall___possibly_compromised_host.yml
+++ b/detections/network/cisco_secure_firewall___possibly_compromised_host.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Possibly Compromised Host
 id: 244a77bb-3b2a-46f1-bf2c-b4f7cd29276d
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: experimental
 type: Anomaly
@@ -16,7 +16,7 @@ search: |
           values(signature) as signature 
           values(rule) as rule 
           min(_time) as firstTime max(_time) as lastTime 
-          by src_ip dest dest_port transport Impact app impact_desc class_desc MitreAttackGroups InlineResult InlineResultReason
+          by src dest dest_port transport Impact app impact_desc class_desc MitreAttackGroups InlineResult InlineResultReason
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___possibly_compromised_host_filter`
@@ -33,12 +33,12 @@ known_false_positives: False positives are directly related to their snort rules
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -46,9 +46,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: A high impact IntrusionEvent was detected from $src_ip$ to $dest$.
+  message: A high impact IntrusionEvent was detected from $src$ to $dest$.
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 35
   threat_objects:

--- a/detections/network/cisco_secure_firewall___potential_data_exfiltration.yml
+++ b/detections/network/cisco_secure_firewall___potential_data_exfiltration.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Potential Data Exfiltration
 id: 3d8536b6-52b4-4c3e-b695-3f2e90bb22be
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -19,7 +19,7 @@ search: |
       Values(url) as url
       Values(rule) as rule
       Values(dest_port) as dest_port
-      by src_ip, dest, Exfiltrated, transport, action
+      by src, dest, Exfiltrated, transport, action
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___potential_data_exfiltration_filter`
@@ -39,12 +39,12 @@ known_false_positives: |
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -52,9 +52,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Potential data exfiltration from $src_ip$ to $dest$ with $Exfiltrated$ MB of data exfiltrated"
+  message: Potential data exfiltration from $src$ to $dest$ with $Exfiltrated$ MB of data exfiltrated"
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 40
   threat_objects:

--- a/detections/network/cisco_secure_firewall___privileged_command_execution_via_http.yml
+++ b/detections/network/cisco_secure_firewall___privileged_command_execution_via_http.yml
@@ -32,7 +32,7 @@ search: |
           by dest
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
-  | `cisco_secure_firewall_privileged_command_execution_via_http_filter`
+  | `cisco_secure_firewall___privileged_command_execution_via_http_filter`
 how_to_implement: |
   This search requires Cisco Secure Firewall Threat Defense Logs, which
   includes the FileEvent EventType. This search uses an input macro named `cisco_secure_firewall`.

--- a/detections/network/cisco_secure_firewall___privileged_command_execution_via_http.yml
+++ b/detections/network/cisco_secure_firewall___privileged_command_execution_via_http.yml
@@ -1,0 +1,90 @@
+name: Cisco Secure Firewall - Privileged Command Execution via HTTP
+id: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
+version: 1
+date: '2026-01-06'
+author: Nasreddine Bencherchali, Michael Haag, Splunk
+status: production
+type: Anomaly
+description: |
+  This analytic detects HTTP requests to privileged execution paths on Cisco routers, specifically targeting the `/level/15/exec/-/*` endpoint using Cisco Secure Firewall Intrusion Events.
+  This detection leverages Snort signature 65370 to identify requests to these sensitive endpoints, which when combined with other indicators may signal active exploitation or post-compromise activity.
+data_source:
+  - Cisco Secure Firewall Threat Defense Intrusion Event
+search: |
+  `cisco_secure_firewall` 
+  EventType=IntrusionEvent 
+  signature_id=65370
+  | fillnull
+  | stats dc(signature_id) as unique_signature_count 
+          values(signature_id) as signature_id 
+          values(signature) as signature 
+          values(class_desc) as class_desc 
+          values(MitreAttackGroups) as MitreAttackGroups 
+          values(InlineResult) as InlineResult 
+          values(InlineResultReason) as InlineResultReason 
+          values(src) as src 
+          values(dest_port) as dest_port 
+          values(rule) as rule 
+          values(transport) as transport 
+          values(app) as app 
+          min(_time) as firstTime 
+          max(_time) as lastTime 
+          by dest
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `cisco_secure_firewall_privileged_command_execution_via_http_filter`
+how_to_implement: |
+  This search requires Cisco Secure Firewall Threat Defense Logs, which
+  includes the FileEvent EventType. This search uses an input macro named `cisco_secure_firewall`.
+  We strongly recommend that you specify your environment-specific configurations
+  (index, source, sourcetype, etc.) for Cisco Secure Firewall Threat Defense logs. Replace the macro definition
+  with configurations for your Splunk environment. The search also uses a post-filter
+  macro designed to filter out known false positives.
+  The logs are to be ingested using the Splunk Add-on for Cisco Security Cloud (https://splunkbase.splunk.com/app/7404).
+  The malware & file access policy must also enable logging.
+known_false_positives: |
+  No false positives have been identified yet.
+references:
+  - https://www.cisa.gov/news-events/cybersecurity-advisories/aa25-239a
+drilldown_searches:
+  - name: View the detection results for - "$src$"
+    search: '%original_detection_search% | search  src = "$src$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$src$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$")
+      starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+      values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+      as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+      as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+      | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+rba:
+  message: HTTP request to privileged execution path detected from $src$ to Cisco router $dest$
+  risk_objects:
+    - field: dest
+      type: system
+      score: 80
+  threat_objects:
+    - field: src
+      type: ip_address
+tags:
+  analytic_story:
+    - Cisco Secure Firewall Threat Defense Analytics
+    - Salt Typhoon
+  asset_type: Network
+  mitre_attack_id:
+    - T1059
+    - T1505.003
+  product:
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
+  security_domain: network
+tests:
+  - name: True Positive Test
+    attack_data:
+      - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/intrusion_event/intrusion_events.log
+        source: not_applicable
+        sourcetype: cisco:sfw:estreamer

--- a/detections/network/cisco_secure_firewall___rare_snort_rule_triggered.yml
+++ b/detections/network/cisco_secure_firewall___rare_snort_rule_triggered.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Rare Snort Rule Triggered
 id: e20313d2-7d63-4fcf-b2d9-d6e12c6c7bd7
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Hunting
@@ -13,7 +13,7 @@ search: |
   `cisco_secure_firewall` EventType=IntrusionEvent earliest=-7d
   | stats dc(_time) as TriggerCount min(_time) as firstTime max(_time) as lastTime 
           values(signature) as signature 
-          values(src_ip) as src_ip 
+          values(src) as src 
           values(dest) as dest 
           values(dest_port) as dest_port
           values(transport) as transport

--- a/detections/network/cisco_secure_firewall___react_server_components_rce_attempt.yml
+++ b/detections/network/cisco_secure_firewall___react_server_components_rce_attempt.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - React Server Components RCE Attempt
 id: d36459b1-7901-401a-a67e-44426c15b168
-version: 1
-date: '2025-12-08'
+version: 2
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk, Talos NTDR
 status: production
 type: TTP
@@ -24,12 +24,12 @@ search: |
           values(MitreAttackGroups) as MitreAttackGroups
           values(InlineResult) as InlineResult
           values(InlineResultReason) as InlineResultReason
-          values(src_ip) as src_ip
+          values(src) as src
           values(dest_port) as dest_port
           values(rule) as rule
           values(transport) as transport
           values(app) as app
-          by dest_ip
+          by dest
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `cisco_secure_firewall___react_server_components_rce_attempt_filter`
@@ -52,22 +52,22 @@ references:
   - https://gist.github.com/maple3142/48bc9393f45e068cf8c90ab865c0f5f3
   - https://www.wiz.io/blog/critical-vulnerability-in-react-cve-2025-55182
 drilldown_searches:
-  - name: View the detection results for - "$src_ip$" and "$dest_ip$"
-    search: '%original_detection_search% | search src_ip="$src_ip$" dest_ip="$dest_ip$"'
+  - name: View the detection results for - "$src$" and "$dest$"
+    search: '%original_detection_search% | search src="$src$" dest="$dest$"'
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
-  - name: View risk events for the last 7 days for - "$src_ip$" and "$dest_ip$"
-    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$", "$dest_ip$") starthoursago=168 | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+  - name: View risk events for the last 7 days for - "$src$" and "$dest$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$", "$dest$") starthoursago=168 | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
     earliest_offset: $info_min_time$
     latest_offset: $info_max_time$
 rba:
-  message: Potential exploitation of CVE-2025-65554 from $src_ip$
+  message: Potential exploitation of CVE-2025-65554 from $src$
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 85
   threat_objects:
-    - field: src_ip
+    - field: src
       type: system
 tags:
   analytic_story:

--- a/detections/network/cisco_secure_firewall___remote_access_software_usage_traffic.yml
+++ b/detections/network/cisco_secure_firewall___remote_access_software_usage_traffic.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Remote Access Software Usage Traffic
 id: ac54d39e-a75d-4f42-971d-006db3a0423a
-version: 3
-date: '2025-10-14'
+version: 4
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -22,7 +22,7 @@ search: |
         values(transport) as transport
         values(url) as url
         values(rule) as rule
-        count by src_ip ClientApplication action
+        count by src ClientApplication action
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | lookup cisco_secure_firewall_appid_remote_mgmt_and_desktop_tools appName AS ClientApplication OUTPUT category, appDescription as Description
@@ -47,12 +47,12 @@ references:
 - https://thedfirreport.com/2022/08/08/bumblebee-roasts-its-way-to-domain-admin/
 - https://thedfirreport.com/2022/11/28/emotet-strikes-again-lnk-file-leads-to-domain-wide-ransomware/
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$")
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$")
     starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
     values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
     as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
@@ -62,9 +62,9 @@ drilldown_searches:
   latest_offset: $info_max_time$
 rba:
   message: Traffic to known remote access software [$ClientApplication$] was 
-    detected from $src_ip$.
+    detected from $src$.
   risk_objects:
-  - field: src_ip
+  - field: src
     type: system
     score: 25
   threat_objects:

--- a/detections/network/cisco_secure_firewall___repeated_blocked_connections.yml
+++ b/detections/network/cisco_secure_firewall___repeated_blocked_connections.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Repeated Blocked Connections
 id: 1f57f10e-1dc5-47ea-852c-2e85b2503d79
-version: 3
-date: '2025-07-10'
+version: 4
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -15,7 +15,7 @@ search: |
   | stats count min(_time) as firstTime max(_time) as lastTime
       Values(dest_port) as dest_port
       Values(url) as url
-      by src_ip, dest, transport, rule, action
+      by src, dest, transport, rule, action
   | where count >= 10
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
@@ -36,12 +36,12 @@ known_false_positives: |
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -49,9 +49,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Repeated blocked connections detected from $src_ip$ to $dest$ according to the configured firewall rule $rule$
+  message: Repeated blocked connections detected from $src$ to $dest$ according to the configured firewall rule $rule$
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 25
   threat_objects:

--- a/detections/network/cisco_secure_firewall___repeated_malware_downloads.yml
+++ b/detections/network/cisco_secure_firewall___repeated_malware_downloads.yml
@@ -1,12 +1,12 @@
 name: Cisco Secure Firewall - Repeated Malware Downloads
 id: aeff2bb5-3483-48d4-9be8-c8976194be1e
-version: 4
-date: '2025-10-14'
+version: 5
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
 description: |
-  The following analytic detects repeated malware file downloads initiated by the same internal host (src_ip) within a short time window. It leverages Cisco Secure Firewall Threat Defense logs and identifies `FileEvent` events with a `SHA_Disposition` of "Malware" and `FileDirection` set to "Download". If ten or more such events occur from the same host within five minutes, this analytic will trigger. This activity may indicate the host is compromised and repeatedly retrieving malicious content either due to command-and-control, malware staging, or automation. If confirmed malicious, this behavior may represent an infection in progress, persistence mechanism, or a malicious downloader.
+  The following analytic detects repeated malware file downloads initiated by the same internal host (src) within a short time window. It leverages Cisco Secure Firewall Threat Defense logs and identifies `FileEvent` events with a `SHA_Disposition` of "Malware" and `FileDirection` set to "Download". If ten or more such events occur from the same host within five minutes, this analytic will trigger. This activity may indicate the host is compromised and repeatedly retrieving malicious content either due to command-and-control, malware staging, or automation. If confirmed malicious, this behavior may represent an infection in progress, persistence mechanism, or a malicious downloader.
 data_source:
   - Cisco Secure Firewall Threat Defense File Event
 search: |
@@ -23,11 +23,11 @@ search: |
           values(ThreatName) as ThreatName
           values(dest) as dest
           values(dest_port) as dest_port
-          by src_ip FileDirection FileType Description
+          by src FileDirection FileType Description
   | where count >= 10
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
-  | table firstTime lastTime src_ip dest dest_port FileDirection FileType Description uri file_name file_hash app ClientApplication ThreatName SHA_Disposition
+  | table firstTime lastTime src dest dest_port FileDirection FileType Description uri file_name file_hash app ClientApplication ThreatName SHA_Disposition
   | `cisco_secure_firewall___repeated_malware_downloads_filter`
 how_to_implement: |
   This search requires Cisco Secure Firewall Threat Defense Logs, which
@@ -42,12 +42,12 @@ known_false_positives: False positives should be minimal here, tuning may be req
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -55,9 +55,9 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Repeated malware file downloads detected from $src_ip$ involving $ThreatName$.
+  message: Repeated malware file downloads detected from $src$ involving $ThreatName$.
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 30
   threat_objects:

--- a/detections/network/cisco_secure_firewall___snort_rule_triggered_across_multiple_hosts.yml
+++ b/detections/network/cisco_secure_firewall___snort_rule_triggered_across_multiple_hosts.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Snort Rule Triggered Across Multiple Hosts
 id: a4c76d0a-56b6-44be-814b-939746c4d406
-version: 2
-date: '2025-05-02'
+version: 3
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -12,7 +12,7 @@ data_source:
 search: |
   `cisco_secure_firewall` EventType=IntrusionEvent
   | bin _time span=1h
-  | stats dc(src_ip) as unique_src_ips, values(src_ip) as src_ip 
+  | stats dc(src) as unique_src_ips, values(src) as src 
           min(_time) as firstTime max(_time) as lastTime
           Values(dest) as dest
           Values(dest_port) as dest_port
@@ -37,12 +37,12 @@ known_false_positives: False positives should be minimal. Simultaneous vulnerabi
 references:
   - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$" and "$signature_id$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$" and signature_id = "$signature_id$"'
+- name: View the detection results for - "$src$" and "$signature_id$"
+  search: '%original_detection_search% | search  src = "$src$" and signature_id = "$signature_id$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$" and "$signature_id$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$", "$signature_id$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$" and "$signature_id$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$", "$signature_id$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -52,7 +52,7 @@ drilldown_searches:
 rba:
   message: The Snort rule $signature$ was triggered by $unique_src_ips$ unique internal hosts within a one-hour window, indicating potential widespread exploitation or coordinated targeting activity.
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 25
   threat_objects:

--- a/detections/network/cisco_secure_firewall___ssh_connection_to_non_standard_port.yml
+++ b/detections/network/cisco_secure_firewall___ssh_connection_to_non_standard_port.yml
@@ -32,7 +32,7 @@ search: |
           by dest
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
-  | `cisco_secure_firewall_ssh_connection_to_non_standard_port_filter`
+  | `cisco_secure_firewall___ssh_connection_to_non_standard_port_filter`
 how_to_implement: |
   This search requires Cisco Secure Firewall Threat Defense Logs, which
   includes the FileEvent EventType. This search uses an input macro named `cisco_secure_firewall`.

--- a/detections/network/cisco_secure_firewall___ssh_connection_to_non_standard_port.yml
+++ b/detections/network/cisco_secure_firewall___ssh_connection_to_non_standard_port.yml
@@ -1,0 +1,89 @@
+name: Cisco Secure Firewall - SSH Connection to Non-Standard Port
+id: 9b0c2d3e-4f5a-6b7c-8d9e-0f1a2b3c4d5e
+version: 1
+date: '2026-01-06'
+author: Nasreddine Bencherchali, Michael Haag, Splunk
+status: production
+type: Anomaly
+description: |
+  This analytic detects inbound SSH connections to non-standard ports on network devices using Cisco Secure Firewall Intrusion Events. APT actors have been observed enabling SSH servers on high, non-default TCP ports to maintain encrypted remote access to compromised network infrastructure.
+  This detection leverages Snort signature 65369 to identify SSH protocol traffic on unusual ports, which may indicate persistence mechanisms or backdoor access established by threat actors.
+data_source:
+  - Cisco Secure Firewall Threat Defense Intrusion Event
+search: |
+  `cisco_secure_firewall` 
+  EventType=IntrusionEvent 
+  signature_id=65369
+  | fillnull
+  | stats dc(signature_id) as unique_signature_count 
+          values(signature_id) as signature_id 
+          values(signature) as signature 
+          values(class_desc) as class_desc 
+          values(MitreAttackGroups) as MitreAttackGroups 
+          values(InlineResult) as InlineResult 
+          values(InlineResultReason) as InlineResultReason 
+          values(src) as src 
+          values(dest_port) as dest_port 
+          values(rule) as rule 
+          values(transport) as transport 
+          values(app) as app 
+          min(_time) as firstTime 
+          max(_time) as lastTime 
+          by dest
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `cisco_secure_firewall_ssh_connection_to_non_standard_port_filter`
+how_to_implement: |
+  This search requires Cisco Secure Firewall Threat Defense Logs, which
+  includes the FileEvent EventType. This search uses an input macro named `cisco_secure_firewall`.
+  We strongly recommend that you specify your environment-specific configurations
+  (index, source, sourcetype, etc.) for Cisco Secure Firewall Threat Defense logs. Replace the macro definition
+  with configurations for your Splunk environment. The search also uses a post-filter
+  macro designed to filter out known false positives.
+  The logs are to be ingested using the Splunk Add-on for Cisco Security Cloud (https://splunkbase.splunk.com/app/7404).
+  The malware & file access policy must also enable logging.
+known_false_positives: |
+  No false positives have been identified yet.
+references:
+  - https://www.cisa.gov/news-events/cybersecurity-advisories/aa25-239a
+drilldown_searches:
+  - name: View the detection results for - "$src$"
+    search: '%original_detection_search% | search  src = "$src$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$src$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$")
+      starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+      values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+      as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+      as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+      | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+rba:
+  message: Inbound SSH connection to non-standard port $dest_port$ detected from $src$ to network device $dest$
+  risk_objects:
+    - field: dest
+      type: system
+      score: 50
+  threat_objects:
+    - field: src
+      type: ip_address
+tags:
+  analytic_story:
+    - Cisco Secure Firewall Threat Defense Analytics
+    - Salt Typhoon
+  asset_type: Network
+  mitre_attack_id:
+    - T1021.004
+  product:
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
+  security_domain: network
+tests:
+  - name: True Positive Test
+    attack_data:
+      - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/intrusion_event/intrusion_events.log
+        source: not_applicable
+        sourcetype: cisco:sfw:estreamer

--- a/detections/network/cisco_secure_firewall___ssh_connection_to_sshd_operns.yml
+++ b/detections/network/cisco_secure_firewall___ssh_connection_to_sshd_operns.yml
@@ -1,0 +1,90 @@
+name: Cisco Secure Firewall - SSH Connection to sshd_operns
+id: 8a9c1d2e-3f4b-5c6d-7e8f-9a0b1c2d3e4f
+version: 1
+date: '2026-01-06'
+author: Nasreddine Bencherchali, Splunk
+status: production
+type: Anomaly
+description: |
+  This analytic detects inbound SSH connections to the sshd_operns service on network devices using Cisco Secure Firewall Intrusion Events.
+  APT actors have been observed enabling sshd_operns and opening it on non-standard ports to maintain encrypted remote access to compromised network infrastructure.
+  This detection leverages Snort signature 65368 to identify connections to this service, which when combined with other indicators may signal persistent access mechanisms established by threat actors.
+data_source:
+  - Cisco Secure Firewall Threat Defense Intrusion Event
+search: |
+  `cisco_secure_firewall` 
+  EventType=IntrusionEvent 
+  signature_id=65368
+  | fillnull
+  | stats dc(signature_id) as unique_signature_count 
+          values(signature_id) as signature_id 
+          values(signature) as signature 
+          values(class_desc) as class_desc 
+          values(MitreAttackGroups) as MitreAttackGroups 
+          values(InlineResult) as InlineResult 
+          values(InlineResultReason) as InlineResultReason 
+          values(src) as src 
+          values(dest_port) as dest_port 
+          values(rule) as rule 
+          values(transport) as transport 
+          values(app) as app 
+          min(_time) as firstTime 
+          max(_time) as lastTime 
+          by dest
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `cisco_secure_firewall_ssh_connection_to_sshd_operns_filter`
+how_to_implement: |
+  This search requires Cisco Secure Firewall Threat Defense Logs, which
+  includes the FileEvent EventType. This search uses an input macro named `cisco_secure_firewall`.
+  We strongly recommend that you specify your environment-specific configurations
+  (index, source, sourcetype, etc.) for Cisco Secure Firewall Threat Defense logs. Replace the macro definition
+  with configurations for your Splunk environment. The search also uses a post-filter
+  macro designed to filter out known false positives.
+  The logs are to be ingested using the Splunk Add-on for Cisco Security Cloud (https://splunkbase.splunk.com/app/7404).
+  The malware & file access policy must also enable logging.
+known_false_positives: |
+  No false positives have been identified yet.
+references:
+  - https://www.cisa.gov/news-events/cybersecurity-advisories/aa25-239a
+drilldown_searches:
+  - name: View the detection results for - "$src$"
+    search: '%original_detection_search% | search  src = "$src$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$src$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$")
+      starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+      values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+      as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+      as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+      | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+rba:
+  message: Inbound SSH connection to sshd_operns detected from $src$ to network device $dest$
+  risk_objects:
+    - field: dest
+      type: system
+      score: 50
+  threat_objects:
+    - field: src
+      type: ip_address
+tags:
+  analytic_story:
+    - Cisco Secure Firewall Threat Defense Analytics
+    - Salt Typhoon
+  asset_type: Network
+  mitre_attack_id:
+    - T1021.004
+  product:
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
+  security_domain: network
+tests:
+  - name: True Positive Test
+    attack_data:
+      - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/cisco_secure_firewall_threat_defense/intrusion_event/intrusion_events.log
+        source: not_applicable
+        sourcetype: cisco:sfw:estreamer

--- a/detections/network/cisco_secure_firewall___ssh_connection_to_sshd_operns.yml
+++ b/detections/network/cisco_secure_firewall___ssh_connection_to_sshd_operns.yml
@@ -33,7 +33,7 @@ search: |
           by dest
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
-  | `cisco_secure_firewall_ssh_connection_to_sshd_operns_filter`
+  | `cisco_secure_firewall___ssh_connection_to_sshd_operns_filter`
 how_to_implement: |
   This search requires Cisco Secure Firewall Threat Defense Logs, which
   includes the FileEvent EventType. This search uses an input macro named `cisco_secure_firewall`.

--- a/detections/network/cisco_secure_firewall___static_tundra_smart_install_abuse.yml
+++ b/detections/network/cisco_secure_firewall___static_tundra_smart_install_abuse.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Static Tundra Smart Install Abuse
 id: 7e9a5a2c-2f1a-4b6a-9a4b-9e7d9c8f5a21
-version: 1
-date: '2025-08-21'
+version: 2
+date: '2026-06-01'
 author: Bhavin Patel, Michael Haag, Splunk
 status: production
 type: TTP
@@ -24,14 +24,14 @@ search: |
           values(MitreAttackGroups) as MitreAttackGroups 
           values(InlineResult) as InlineResult 
           values(InlineResultReason) as InlineResultReason 
-          values(dest_ip) as dest_ip 
+          values(dest) as dest 
           values(dest_port) as dest_port 
           values(rule) as rule 
           values(transport) as transport 
           values(app) as app 
           min(_time) as firstTime 
           max(_time) as lastTime 
-          by src_ip
+          by src
   | where unique_signature_count >= 2
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
@@ -48,12 +48,12 @@ references:
 - https://blog.talosintelligence.com/static-tundra/
 - https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180328-smi2
 drilldown_searches:
-- name: View the detection results for - "$dest_ip$"
-  search: '%original_detection_search% | search  dest_ip = "$dest_ip$"'
+- name: View the detection results for - "$dest$"
+  search: '%original_detection_search% | search  dest = "$dest$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -61,13 +61,13 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Smart Install exploitation or protocol abuse targeting $dest_ip$ originating from $src_ip$
+  message: Smart Install exploitation or protocol abuse targeting $dest$ originating from $src$
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 30
   threat_objects:
-    - field: src_ip
+    - field: src
       type: ip_address
     - field: signature
       type: signature

--- a/detections/network/cisco_secure_firewall___veeam_cve_2023_27532_exploitation_activity.yml
+++ b/detections/network/cisco_secure_firewall___veeam_cve_2023_27532_exploitation_activity.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Veeam CVE-2023-27532 Exploitation Activity
 id: 7b7c2e92-f0b2-48d2-9c9b-b8de52b6b2ae
-version: 1
-date: '2025-04-14'
+version: 2
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk, Talos NTDR
 status: production
 type: TTP
@@ -23,14 +23,14 @@ search: |
           values(MitreAttackGroups) as MitreAttackGroups 
           values(InlineResult) as InlineResult 
           values(InlineResultReason) as InlineResultReason 
-          values(src_ip) as src_ip 
+          values(src) as src 
           values(dest_port) as dest_port 
           values(rule) as rule 
           values(transport) as transport 
           values(app) as app 
           min(_time) as firstTime 
           max(_time) as lastTime 
-          by dest_ip
+          by dest
   | where unique_signature_count = 2
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
@@ -49,12 +49,12 @@ references:
   - https://nvd.nist.gov/vuln/detail/CVE-2023-27532
   - https://www.veeam.com/kb4424
 drilldown_searches:
-- name: View the detection results for - "$dest_ip$" and "$src_ip$"
-  search: '%original_detection_search% | search  dest_ip = "$dest_ip$" and src_ip = "$src_ip$"'
+- name: View the detection results for - "$dest$" and "$src$"
+  search: '%original_detection_search% | search  dest = "$dest$" and src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$dest$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -62,15 +62,15 @@ drilldown_searches:
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
 rba:
-  message: Exploitation attempt of Veeam CVE-2023-27532 on host $dest_ip$ by $src_ip$.
+  message: Exploitation attempt of Veeam CVE-2023-27532 on host $dest$ by $src$.
   risk_objects:
-    - field: dest_ip
+    - field: dest
       type: system
       score: 25
   threat_objects:
     - field: signature
       type: signature
-    - field: src_ip
+    - field: src
       type: ip_address
 tags:
   analytic_story: 

--- a/detections/network/cisco_secure_firewall___wget_or_curl_download.yml
+++ b/detections/network/cisco_secure_firewall___wget_or_curl_download.yml
@@ -1,7 +1,7 @@
 name: Cisco Secure Firewall - Wget or Curl Download
 id: 173a1cb9-1814-4128-a9dc-f29dade89957
-version: 3
-date: '2025-07-10'
+version: 4
+date: '2026-06-01'
 author: Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
@@ -18,8 +18,8 @@ search: |
       Values(dest_port) as dest_port
       Values(ClientApplicationVersion) as ClientApplicationVersion
       Values(src_port) as src_port
-      by src_ip, dest, transport, EVE_Process, ClientApplication, action
-  | table src_ip src_port dest dest_port transport url EVE_Process ClientApplication ClientApplicationVersion rule firstTime lastTime
+      by src, dest, transport, EVE_Process, ClientApplication, action
+  | table src src_port dest dest_port transport url EVE_Process ClientApplication ClientApplicationVersion rule firstTime lastTime
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)` 
   | `cisco_secure_firewall___wget_or_curl_download_filter`
@@ -39,12 +39,12 @@ known_false_positives: |
 references:
 - https://www.cisco.com/c/en/us/td/docs/security/firepower/741/api/FQE/secure_firewall_estreamer_fqe_guide_740.pdf
 drilldown_searches:
-- name: View the detection results for - "$src_ip$"
-  search: '%original_detection_search% | search  src_ip = "$src_ip$"'
+- name: View the detection results for - "$src$"
+  search: '%original_detection_search% | search  src = "$src$"'
   earliest_offset: $info_min_time$
   latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src_ip$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src_ip$") starthoursago=168  | stats count min(_time)
+- name: View risk events for the last 7 days for - "$src$"
+  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$") starthoursago=168  | stats count min(_time)
     as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message)
     as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
     as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
@@ -54,7 +54,7 @@ drilldown_searches:
 rba:
   message: The process $EVE_Process$ initiated an allowed connection to download content using a command-line utility ($ClientApplication$) from $url$. This behavior may indicate tool staging or payload retrieval via curl or wget.
   risk_objects:
-    - field: src_ip
+    - field: src
       type: system
       score: 25
   threat_objects:


### PR DESCRIPTION
This PR introduces a couple new analytics related to Snort/ Cisco IOS and updates to output and RBA fields of old snort based detections.

### New Analytics [5]
- Cisco Privileged Account Creation with HTTP Command Execution
- Cisco Privileged Account Creation with Suspicious SSH Activity
- Cisco Secure Firewall - Privileged Command Execution via HTTP
- Cisco Secure Firewall - SSH Connection to Non-Standard Port
- Cisco Secure Firewall - SSH Connection to sshd_operns

### Updated Analytics [29]
The updates mainly focused on changing the `dest_ip` and `src_ip` to `dest` and `src` respectively for ES compliance.

### Updated Data Sources [3]
Updated the output fields from `src_ip` to `src` for ES compliance.
- data_sources/cisco_secure_firewall_threat_defense_connection_event.yml
- data_sources/cisco_secure_firewall_threat_defense_file_event.yml
- data_sources/cisco_secure_firewall_threat_defense_intrusion_event.yml