### PR TITLE
Refactor search query for prohibited network traffic

### DIFF
--- a/detections/network/prohibited_network_traffic_allowed.yml
+++ b/detections/network/prohibited_network_traffic_allowed.yml
@@ -20,10 +20,10 @@ search: '| tstats `security_content_summariesonly` count min(_time) as firstTime
   where All_Traffic.action IN ("allowed", "allow") 
   [| inputlookup interesting_ports_lookup where is_prohibited="true" 
   | table dest_port transport | dedup dest_port transport 
-  | rename dest_port as All_Traffic.dest_port | rename transport as All_Traffic.transport]
+  | rename dest_port as All_Traffic.dest_port | rename transport as All_Traffic.transport] 
   by All_Traffic.src_ip All_Traffic.dest_ip All_Traffic.dest_port All_Traffic.action All_Traffic.dvc All_Traffic.src_port All_Traffic.vendor_product All_Traffic.rule 
-  | lookup update=true interesting_ports_lookup dest_port as All_Traffic.dest_port transport as All_Traffic.transport OUTPUT app is_prohibited note
-  | `security_content_ctime(firstTime)`
+  | lookup update=true interesting_ports_lookup dest_port as All_Traffic.dest_port transport as All_Traffic.transport OUTPUT app is_prohibited note 
+  | `security_content_ctime(firstTime)` 
   | `security_content_ctime(lastTime)` 
   | `drop_dm_object_name("All_Traffic")` 
   | `prohibited_network_traffic_allowed_filter`'

--- a/detections/network/prohibited_network_traffic_allowed.yml
+++ b/detections/network/prohibited_network_traffic_allowed.yml
@@ -1,7 +1,7 @@
 name: Prohibited Network Traffic Allowed
 id: ce5a0962-849f-4720-a678-753fe6674479
-version: 9
-date: '2025-06-17'
+version: 10
+date: '2025-01-16'
 author: Rico Valdez, Splunk
 status: production
 type: TTP

--- a/detections/network/prohibited_network_traffic_allowed.yml
+++ b/detections/network/prohibited_network_traffic_allowed.yml
@@ -15,13 +15,18 @@ description: The following analytic detects instances where network traffic, ide
   compromising the organization's security posture.
 data_source:
 - Cisco Secure Firewall Threat Defense Connection Event
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Network_Traffic where All_Traffic.action IN ("allowed", "allow") by
-  All_Traffic.src_ip All_Traffic.dest_ip All_Traffic.dest_port All_Traffic.action
-  All_Traffic.dvc All_Traffic.src_port All_Traffic.vendor_product  All_Traffic.rule | lookup update=true
-  interesting_ports_lookup dest_port as All_Traffic.dest_port OUTPUT app is_prohibited
-  note transport | search is_prohibited=true | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` | `drop_dm_object_name("All_Traffic")` | `prohibited_network_traffic_allowed_filter`'
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime 
+  from datamodel=Network_Traffic 
+  where All_Traffic.action IN ("allowed", "allow") 
+  [| inputlookup interesting_ports_lookup where is_prohibited="true" 
+  | table dest_port transport | dedup dest_port transport 
+  | rename dest_port as All_Traffic.dest_port | rename transport as All_Traffic.transport]
+  by All_Traffic.src_ip All_Traffic.dest_ip All_Traffic.dest_port All_Traffic.action All_Traffic.dvc All_Traffic.src_port All_Traffic.vendor_product All_Traffic.rule 
+  | lookup update=true interesting_ports_lookup dest_port as All_Traffic.dest_port transport as All_Traffic.transport OUTPUT app is_prohibited note
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)` 
+  | `drop_dm_object_name("All_Traffic")` 
+  | `prohibited_network_traffic_allowed_filter`'
 how_to_implement: In order to properly run this search, Splunk needs to ingest data
   from firewalls or other network control devices that mediate the traffic allowed
   into an environment. This is necessary so that the search can identify an 'action'

--- a/detections/network/prohibited_network_traffic_allowed.yml
+++ b/detections/network/prohibited_network_traffic_allowed.yml
@@ -1,7 +1,7 @@
 name: Prohibited Network Traffic Allowed
 id: ce5a0962-849f-4720-a678-753fe6674479
 version: 10
-date: '2025-01-16'
+date: '2026-01-16'
 author: Rico Valdez, Splunk
 status: production
 type: TTP


### PR DESCRIPTION
### **Describe the bug**
The search can detect a 514 udp as rsh on tcp.
When "interesting_ports_lookup" is used, only the port is checked, not the protocol. Plus, only the first result is returned.
This lookup include several entries for the same port (like 514 rsh/syslog) and the wrong entry can get returned. This create false match. The wrong enrichment is given (including a wrong transport method) and a notable is generated when it shouldn't. It can also be greatly optimized by moving the filter logic to the where of the tstats.

### **Expected behavior**
If a 514 udp is detected by the firewall, it should match syslog and not create a notable (or risk) saying it detected a rsh 514 tcp.

### Details

It only contains a patch for the search in the rule "Prohibited Network Traffic Allowed".
It now get the transport from the log instead of adding it from the lookup, add transport to the match in the lookup "interesting_ports_lookup" command and the filter logic is now in the where.
