### PR TITLE
Update Analytics Performance 

### DIFF
--- a/detections/endpoint/common_ransomware_extensions.yml
+++ b/detections/endpoint/common_ransomware_extensions.yml
@@ -1,7 +1,7 @@
 name: Common Ransomware Extensions
 id: a9e5c5db-db11-43ca-86a8-c852d1b2c0ec
-version: 16
-date: '2025-10-01'
+version: 17
+date: '2026-01-19'
 author: David Dorsey, Michael Haag, Splunk, Steven Dick
 status: production
 type: TTP
@@ -21,14 +21,44 @@ search: |
     max(_time) as lastTime 
     count latest(Filesystem.user) as user 
           values(Filesystem.file_path) as file_path 
-    from datamodel=Endpoint.Filesystem by 
-          Filesystem.action Filesystem.dest
-          Filesystem.file_access_time Filesystem.file_create_time 
-          Filesystem.file_hash Filesystem.file_modify_time
-          Filesystem.file_name Filesystem.file_path 
-          Filesystem.file_acl Filesystem.file_size
-          Filesystem.process_guid Filesystem.process_id 
-          Filesystem.user Filesystem.vendor_product
+    from datamodel=Endpoint.Filesystem
+    where NOT Filesystem.file_name IN (
+      "*.bat",
+      "*.cmd",
+      "*.com",
+      "*.cpl",
+      "*.dll",
+      "*.doc",
+      "*.docx",
+      "*.exe",
+      "*.gif",
+      "*.jar",
+      "*.jpeg",
+      "*.jpg",
+      "*.js",
+      "*.lnk",
+      "*.pif",
+      "*.png",
+      "*.ppt",
+      "*.pptx",
+      "*.ps1",
+      "*.psm1",
+      "*.scr",
+      "*.sys",
+      "*.txt",
+      "*.vbs",
+      "*.wsf",
+      "*.xls",
+      "*.xlsx",
+      "*.zip"
+    )
+    by Filesystem.action Filesystem.dest
+       Filesystem.file_access_time Filesystem.file_create_time 
+       Filesystem.file_hash Filesystem.file_modify_time
+       Filesystem.file_name Filesystem.file_path 
+       Filesystem.file_acl Filesystem.file_size
+       Filesystem.process_guid Filesystem.process_id 
+       Filesystem.user Filesystem.vendor_product
   | `drop_dm_object_name(Filesystem)` 
   | rex field=file_name "(?<file_extension>(\.[^\.]+){1,2})$"
   | lookup update=true ransomware_extensions_lookup Extensions AS file_extension OUTPUT

--- a/detections/endpoint/common_ransomware_extensions.yml
+++ b/detections/endpoint/common_ransomware_extensions.yml
@@ -73,6 +73,7 @@ search: |
           values(file_modify_time) as file_modify_time
           values(file_acl) as file_acl 
           values(file_size) as file_size 
+          values(file_path) as file_path 
           values(process_guid) as process_guid 
           values(process_id) as process_id 
           values(user) as user 

--- a/detections/endpoint/common_ransomware_extensions.yml
+++ b/detections/endpoint/common_ransomware_extensions.yml
@@ -49,8 +49,7 @@ search: |
       "*.vbs",
       "*.wsf",
       "*.xls",
-      "*.xlsx",
-      "*.zip"
+      "*.xlsx"
     )
     by Filesystem.action Filesystem.dest
        Filesystem.file_access_time Filesystem.file_create_time 
@@ -61,8 +60,7 @@ search: |
        Filesystem.user Filesystem.vendor_product
   | `drop_dm_object_name(Filesystem)` 
   | rex field=file_name "(?<file_extension>(\.[^\.]+){1,2})$"
-  | lookup update=true ransomware_extensions_lookup Extensions AS file_extension OUTPUT
-  Extensions Name 
+  | lookup update=true ransomware_extensions_lookup Extensions AS file_extension OUTPUT Extensions Name 
   | search Name !=False 
   | stats min(firstTime) as firstTime 
           max(lastTime) as lastTime 

--- a/detections/endpoint/common_ransomware_notes.yml
+++ b/detections/endpoint/common_ransomware_notes.yml
@@ -1,6 +1,6 @@
 name: Common Ransomware Notes
 id: ada0f478-84a8-4641-a3f1-d82362d6bd71
-version: 14
+version: 13
 date: '2026-01-16'
 author: David Dorsey, Splunk
 status: production

--- a/detections/endpoint/common_ransomware_notes.yml
+++ b/detections/endpoint/common_ransomware_notes.yml
@@ -1,67 +1,81 @@
 name: Common Ransomware Notes
 id: ada0f478-84a8-4641-a3f1-d82362d6bd71
-version: 13
-date: '2025-12-15'
+version: 14
+date: '2026-01-16'
 author: David Dorsey, Splunk
 status: production
 type: Hunting
-description: The following analytic detects the creation of files with names commonly
-  associated with ransomware notes. It leverages file-system activity data from the
-  Endpoint Filesystem data model, typically populated by endpoint detection and response
-  (EDR) tools or Sysmon logs. This activity is significant because ransomware notes
-  indicate a potential ransomware attack, which can lead to data encryption and extortion.
-  If confirmed malicious, this activity could result in significant data loss, operational
-  disruption, and financial impact due to ransom demands.
+description: |
+  The following analytic detects the creation of files with names commonly associated with ransomware notes.
+  It leverages file-system activity data from the Endpoint Filesystem data model, typically populated by endpoint detection and response (EDR) tools or Sysmon logs.
+  This activity is significant because ransomware notes indicate a potential ransomware attack, which can lead to data encryption and extortion.
+  If confirmed malicious, this activity could result in significant data loss, operational disruption, and financial impact due to ransom demands.
+  Note that this analytic relies on a lookup table (ransomware_notes_lookup) that contains known ransomware note file names.
+  Ensure that this lookup table is regularly updated to include new ransomware note file names as they are identified in the threat landscape.
+  Also this analytic leverages a sub-search to enhance performance. sub-searches have limitations on the amount of data they can return. Keep this in mind if you have an extensive list of ransomware note file names.
 data_source:
 - Sysmon EventID 11
 search: |
-  | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime values(Filesystem.user) as user values(Filesystem.dest) as dest values(Filesystem.file_path)
-  as file_path from datamodel=Endpoint.Filesystem
-  by Filesystem.action Filesystem.dest Filesystem.file_access_time Filesystem.file_create_time
-     Filesystem.file_hash Filesystem.file_modify_time
-     Filesystem.file_name Filesystem.file_path Filesystem.file_acl Filesystem.file_size
-     Filesystem.process_guid Filesystem.process_id Filesystem.user Filesystem.vendor_product
+  | tstats `security_content_summariesonly`
+    count
+    min(_time) as firstTime
+    max(_time) as lastTime
+    values(Filesystem.user) as user
+    values(Filesystem.dest) as dest
+    values(Filesystem.file_path) as file_path
+  from datamodel=Endpoint.Filesystem
+  where [
+    | inputlookup ransomware_notes_lookup
+    | search status=true
+    | fields ransomware_notes
+    | dedup ransomware_notes
+    | rename ransomware_notes as Filesystem.file_name
+  ]
+  by Filesystem.action Filesystem.dest Filesystem.file_access_time
+     Filesystem.file_create_time Filesystem.file_hash
+     Filesystem.file_modify_time Filesystem.file_name
+     Filesystem.file_path Filesystem.file_acl Filesystem.file_size
+     Filesystem.process_guid Filesystem.process_id Filesystem.user
+     Filesystem.vendor_product
   | `drop_dm_object_name(Filesystem)`
   | `security_content_ctime(lastTime)`
   | `security_content_ctime(firstTime)`
-  | lookup ransomware_notes_lookup ransomware_notes as file_name OUTPUT status as "Known Ransomware Notes"
-  | search "Known Ransomware Notes"=True
   | `common_ransomware_notes_filter`
 how_to_implement: You must be ingesting data that records file-system activity from
   your hosts to populate the Endpoint Filesystem data-model node. This is typically
   populated via endpoint detection-and-response product, such as Carbon Black, or
   via other endpoint data sources, such as Sysmon. The data used for this search is
   typically generated via logs that report file-system reads and writes.
-known_false_positives: It's possible that a legitimate file could be created with
-  the same name used by ransomware note files.
+known_false_positives: |
+  There could be cases where a legitimate file coincidentally matches a known ransomware note
+  name. In such cases, further investigation is required to determine the nature of the file and its context.
 references: []
 tags:
   analytic_story:
-  - Chaos Ransomware
-  - Rhysida Ransomware
-  - Ransomware
-  - LockBit Ransomware
-  - Medusa Ransomware
-  - SamSam Ransomware
-  - Clop Ransomware
-  - Ryuk Ransomware
-  - Black Basta Ransomware
-  - Termite Ransomware
-  - Interlock Ransomware
-  - NailaoLocker Ransomware
-  - Hellcat Ransomware
+    - Chaos Ransomware
+    - Rhysida Ransomware
+    - Ransomware
+    - LockBit Ransomware
+    - Medusa Ransomware
+    - SamSam Ransomware
+    - Clop Ransomware
+    - Ryuk Ransomware
+    - Black Basta Ransomware
+    - Termite Ransomware
+    - Interlock Ransomware
+    - NailaoLocker Ransomware
+    - Hellcat Ransomware
   asset_type: Endpoint
   mitre_attack_id:
-  - T1485
+    - T1485
   product:
-  - Splunk Enterprise
-  - Splunk Enterprise Security
-  - Splunk Cloud
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
   security_domain: endpoint
 tests:
-- name: True Positive Test
-  attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1485/ransomware_notes/windows-sysmon.log
-    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    sourcetype: XmlWinEventLog
+  - name: True Positive Test
+    attack_data:
+    - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1485/ransomware_notes/windows-sysmon.log
+      source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+      sourcetype: XmlWinEventLog

--- a/detections/endpoint/detect_rare_executables.yml
+++ b/detections/endpoint/detect_rare_executables.yml
@@ -1,37 +1,51 @@
 name: Detect Rare Executables
 id: 44fddcb2-8d3b-454c-874e-7c6de5a4f7ac
-version: 10
-date: '2025-05-02'
+version: 11
+date: '2026-01-15'
 author: Bhavin Patel, Splunk
 status: production
 type: Anomaly
-description: The following analytic detects the execution of rare processes that appear
-  only once across the network within a specified timeframe. It leverages data from
-  Endpoint Detection and Response (EDR) agents, focusing on process execution logs.
-  This activity is significant for a SOC as it helps identify potentially malicious
-  activities or unauthorized software, which could indicate a security breach or ongoing
-  attack. If confirmed malicious, such rare processes could lead to data theft, privilege
-  escalation, or complete system compromise, making early detection crucial for minimizing
-  impact.
+description: |
+  The following analytic detects the execution of rare processes that appear only once across the network within a specified timeframe.
+  It leverages data from Endpoint Detection and Response (EDR) agents, focusing on process execution logs.
+  This activity is significant for a SOC as it helps identify potentially malicious activities or unauthorized software, which could indicate a security breach or ongoing attack.
+  If confirmed malicious, such rare processes could lead to data theft, privilege escalation, or complete system compromise, making early detection crucial for minimizing impact.
+  The search currently identifies processes executed on fewer than 10 hosts, but this threshold can be adjusted based on the organization's environment and risk tolerance.
+  The search groups results by process name which can lead to blind spots if a malicious process uses a common name. To mitigate this, consider enhancing the detection logic to group by additional attributes such as process hash.
 data_source:
-- Sysmon EventID 1
-- Windows Event Log Security 4688
-- CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` dc(Processes.dest) as dc_dest values(Processes.dest)
-  as dest values(Processes.user) as user min(_time) as firstTime max(_time) as lastTime
-  values(Processes.action) as action values(Processes.original_file_name) as original_file_name
-  values(Processes.parent_process) as parent_process values(Processes.parent_process_exec)
-  as parent_process_exec values(Processes.parent_process_guid) as parent_process_guid
-  values(Processes.parent_process_id) as parent_process_id values(Processes.parent_process_name)
-  as parent_process_name values(Processes.parent_process_path) as parent_process_path
-  values(Processes.process) as process values(Processes.process_exec) as process_exec
-  values(Processes.process_guid) as process_guid values(Processes.process_hash) as
-  process_hash values(Processes.process_id) as process_id values(Processes.process_integrity_level)
-  as process_integrity_level values(Processes.process_path) as process_path values(Processes.user_id)
-  as user_id values(Processes.vendor_product) as vendor_product from datamodel=Endpoint.Processes
-  by Processes.process_name | `drop_dm_object_name(Processes)` | search dc_dest <
-  10 | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` |
-  `detect_rare_executables_filter`'
+  - Sysmon EventID 1
+  - Windows Event Log Security 4688
+  - CrowdStrike ProcessRollup2
+search: |
+  | tstats `security_content_summariesonly`
+    dc(Processes.dest) as dc_dest
+    values(Processes.dest) as dest
+    values(Processes.user) as user
+    min(_time) as firstTime
+    max(_time) as lastTime
+    values(Processes.original_file_name) as original_file_name
+    values(Processes.parent_process) as parent_process
+    values(Processes.parent_process_exec) as parent_process_exec
+    latest(Processes.parent_process_guid) as parent_process_guid
+    latest(Processes.parent_process_id) as parent_process_id
+    values(Processes.parent_process_name) as parent_process_name
+    values(Processes.parent_process_path) as parent_process_path
+    values(Processes.process) as process
+    values(Processes.process_exec) as process_exec
+    latest(Processes.process_guid) as process_guid
+    values(Processes.process_hash) as process_hash
+    values(Processes.process_path) as process_path
+    latest(Processes.process_id) as process_id
+    latest(Processes.process_integrity_level) as process_integrity_level
+    latest(Processes.user_id) as user_id
+    latest(Processes.vendor_product) as vendor_product
+  from datamodel=Endpoint.Processes
+  by Processes.process_name
+  | `drop_dm_object_name(Processes)`
+  | search dc_dest < 10
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `detect_rare_executables_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
@@ -41,50 +55,52 @@ how_to_implement: The detection is based on data that originates from Endpoint D
   the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint`
   data model. Use the Splunk Common Information Model (CIM) to normalize the field
   names and speed up the data modeling process.
-known_false_positives: Some legitimate processes may be only rarely executed in your
-  environment.
+known_false_positives: |
+  Some legitimate processes may be only rarely executed in your environment.
+  Apply additional filters as needed.
 references: []
 drilldown_searches:
-- name: View the detection results for - "$dest$"
-  search: '%original_detection_search% | search  dest = "$dest$"'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
-    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
-    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
-    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
-    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
-    | `security_content_ctime(lastTime)`'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
+  - name: View the detection results for - "$dest$"
+    search: '%original_detection_search% | search  dest = "$dest$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$dest$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$")
+      starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+      values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+      as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+      as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+      | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
 rba:
-  message: A rare process - [$process_name$] has been detected on less than 10 hosts
-    in your environment.
+  message: A rare process - [$process_name$] has been detected on less than 10 hosts on $dest$.
   risk_objects:
-  - field: dest
-    type: system
-    score: 25
-  threat_objects: []
+    - field: dest
+      type: system
+      score: 25
+  threat_objects:
+    - field: process_name
+      type: process_name
 tags:
   analytic_story:
-  - China-Nexus Threat Activity
-  - Unusual Processes
-  - SnappyBee
-  - Salt Typhoon
-  - Rhysida Ransomware
-  - Crypto Stealer
+    - China-Nexus Threat Activity
+    - Unusual Processes
+    - SnappyBee
+    - Salt Typhoon
+    - Rhysida Ransomware
+    - Crypto Stealer
   asset_type: Endpoint
   mitre_attack_id:
-  - T1204
+    - T1204
   product:
-  - Splunk Enterprise
-  - Splunk Enterprise Security
-  - Splunk Cloud
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
   security_domain: endpoint
 tests:
-- name: True Positive Test
-  attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1204/rare_executables/windows-sysmon.log
-    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    sourcetype: XmlWinEventLog
+  - name: True Positive Test
+    attack_data:
+    - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1204/rare_executables/windows-sysmon.log
+      source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+      sourcetype: XmlWinEventLog

--- a/detections/endpoint/detect_rare_executables.yml
+++ b/detections/endpoint/detect_rare_executables.yml
@@ -23,6 +23,7 @@ search: |
     values(Processes.user) as user
     min(_time) as firstTime
     max(_time) as lastTime
+    latest(Processes.action) as action
     values(Processes.original_file_name) as original_file_name
     values(Processes.parent_process) as parent_process
     values(Processes.parent_process_exec) as parent_process_exec

--- a/detections/endpoint/detect_remote_access_software_usage_file.yml
+++ b/detections/endpoint/detect_remote_access_software_usage_file.yml
@@ -11,6 +11,8 @@ description: |
   This activity is significant as adversaries often use remote access tools like AnyDesk, GoToMyPC, LogMeIn, and TeamViewer to maintain unauthorized access.
   If confirmed malicious, this could allow attackers to persist in the environment, potentially leading to data exfiltration, further compromise, or complete control over affected systems.
   It is best to update both the remote_access_software_usage_exception.csv lookup and the remote_access_software lookup with any known or approved remote access software to reduce false positives and increase coverage.
+  In order to enhance performance, the detection filters for specific file names extensions / names that are used in the remote_access_software lookup.
+  If add additional entries, consider updating the search filters to include those file names / extensions as well, if not alread covered.
 data_source:
 - Sysmon EventID 11
 search: |
@@ -19,6 +21,15 @@ search: |
           max(_time) as lastTime
           values(Filesystem.file_path) as file_path
   from datamodel=Endpoint.Filesystem
+  where Filesystem.file_name IN (
+    "*.app",
+    "*.exe",
+    "*.msi",
+    "*.pkg",
+    "*echoware.dll",
+    "*Idrive.*",
+    "*rdp2tcp.py"
+  )
   by Filesystem.action Filesystem.dest Filesystem.file_access_time
      Filesystem.file_create_time Filesystem.file_hash
      Filesystem.file_modify_time Filesystem.file_name

--- a/detections/endpoint/detect_remote_access_software_usage_file.yml
+++ b/detections/endpoint/detect_remote_access_software_usage_file.yml
@@ -1,7 +1,7 @@
 name: Detect Remote Access Software Usage File
 id: 3bf5541a-6a45-4fdc-b01d-59b899fff961
-version: 12
-date: '2025-10-14'
+version: 13
+date: '2026-01-19'
 author: Steven Dick
 status: production
 type: Anomaly

--- a/detections/endpoint/detect_remote_access_software_usage_file.yml
+++ b/detections/endpoint/detect_remote_access_software_usage_file.yml
@@ -5,26 +5,33 @@ date: '2025-10-14'
 author: Steven Dick
 status: production
 type: Anomaly
-description: The following analytic detects the writing of files from known 
-  remote access software to disk within the environment. It leverages data from 
-  Endpoint Detection and Response (EDR) agents, focusing on file path, file 
-  name, and user information. This activity is significant as adversaries often 
-  use remote access tools like AnyDesk, GoToMyPC, LogMeIn, and TeamViewer to 
-  maintain unauthorized access. If confirmed malicious, this could allow 
-  attackers to persist in the environment, potentially leading to data 
-  exfiltration, further compromise, or complete control over affected systems.
+description: |
+  The following analytic detects the writing of files from known remote access software to disk within the environment.
+  It leverages data from Endpoint Detection and Response (EDR) agents, focusing on file path, file name, and user information.
+  This activity is significant as adversaries often use remote access tools like AnyDesk, GoToMyPC, LogMeIn, and TeamViewer to maintain unauthorized access.
+  If confirmed malicious, this could allow attackers to persist in the environment, potentially leading to data exfiltration, further compromise, or complete control over affected systems.
+  It is best to update both the remote_access_software_usage_exception.csv lookup and the remote_access_software lookup with any known or approved remote access software to reduce false positives and increase coverage.
 data_source:
 - Sysmon EventID 11
-search: '| tstats `security_content_summariesonly` count, min(_time) as firstTime,
-  max(_time) as lastTime, values(Filesystem.file_path) as file_path from datamodel=Endpoint.Filesystem
-  by Filesystem.action Filesystem.dest Filesystem.file_access_time Filesystem.file_create_time
-  Filesystem.file_hash Filesystem.file_modify_time Filesystem.file_name Filesystem.file_path
-  Filesystem.file_acl Filesystem.file_size Filesystem.process_guid Filesystem.process_id
-  Filesystem.user Filesystem.vendor_product | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` | `drop_dm_object_name(Filesystem)` | lookup
-  remote_access_software remote_utility AS file_name OUTPUT isutility, description
-  as signature, comment_reference as desc, category | search isutility = TRUE | `remote_access_software_usage_exceptions`
-  | `detect_remote_access_software_usage_file_filter`'
+search: |
+  | tstats `security_content_summariesonly`
+    count min(_time) as firstTime,
+          max(_time) as lastTime
+          values(Filesystem.file_path) as file_path
+  from datamodel=Endpoint.Filesystem
+  by Filesystem.action Filesystem.dest Filesystem.file_access_time
+     Filesystem.file_create_time Filesystem.file_hash
+     Filesystem.file_modify_time Filesystem.file_name
+     Filesystem.file_path Filesystem.file_acl Filesystem.file_size
+     Filesystem.process_guid Filesystem.process_id
+     Filesystem.user Filesystem.vendor_product
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `drop_dm_object_name(Filesystem)`
+  | lookup remote_access_software remote_utility AS file_name OUTPUT isutility, description as signature, comment_reference as desc, category
+  | search isutility = TRUE
+  | `remote_access_software_usage_exceptions`
+  | `detect_remote_access_software_usage_file_filter`
 how_to_implement: The detection is based on data that originates from Endpoint 
   Detection and Response (EDR) agents. These agents are designed to provide 
   security-related telemetry from the endpoints where the agent is installed. To
@@ -46,59 +53,59 @@ references:
 - https://thedfirreport.com/2022/08/08/bumblebee-roasts-its-way-to-domain-admin/
 - https://thedfirreport.com/2022/11/28/emotet-strikes-again-lnk-file-leads-to-domain-wide-ransomware/
 drilldown_searches:
-- name: View the detection results for - "$dest$" and "$user$"
-  search: '%original_detection_search% | search  dest = "$dest$" user = "$user$"'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$dest$" and "$user$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$",
-    "$user$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
-    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
-    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
-    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
-    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: Investigate files on $dest$
-  search: '| from datamodel:Endpoint.Filesystem | search dest=$dest$ file_name=$file_name$'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
+  - name: View the detection results for - "$dest$" and "$user$"
+    search: '%original_detection_search% | search  dest = "$dest$" user = "$user$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$dest$" and "$user$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$",
+      "$user$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+      as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+      Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+      as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+      by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: Investigate files on $dest$
+    search: '| from datamodel:Endpoint.Filesystem | search dest=$dest$ file_name=$file_name$'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
 rba:
   message: A file for known a remote access software [$file_name$] was created 
     on $dest$ by $user$.
   risk_objects:
-  - field: dest
-    type: system
-    score: 25
-  - field: user
-    type: user
-    score: 25
+    - field: dest
+      type: system
+      score: 25
+    - field: user
+      type: user
+      score: 25
   threat_objects:
-  - field: file_name
-    type: file_name
-  - field: signature
-    type: signature
+    - field: file_name
+      type: file_name
+    - field: signature
+      type: signature
 tags:
   analytic_story:
-  - Insider Threat
-  - Command And Control
-  - Ransomware
-  - Gozi Malware
-  - CISA AA24-241A
-  - Remote Monitoring and Management Software
-  - Cactus Ransomware
-  - Seashell Blizzard
-  - Scattered Spider
-  - Interlock Ransomware
-  - GhostRedirector IIS Module and Rungan Backdoor
-  - Scattered Lapsus$ Hunters
+    - Cactus Ransomware
+    - CISA AA24-241A
+    - Command And Control
+    - GhostRedirector IIS Module and Rungan Backdoor
+    - Gozi Malware
+    - Insider Threat
+    - Interlock Ransomware
+    - Ransomware
+    - Remote Monitoring and Management Software
+    - Scattered Lapsus$ Hunters
+    - Scattered Spider
+    - Seashell Blizzard
   asset_type: Endpoint
   mitre_attack_id:
-  - T1219
+    - T1219
   product:
-  - Splunk Enterprise
-  - Splunk Enterprise Security
-  - Splunk Cloud
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
   security_domain: endpoint
   manual_test: This detection uses A&I lookups from Enterprise Security.
 tests:

--- a/detections/endpoint/file_with_samsam_extension.yml
+++ b/detections/endpoint/file_with_samsam_extension.yml
@@ -1,77 +1,91 @@
 name: File with Samsam Extension
 id: 02c6cfc2-ae66-4735-bfc7-6291da834cbf
-version: 9
-date: '2025-10-14'
+version: 10
+date: '2026-01-17'
 author: Rico Valdez, Splunk
 status: production
 type: TTP
-description: The following analytic detects file writes with extensions indicative
-  of a SamSam ransomware attack. It leverages file-system activity data to identify
-  file names ending in .stubbin, .berkshire, .satoshi, .sophos, or .keyxml. This activity
-  is significant because SamSam ransomware is highly destructive, leading to file
-  encryption and ransom demands. If confirmed malicious, the impact includes significant
-  financial losses, operational disruptions, and reputational damage. Immediate actions
-  should include isolating affected systems, restoring files from backups, and investigating
-  the attack source to prevent further incidents.
+description: |
+  The following analytic detects file writes with extensions indicative of a SamSam ransomware attack.
+  It leverages file-system activity data to identify file names ending in .stubbin, .berkshire, .satoshi, .sophos, or .keyxml.
+  This activity is significant because SamSam ransomware is highly destructive, leading to file encryption and ransom demands.
+  If confirmed malicious, the impact includes significant financial losses, operational disruptions, and reputational damage.
+  Immediate actions should include isolating affected systems, restoring files from backups, and investigating the attack source to prevent further incidents.
 data_source:
 - Sysmon EventID 11
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime values(Filesystem.user) as user values(Filesystem.dest) as dest values(Filesystem.file_path)
-  as file_path from datamodel=Endpoint.Filesystem by Filesystem.action Filesystem.dest
-  Filesystem.file_access_time Filesystem.file_create_time Filesystem.file_hash Filesystem.file_modify_time
-  Filesystem.file_name Filesystem.file_path Filesystem.file_acl Filesystem.file_size
-  Filesystem.process_guid Filesystem.process_id Filesystem.user Filesystem.vendor_product
-  | `drop_dm_object_name(Filesystem)` | `security_content_ctime(lastTime)` | `security_content_ctime(firstTime)`|
-  rex field=file_name "(?<file_extension>\.[^\.]+)$" | search file_extension=.stubbin
-  OR file_extension=.berkshire OR file_extension=.satoshi OR file_extension=.sophos
-  OR file_extension=.keyxml | `file_with_samsam_extension_filter`'
+search: |
+  | tstats `security_content_summariesonly`
+    count min(_time) as firstTime
+          max(_time) as lastTime
+          values(Filesystem.user) as user
+          values(Filesystem.dest) as dest
+          values(Filesystem.file_path) as file_path
+  from datamodel=Endpoint.Filesystem where
+  Filesystem.file_name IN (
+    "*.berkshire",
+    "*.keyxml",
+    "*.satoshi",
+    "*.sophos",
+    "*.stubbin"
+  )
+  by Filesystem.action Filesystem.dest Filesystem.file_access_time
+     Filesystem.file_create_time Filesystem.file_hash
+     Filesystem.file_modify_time Filesystem.file_name
+     Filesystem.file_path Filesystem.file_acl Filesystem.file_size
+     Filesystem.process_guid Filesystem.process_id
+     Filesystem.user Filesystem.vendor_product
+  | `drop_dm_object_name(Filesystem)`
+  | `security_content_ctime(lastTime)`
+  | `security_content_ctime(firstTime)`
+  | rex field=file_name "(?<file_extension>\.[^\.]+)$"
+  | search file_extension IN (".berkshire", ".keyxml", ".satoshi", ".sophos", ".stubbin")
+  | `file_with_samsam_extension_filter`
 how_to_implement: You must be ingesting data that records file-system activity from
   your hosts to populate the Endpoint file-system data-model node. If you are using
   Sysmon, you will need a Splunk Universal Forwarder on each endpoint from which you
   want to collect data.
-known_false_positives: Because these extensions are not typically used in normal operations,
-  you should investigate all results.
+known_false_positives: |
+  Because these extensions are not typically used in normal operations, you should investigate all results.
 references: []
 drilldown_searches:
-- name: View the detection results for - "$user$" and "$dest$"
-  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$user$" and "$dest$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
-    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
-    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
-    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
-    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
-    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
+  - name: View the detection results for - "$user$" and "$dest$"
+    search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$user$" and "$dest$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+      "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+      as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+      Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+      as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+      by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
 rba:
-  message: File writes $file_name$ with extensions consistent with a SamSam ransomware
-    attack seen on $dest$
+  message: The $file_name$ with extensions consistent with a SamSam ransomware attack seen on $dest$
   risk_objects:
-  - field: user
-    type: user
-    score: 90
-  - field: dest
-    type: system
-    score: 90
+    - field: user
+      type: user
+      score: 90
+    - field: dest
+      type: system
+      score: 90
   threat_objects:
-  - field: file_name
-    type: file_name
+    - field: file_name
+      type: file_name
 tags:
   analytic_story:
-  - SamSam Ransomware
-  - Hellcat Ransomware
+    - SamSam Ransomware
+    - Hellcat Ransomware
   asset_type: Endpoint
   product:
-  - Splunk Enterprise
-  - Splunk Enterprise Security
-  - Splunk Cloud
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
   security_domain: endpoint
 tests:
-- name: True Positive Test
-  attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1036.003/samsam_extension/windows-sysmon.log
-    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    sourcetype: XmlWinEventLog
+  - name: True Positive Test
+    attack_data:
+    - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1036.003/samsam_extension/windows-sysmon.log
+      source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+      sourcetype: XmlWinEventLog

--- a/detections/endpoint/windows_dotnet_binary_in_non_standard_path.yml
+++ b/detections/endpoint/windows_dotnet_binary_in_non_standard_path.yml
@@ -1,7 +1,7 @@
 name: Windows DotNet Binary in Non Standard Path
 id: fddf3b56-7933-11ec-98a6-acde48001122
-version: 10
-date: '2025-12-13'
+version: 11
+date: '2026-01-19'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -30,6 +30,14 @@ search: |
         "*:\\Windows\\SysWOW64\\*",
         "*:\\Windows\\WinSxS\\*"
       )
+  (
+    [ | inputlookup is_net_windows_file
+      | search netFile=true
+      | fields originalFileName
+      | rename originalFileName as Processes.original_file_name
+      | format
+    ]
+  )
   by Processes.action Processes.dest Processes.original_file_name Processes.parent_process
      Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id
      Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec

--- a/detections/endpoint/windows_dotnet_binary_in_non_standard_path.yml
+++ b/detections/endpoint/windows_dotnet_binary_in_non_standard_path.yml
@@ -1,6 +1,6 @@
 name: Windows DotNet Binary in Non Standard Path
 id: fddf3b56-7933-11ec-98a6-acde48001122
-version: 11
+version: 10
 date: '2026-01-19'
 author: Michael Haag, Splunk
 status: production

--- a/detections/endpoint/windows_dotnet_binary_in_non_standard_path.yml
+++ b/detections/endpoint/windows_dotnet_binary_in_non_standard_path.yml
@@ -5,18 +5,16 @@ date: '2026-01-19'
 author: Michael Haag, Splunk
 status: production
 type: TTP
-description: The following analytic detects the execution of native .NET binaries
-  from non-standard directories within the Windows operating system. It leverages
-  Endpoint Detection and Response (EDR) telemetry, comparing process names and original
-  file names against a predefined lookup "is_net_windows_file".
-  This activity is significant because adversaries may move .NET binaries to unconventional
-  paths to evade detection and execute malicious code. If confirmed malicious, this
-  behavior could allow attackers to execute arbitrary code, escalate privileges, or
-  maintain persistence within the environment, posing a significant security risk.
+description: |
+  The following analytic detects the execution of native .NET binaries from non-standard directories within the Windows operating system.
+  It leverages Endpoint Detection and Response (EDR) telemetry, comparing process names and original file names against a predefined lookup "is_net_windows_file".
+  This activity is significant because adversaries may move .NET binaries to unconventional paths to evade detection and execute malicious code.
+  If confirmed malicious, this behavior could allow attackers to execute arbitrary code, escalate privileges, or maintain persistence within the environment, posing a significant security risk.
+  Also this analytic leverages a sub-search to enhance performance. sub-searches have limitations on the amount of data they can return. Keep this in mind if you have an extensive list of ransomware note file names.
 data_source:
-- Sysmon EventID 1
-- Windows Event Log Security 4688
-- CrowdStrike ProcessRollup2
+  - Sysmon EventID 1
+  - Windows Event Log Security 4688
+  - CrowdStrike ProcessRollup2
 search: |
   | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
   as lastTime
@@ -50,7 +48,8 @@ search: |
   | lookup update=true is_net_windows_file originalFileName as original_file_name OUTPUT netFile
   | search netFile=true
   | `windows_dotnet_binary_in_non_standard_path_filter`
-how_to_implement: The detection is based on data that originates from Endpoint Detection
+how_to_implement: |
+  The detection is based on data that originates from Endpoint Detection
   and Response (EDR) agents. These agents are designed to provide security-related
   telemetry from the endpoints where the agent is installed. To implement this search,
   you must ingest logs that contain the process GUID, process name, and parent process.
@@ -63,59 +62,59 @@ known_false_positives: False positives may be present and filtering may be requi
   Certain utilities will run from non-standard paths based on the third-party application
   in use.
 references:
-- https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1036.003/T1036.003.yaml
-- https://attack.mitre.org/techniques/T1036/003/
-- https://www.microsoft.com/security/blog/2022/01/15/destructive-malware-targeting-ukrainian-organizations/
-- https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.004/T1218.004.md
+  - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1036.003/T1036.003.yaml
+  - https://attack.mitre.org/techniques/T1036/003/
+  - https://www.microsoft.com/security/blog/2022/01/15/destructive-malware-targeting-ukrainian-organizations/
+  - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.004/T1218.004.md
 drilldown_searches:
-- name: View the detection results for - "$user$" and "$dest$"
-  search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$user$" and "$dest$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
-    "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
-    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
-    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
-    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
-    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
+  - name: View the detection results for - "$user$" and "$dest$"
+    search: '%original_detection_search% | search  user = "$user$" dest = "$dest$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$user$" and "$dest$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$",
+      "$dest$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+      as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+      Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+      as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+      by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
 rba:
   message: An instance of $parent_process_name$ spawning $process_name$ from a non-standard
     path was identified on endpoint $dest$ by user $user$.
   risk_objects:
-  - field: user
-    type: user
-    score: 49
-  - field: dest
-    type: system
-    score: 49
+    - field: user
+      type: user
+      score: 49
+    - field: dest
+      type: system
+      score: 49
   threat_objects:
-  - field: parent_process_name
-    type: parent_process_name
-  - field: process_name
-    type: process_name
+    - field: parent_process_name
+      type: parent_process_name
+    - field: process_name
+      type: process_name
 tags:
   analytic_story:
-  - Masquerading - Rename System Utilities
-  - Ransomware
-  - Unusual Processes
-  - Signed Binary Proxy Execution InstallUtil
-  - Data Destruction
-  - WhisperGate
+    - Masquerading - Rename System Utilities
+    - Ransomware
+    - Unusual Processes
+    - Signed Binary Proxy Execution InstallUtil
+    - Data Destruction
+    - WhisperGate
   asset_type: Endpoint
   mitre_attack_id:
-  - T1036.003
-  - T1218.004
+    - T1036.003
+    - T1218.004
   product:
-  - Splunk Enterprise
-  - Splunk Enterprise Security
-  - Splunk Cloud
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
   security_domain: endpoint
 tests:
-- name: True Positive Test
-  attack_data:
-  - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1218.004/atomic_red_team/windows-sysmon_installutil_path.log
-    source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    sourcetype: XmlWinEventLog
+  - name: True Positive Test
+    attack_data:
+    - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1218.004/atomic_red_team/windows-sysmon_installutil_path.log
+      source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+      sourcetype: XmlWinEventLog

--- a/detections/endpoint/windows_nirsoft_utilities.yml
+++ b/detections/endpoint/windows_nirsoft_utilities.yml
@@ -5,13 +5,13 @@ date: '2025-12-13'
 author: Michael Haag, Splunk
 status: production
 type: Hunting
-description: The following analytic identifies the execution of commonly used NirSoft
-  utilities on Windows systems. It leverages data from Endpoint Detection and Response
-  (EDR) agents, focusing on process execution details such as process name, parent
-  process, and command-line arguments. This activity is significant for a SOC because
-  NirSoft utilities, while legitimate, can be used by adversaries for malicious purposes
-  like credential theft or system reconnaissance. If confirmed malicious, this activity
-  could lead to unauthorized access, data exfiltration, or further system compromise.
+description: |
+  The following analytic identifies the execution of commonly used NirSoft utilities on Windows systems.
+  It leverages data from Endpoint Detection and Response (EDR) agents, focusing on process execution details such as process name, parent process, and command-line arguments.
+  This activity is significant for a SOC because NirSoft utilities, while legitimate, can be used by adversaries for malicious purposes like credential theft or system reconnaissance.
+  If confirmed malicious, this activity could lead to unauthorized access, data exfiltration, or further system compromise.
+  Note that this search does not use a where clause to filter out known benign paths, as NirSoft utilities can be executed from various locations. This might hinder performance in environments with high data volumes.
+  Apply additional filtering as necessary to enhance this.
 data_source:
 - Sysmon EventID 1
 - Windows Event Log Security 4688

--- a/detections/network/3cx_supply_chain_attack_network_indicators.yml
+++ b/detections/network/3cx_supply_chain_attack_network_indicators.yml
@@ -20,7 +20,7 @@ search: |
     count min(_time) as firstTime
           max(_time) as lastTime
   from datamodel=Network_Resolution
-  where isnotnull(DNS.query) AND DNS.query!=""
+  where DNS.query=*
   by DNS.answer DNS.answer_count DNS.query
      DNS.query_count DNS.reply_code_id DNS.src
      DNS.vendor_product

--- a/detections/network/3cx_supply_chain_attack_network_indicators.yml
+++ b/detections/network/3cx_supply_chain_attack_network_indicators.yml
@@ -19,8 +19,9 @@ search: |
   | tstats `security_content_summariesonly`
     count min(_time) as firstTime
           max(_time) as lastTime
-  from datamodel=Network_Resolution
-  where DNS.query=*
+  from datamodel=Network_Resolution where
+  DNS.query=*
+  NOT DNS.query IN ("-", "unknown")
   by DNS.answer DNS.answer_count DNS.query
      DNS.query_count DNS.reply_code_id DNS.src
      DNS.vendor_product

--- a/detections/network/3cx_supply_chain_attack_network_indicators.yml
+++ b/detections/network/3cx_supply_chain_attack_network_indicators.yml
@@ -1,7 +1,7 @@
 name: 3CX Supply Chain Attack Network Indicators
 id: 791b727c-deec-4fbe-a732-756131b3c5a1
-version: 7
-date: '2025-06-10'
+version: 8
+date: '2026-01-19'
 author: Michael Haag, Splunk
 status: production
 type: TTP
@@ -15,11 +15,21 @@ description: The following analytic identifies DNS queries to domains associated
   and data breaches.
 data_source:
 - Sysmon EventID 22
-search: '| tstats `security_content_summariesonly` min(_time) as firstTime from datamodel=Network_Resolution
-  by DNS.answer DNS.answer_count DNS.query DNS.query_count DNS.reply_code_id DNS.src
-  DNS.vendor_product | `drop_dm_object_name(DNS)` | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` | lookup 3cx_ioc_domains domain as query OUTPUT
-  Description isIOC | search isIOC=true | `3cx_supply_chain_attack_network_indicators_filter`'
+search: |
+  | tstats `security_content_summariesonly`
+    count min(_time) as firstTime
+          max(_time) as lastTime
+  from datamodel=Network_Resolution
+  where isnotnull(DNS.query) AND DNS.query!=""
+  by DNS.answer DNS.answer_count DNS.query
+     DNS.query_count DNS.reply_code_id DNS.src
+     DNS.vendor_product
+  | `drop_dm_object_name(DNS)`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | lookup 3cx_ioc_domains domain as query OUTPUT Description isIOC
+  | search isIOC=true
+  | `3cx_supply_chain_attack_network_indicators_filter`
 how_to_implement: To successfully implement this search you need to be ingesting information
   into the `Network Resolution` datamodel in the `DNS` node. In addition, confirm
   the latest CIM App 4.20 or higher is installed and the latest TA''s are installed.

--- a/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
+++ b/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
@@ -1,6 +1,6 @@
 name: Detect hosts connecting to dynamic domain providers
 id: a1e761ac-1344-4dbd-88b2-3f34c912d359
-version: 10
+version: 9
 date: '2026-01-19'
 author: Bhavin Patel, Splunk
 status: production

--- a/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
+++ b/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
@@ -17,8 +17,9 @@ data_source:
 - Sysmon EventID 22
 search: |
   | tstats `security_content_summariesonly` count min(_time) as firstTime
-    from datamodel=Network_Resolution
-    where DNS.query=*
+    from datamodel=Network_Resolution where
+    DNS.query=*
+    NOT DNS.query IN ("-", "unknown")
     by DNS.answer DNS.answer_count DNS.query DNS.query_count
        DNS.reply_code_id DNS.src DNS.vendor_product
   | `drop_dm_object_name("DNS")`

--- a/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
+++ b/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
@@ -1,7 +1,7 @@
 name: Detect hosts connecting to dynamic domain providers
 id: a1e761ac-1344-4dbd-88b2-3f34c912d359
-version: 9
-date: '2025-12-18'
+version: 10
+date: '2026-01-19'
 author: Bhavin Patel, Splunk
 status: production
 type: TTP
@@ -18,6 +18,7 @@ data_source:
 search: |
   | tstats `security_content_summariesonly` count min(_time) as firstTime
     from datamodel=Network_Resolution
+    where isnotnull(DNS.query) AND DNS.query!=""
     by DNS.answer DNS.answer_count DNS.query DNS.query_count
        DNS.reply_code_id DNS.src DNS.vendor_product
   | `drop_dm_object_name("DNS")`

--- a/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
+++ b/detections/network/detect_hosts_connecting_to_dynamic_domain_providers.yml
@@ -18,7 +18,7 @@ data_source:
 search: |
   | tstats `security_content_summariesonly` count min(_time) as firstTime
     from datamodel=Network_Resolution
-    where isnotnull(DNS.query) AND DNS.query!=""
+    where DNS.query=*
     by DNS.answer DNS.answer_count DNS.query DNS.query_count
        DNS.reply_code_id DNS.src DNS.vendor_product
   | `drop_dm_object_name("DNS")`

--- a/detections/network/detect_remote_access_software_usage_dns.yml
+++ b/detections/network/detect_remote_access_software_usage_dns.yml
@@ -18,8 +18,9 @@ search: |
   | tstats `security_content_summariesonly`
     count min(_time) as firstTime
           max(_time) as lastTime
-  from datamodel=Network_Resolution
-  where DNS.query=*
+  from datamodel=Network_Resolution where
+  DNS.query=*
+  NOT DNS.query IN ("-", "unknown")
   by DNS.answer DNS.answer_count DNS.query
      DNS.query_count DNS.reply_code_id DNS.src
      DNS.vendor_product

--- a/detections/network/detect_remote_access_software_usage_dns.yml
+++ b/detections/network/detect_remote_access_software_usage_dns.yml
@@ -19,7 +19,7 @@ search: |
     count min(_time) as firstTime
           max(_time) as lastTime
   from datamodel=Network_Resolution
-  where isnotnull(DNS.query) AND DNS.query!=""
+  where DNS.query=*
   by DNS.answer DNS.answer_count DNS.query
      DNS.query_count DNS.reply_code_id DNS.src
      DNS.vendor_product

--- a/detections/network/detect_remote_access_software_usage_dns.yml
+++ b/detections/network/detect_remote_access_software_usage_dns.yml
@@ -1,7 +1,7 @@
 name: Detect Remote Access Software Usage DNS
 id: a16b797d-e309-41bd-8ba0-5067dae2e4be
-version: 10
-date: '2025-10-14'
+version: 11
+date: '2026-01-19'
 author: Steven Dick
 status: production
 type: Anomaly
@@ -14,13 +14,24 @@ description: The following analytic detects DNS queries to domains associated
   impacts if these threats are not mitigated promptly.
 data_source:
 - Sysmon EventID 22
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime from datamodel=Network_Resolution by DNS.answer DNS.answer_count DNS.query
-  DNS.query_count DNS.reply_code_id DNS.src DNS.vendor_product | `drop_dm_object_name("DNS")`
-  | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | lookup
-  remote_access_software remote_domain AS query OUTPUT isutility, description as signature,
-  comment_reference as desc, category | eval dest = query | search isutility = True
-  | `remote_access_software_usage_exceptions` | `detect_remote_access_software_usage_dns_filter`'
+search: |
+  | tstats `security_content_summariesonly`
+    count min(_time) as firstTime
+          max(_time) as lastTime
+  from datamodel=Network_Resolution
+  where isnotnull(DNS.query) AND DNS.query!=""
+  by DNS.answer DNS.answer_count DNS.query
+     DNS.query_count DNS.reply_code_id DNS.src
+     DNS.vendor_product
+  | `drop_dm_object_name("DNS")`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | lookup remote_access_software remote_domain AS query OUTPUT isutility, description as signature,
+  comment_reference as desc, category
+  | eval dest = query
+  | search isutility = True
+  | `remote_access_software_usage_exceptions`
+  | `detect_remote_access_software_usage_dns_filter`
 how_to_implement: To implement this search, you must ingest logs that contain 
   the DNS query and the source of the query. These logs must be processed using 
   the appropriate Splunk Technology Add-ons that are specific to the DNS logs. 

--- a/detections/network/detect_remote_access_software_usage_traffic.yml
+++ b/detections/network/detect_remote_access_software_usage_traffic.yml
@@ -1,7 +1,7 @@
 name: Detect Remote Access Software Usage Traffic
 id: 885ea672-07ee-475a-879e-60d28aa5dd42
-version: 11
-date: '2025-10-14'
+version: 12
+date: '2026-01-19'
 author: Steven Dick
 status: production
 type: Anomaly
@@ -15,16 +15,27 @@ description: The following analytic detects network traffic associated with
   malware, posing a severe threat to the organization's security.
 data_source:
 - Palo Alto Network Traffic
-search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time)
-  as lastTime values(All_Traffic.dest_port) as dest_port latest(All_Traffic.user)
-  as user from datamodel=Network_Traffic by All_Traffic.action All_Traffic.app All_Traffic.bytes
-  All_Traffic.bytes_in All_Traffic.bytes_out All_Traffic.dest All_Traffic.dest_ip
-  All_Traffic.dest_port All_Traffic.dvc All_Traffic.protocol All_Traffic.protocol_version
-  All_Traffic.src All_Traffic.src_ip All_Traffic.src_port All_Traffic.transport All_Traffic.user
-  All_Traffic.vendor_product | `drop_dm_object_name("All_Traffic")` | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` | lookup remote_access_software remote_appid
-  AS app OUTPUT isutility, description as signature, comment_reference as desc, category
-  | search isutility = True | `remote_access_software_usage_exceptions` | `detect_remote_access_software_usage_traffic_filter`'
+search: |
+  | tstats `security_content_summariesonly`
+    count min(_time) as firstTime
+          max(_time) as lastTime
+          values(All_Traffic.dest_port) as dest_port
+          latest(All_Traffic.user) as user
+  from datamodel=Network_Traffic
+  where isnotnull(All_Traffic.app) AND All_Traffic.app!=""
+  by All_Traffic.action All_Traffic.app All_Traffic.bytes All_Traffic.bytes_in
+     All_Traffic.bytes_out All_Traffic.dest All_Traffic.dest_ip
+     All_Traffic.dest_port All_Traffic.dvc All_Traffic.protocol
+     All_Traffic.protocol_version All_Traffic.src All_Traffic.src_ip
+     All_Traffic.src_port All_Traffic.transport All_Traffic.user
+     All_Traffic.vendor_product
+  | `drop_dm_object_name("All_Traffic")`
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | lookup remote_access_software remote_appid AS app OUTPUT isutility, description as signature, comment_reference as desc, category
+  | search isutility = True
+  | `remote_access_software_usage_exceptions`
+  | `detect_remote_access_software_usage_traffic_filter`
 how_to_implement: The following analytic was developed with Palo Alto traffic 
   logs. Ensure that the logs are being ingested into Splunk and mapped to the 
   Network_Traffic data model. Use the Splunk Common Information Model (CIM) to 

--- a/detections/network/detect_remote_access_software_usage_traffic.yml
+++ b/detections/network/detect_remote_access_software_usage_traffic.yml
@@ -22,7 +22,7 @@ search: |
           values(All_Traffic.dest_port) as dest_port
           latest(All_Traffic.user) as user
   from datamodel=Network_Traffic
-  where isnotnull(All_Traffic.app) AND All_Traffic.app!=""
+  where All_Traffic.app=*
   by All_Traffic.action All_Traffic.app All_Traffic.bytes All_Traffic.bytes_in
      All_Traffic.bytes_out All_Traffic.dest All_Traffic.dest_ip
      All_Traffic.dest_port All_Traffic.dvc All_Traffic.protocol

--- a/detections/network/detect_remote_access_software_usage_traffic.yml
+++ b/detections/network/detect_remote_access_software_usage_traffic.yml
@@ -21,8 +21,9 @@ search: |
           max(_time) as lastTime
           values(All_Traffic.dest_port) as dest_port
           latest(All_Traffic.user) as user
-  from datamodel=Network_Traffic
-  where All_Traffic.app=*
+  from datamodel=Network_Traffic where
+  All_Traffic.app=*
+  NOT All_Traffic.app IN ("-", "unknown")
   by All_Traffic.action All_Traffic.app All_Traffic.bytes All_Traffic.bytes_in
      All_Traffic.bytes_out All_Traffic.dest All_Traffic.dest_ip
      All_Traffic.dest_port All_Traffic.dvc All_Traffic.protocol

--- a/detections/web/detect_remote_access_software_usage_url.yml
+++ b/detections/web/detect_remote_access_software_usage_url.yml
@@ -24,7 +24,7 @@ search: |
                  latest(Web.user) as user
                  latest(Web.dest) as dest
   from datamodel=Web
-  where isnotnull(Web.url_domain) AND Web.url_domain!=""
+  where Web.url_domain=*
   by Web.action Web.src Web.category Web.url_domain Web.url_length
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`

--- a/detections/web/detect_remote_access_software_usage_url.yml
+++ b/detections/web/detect_remote_access_software_usage_url.yml
@@ -1,101 +1,112 @@
 name: Detect Remote Access Software Usage URL
 id: 9296f515-073c-43a5-88ec-eda5a4626654
-version: 11
-date: '2025-10-14'
+version: 12
+date: '2026-01-19'
 author: Steven Dick
 status: production
 type: Anomaly
 description: The following analytic detects the execution of known remote access
-  software within the environment. It leverages network logs mapped to the Web 
-  data model, identifying specific URLs and user agents associated with remote 
+  software within the environment. It leverages network logs mapped to the Web
+  data model, identifying specific URLs and user agents associated with remote
   access tools like AnyDesk, GoToMyPC, LogMeIn, and TeamViewer. This activity is
-  significant as adversaries often use these utilities to maintain unauthorized 
-  remote access. If confirmed malicious, this could allow attackers to control 
+  significant as adversaries often use these utilities to maintain unauthorized
+  remote access. If confirmed malicious, this could allow attackers to control
   systems remotely, exfiltrate data, or further compromise the network, posing a
   severe security risk.
 data_source:
 - Palo Alto Network Threat
-search: '| tstats count min(_time) as firstTime max(_time) as lastTime latest(Web.http_method)
-  as http_method latest(Web.http_user_agent) as http_user_agent latest(Web.url) as
-  url latest(Web.user) as user latest(Web.dest) as dest from datamodel=Web by Web.action
-  Web.src Web.category Web.url_domain Web.url_length | `security_content_ctime(firstTime)`
-  | `security_content_ctime(lastTime)` | `drop_dm_object_name("Web")` | lookup remote_access_software
-  remote_domain AS url_domain OUTPUT isutility, description as signature, comment_reference
-  as desc, category | search isutility = True | `remote_access_software_usage_exceptions`
-  | `detect_remote_access_software_usage_url_filter`'
-how_to_implement: The detection is based on data that originates from network 
-  logs. These logs must be processed using the appropriate Splunk Technology 
+search: |
+  | tstats count min(_time) as firstTime
+                 max(_time) as lastTime
+                 latest(Web.http_method) as http_method
+                 latest(Web.http_user_agent) as http_user_agent
+                 latest(Web.url) as url
+                 latest(Web.user) as user
+                 latest(Web.dest) as dest
+  from datamodel=Web
+  where isnotnull(Web.url_domain) AND Web.url_domain!=""
+  by Web.action Web.src Web.category Web.url_domain Web.url_length
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `drop_dm_object_name("Web")`
+  | lookup remote_access_software remote_domain AS url_domain OUTPUT isutility, description as signature, comment_reference
+  as desc, category
+  | search isutility = True
+  | `remote_access_software_usage_exceptions`
+  | `detect_remote_access_software_usage_url_filter`
+how_to_implement: The detection is based on data that originates from network
+  logs. These logs must be processed using the appropriate Splunk Technology
   Add-ons that are specific to the network logs. The logs must also be mapped to
-  the `Web` data model. Use the Splunk Common Information Model (CIM) to 
-  normalize the field names and speed up the data modeling process. The 
-  "exceptions" macro leverages both an Assets and Identities lookup, as well as 
-  a KVStore collection called "remote_software_exceptions" that lets you track 
+  the `Web` data model. Use the Splunk Common Information Model (CIM) to
+  normalize the field names and speed up the data modeling process. The
+  "exceptions" macro leverages both an Assets and Identities lookup, as well as
+  a KVStore collection called "remote_software_exceptions" that lets you track
   and maintain device- based exceptions for this set of detections.
-known_false_positives: It is possible that legitimate remote access software is 
-  used within the environment. Ensure that the lookup is reviewed and updated 
-  with any additional remote access software that is used within the 
-  environment. Known false positives can be added to the 
-  remote_access_software_usage_exception.csv lookup to globally suppress these 
+known_false_positives: It is possible that legitimate remote access software is
+  used within the environment. Ensure that the lookup is reviewed and updated
+  with any additional remote access software that is used within the
+  environment. Known false positives can be added to the
+  remote_access_software_usage_exception.csv lookup to globally suppress these
   situations across all remote access content
 references:
-- https://attack.mitre.org/techniques/T1219/
-- https://thedfirreport.com/2022/08/08/bumblebee-roasts-its-way-to-domain-admin/
-- https://thedfirreport.com/2022/11/28/emotet-strikes-again-lnk-file-leads-to-domain-wide-ransomware/
+  - https://attack.mitre.org/techniques/T1219/
+  - https://thedfirreport.com/2022/08/08/bumblebee-roasts-its-way-to-domain-admin/
+  - https://thedfirreport.com/2022/11/28/emotet-strikes-again-lnk-file-leads-to-domain-wide-ransomware/
 drilldown_searches:
-- name: View the detection results for - "$src$" and "$user$"
-  search: '%original_detection_search% | search  src = "$src$" user = "$user$"'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$src$" and "$user$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$",
-    "$user$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
-    as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
-    Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
-    as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
-    by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: Investigate traffic to $url_domain$
-  search: '| from datamodel:Web | search src=$src$ url_domain=$url_domain$'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
+  - name: View the detection results for - "$src$" and "$user$"
+    search: '%original_detection_search% | search  src = "$src$" user = "$user$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$src$" and "$user$"
+    search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$src$",
+      "$user$") starthoursago=168  | stats count min(_time) as firstTime max(_time)
+      as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk
+      Message" values(analyticstories) as "Analytic Stories" values(annotations._all)
+      as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics"
+      by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: Investigate traffic to $url_domain$
+    search: '| from datamodel:Web | search src=$src$ url_domain=$url_domain$'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
 rba:
-  message: A domain for a known remote access software $url_domain$ was 
+  message: A domain for a known remote access software $url_domain$ was
     contacted by $src$.
   risk_objects:
-  - field: src
-    type: system
-    score: 25
-  - field: user
-    type: user
-    score: 25
+    - field: src
+      type: system
+      score: 25
+    - field: user
+      type: user
+      score: 25
   threat_objects:
-  - field: url_domain
-    type: domain
-  - field: signature
-    type: signature
+    - field: url_domain
+      type: domain
+    - field: signature
+      type: signature
 tags:
   analytic_story:
-  - Insider Threat
-  - Command And Control
-  - Ransomware
-  - CISA AA24-241A
-  - Remote Monitoring and Management Software
-  - Interlock Ransomware
-  - Scattered Lapsus$ Hunters
+    - Insider Threat
+    - Command And Control
+    - Ransomware
+    - CISA AA24-241A
+    - Remote Monitoring and Management Software
+    - Interlock Ransomware
+    - Scattered Lapsus$ Hunters
   asset_type: Network
   mitre_attack_id:
-  - T1219
+    - T1219
   product:
-  - Splunk Enterprise
-  - Splunk Enterprise Security
-  - Splunk Cloud
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
   security_domain: network
   manual_test: This detection uses A&I lookups from Enterprise Security.
 tests:
-- name: True Positive Test
-  attack_data:
-  - data: 
-      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1219/screenconnect/screenconnect_palo.log
-    source: screenconnect_palo
-    sourcetype: pan:threat
+  - name: True Positive Test
+    attack_data:
+    - data:
+        https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1219/screenconnect/screenconnect_palo.log
+      source: screenconnect_palo
+      sourcetype: pan:threat

--- a/detections/web/detect_remote_access_software_usage_url.yml
+++ b/detections/web/detect_remote_access_software_usage_url.yml
@@ -23,8 +23,9 @@ search: |
                  latest(Web.url) as url
                  latest(Web.user) as user
                  latest(Web.dest) as dest
-  from datamodel=Web
-  where Web.url_domain=*
+  from datamodel=Web where
+  Web.url_domain=*
+  NOT Web.url_domain IN ("-", "unknown")
   by Web.action Web.src Web.category Web.url_domain Web.url_length
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`

--- a/lookups/ransomware_notes_lookup.csv
+++ b/lookups/ransomware_notes_lookup.csv
@@ -74,5 +74,5 @@ read_it.txt,True
 How_to_back_files.HTML,True
 CriticalBreachDetected.pdf,True
 How To Restore Your Files.txt, True
- !__README__!.txt, True
- unlock_please_view_this_file.html, True
+!__README__!.txt, True
+unlock_please_view_this_file.html, True


### PR DESCRIPTION
This PR enhances the performance of a couple of detections as part of a continued effort that I was tracking from the issue #3809. Details are below.

> **Note All tests were executed on Endor**
> **First batch was addressed in https://github.com/splunk/security_content/pull/3850**

### Updated Analytics [11]

- `Common Ransomware Notes` - From 164 seconds to 33.44 seconds - Switch to using a subsearch since the lookup is small enough. Added a warning in the description to inform the user about this too.
- `File with Samsam Extension` - From 160 seconds to 11 seconds - Moved the extension search to the `where` and kept the extraction for better output.
- `Detect Rare Executables` - From 300~ seconds to 100~ seconds - Reduces usage of `values` and switched them to `latest` so that we can reduce MV calcs which are expensive.
- `3CX Supply Chain Attack Network Indicators` - Added a where clause with `DNS.query=*` to ensure the existence of the field, since it is used as a filter in the lookup. This is a best effort and will only reduce search time by some time. The same thing was applied to the following `Detect hosts connecting to dynamic domain providers`, `Detect Remote Access Software Usage DNS`
- `Detect Remote Access Software Usage URL` -  Added a where clause with `Web.url_domain=*` to ensure the existence of the field, since it is used as a filter in the lookup. 
- `Detect Remote Access Software Usage Traffic` - Added a where clause with `All_Traffic.app=*` to ensure the existence of the field, since it is used as a filter in the lookup.
- `Common Ransomware Extensions` - To enhance this we added filter for known extensions to reduce the search space. By excluding stuff like `.exe`...etc from file creation we already get rid of a lot. This can ofc be further enhanced by adding more to the list.
- `Detect Remote Access Software Usage File` - In order to also enhance perf, we allow only the extensions that are referenced by the lookup itself. Because this is using an file creation event, this will reduce the search space by a lot.
- `Windows DotNet Binary in Non Standard Path` - From 852 seconds to 7 seconds - Using a subsearch to enhance performance with the accepted limitation just because the lookup is small. 