### PR TITLE
Fix search mistake in windows abused web services

### DIFF
--- a/detections/network/windows_abused_web_services.yml
+++ b/detections/network/windows_abused_web_services.yml
@@ -14,7 +14,7 @@ description: The following analytic detects a suspicious process making DNS quer
   significant as it may indicate an adversary attempting to download malicious files,
   a common initial access technique. If confirmed malicious, this could lead to unauthorized
   code execution, data exfiltration, or further compromise of the target host.
-search: '`sysmon` EventCode=22 QueryName IN ("*pastebin*",""*textbin*"", "*ngrok.io*",
+search: '`sysmon` EventCode=22 QueryName IN ("*pastebin*","*textbin*", "*ngrok.io*",
   "*discord*", "*duckdns.org*", "*pasteio.com*") | stats count min(_time) as firstTime
   max(_time) as lastTime by answer answer_count dvc process_exec process_guid process_name
   query query_count reply_code_id signature signature_id src user_id vendor_product

--- a/detections/network/windows_abused_web_services.yml
+++ b/detections/network/windows_abused_web_services.yml
@@ -1,7 +1,7 @@
 name: Windows Abused Web Services
 id: 01f0aef4-8591-4daa-a53d-0ed49823b681
-version: 7
-date: '2025-05-26'
+version: 8
+date: '2026-01-24'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP


### PR DESCRIPTION
### Details

fix grammar mistake for search query in windows_abused_web_services.yml
<img width="711" height="108" alt="image" src="https://github.com/user-attachments/assets/dcad611f-f568-4cad-aff3-c0bf416b0221" />

This grammar mistake found by [spl_validator](https://github.com/aaaAlexanderaaa/spl_validator).

### Checklist

- [ no related changes] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [✔️ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [✔️ ] Validated SPL logic.
- [no related changes ] Validated tags, description, and how to implement.
- [ no related changes ] Verified references match analytic.
- [ no related changes ] Confirm updates to lookups are handled properly.
