### PR TITLE
fix: adding firstTime and lastTime for "Set Default PowerShell Execut…

### DIFF
--- a/detections/endpoint/set_default_powershell_execution_policy_to_unrestricted_or_bypass.yml
+++ b/detections/endpoint/set_default_powershell_execution_policy_to_unrestricted_or_bypass.yml
@@ -1,6 +1,5 @@
 name: Set Default PowerShell Execution Policy To Unrestricted or Bypass
 id: c2590137-0b08-4985-9ec5-6ae23d92f63d
-version: 17
 version: 18
 date: '2026-01-30'
 author: Steven Dick, Patrick Bareiss, Splunk

--- a/detections/endpoint/set_default_powershell_execution_policy_to_unrestricted_or_bypass.yml
+++ b/detections/endpoint/set_default_powershell_execution_policy_to_unrestricted_or_bypass.yml
@@ -14,7 +14,7 @@ description: The following analytic detects changes to the PowerShell ExecutionP
   to further compromise of the system and potential escalation of privileges.
 data_source:
 - Sysmon EventID 13
-search: '| tstats `security_content_summariesonly` count FROM datamodel=Endpoint.Registry
+search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Registry
   WHERE (Registry.registry_path=*Software\\Microsoft\\Powershell\\1\\ShellIds\\Microsoft.PowerShell*
   Registry.registry_value_name=ExecutionPolicy (Registry.registry_value_data=Unrestricted
   OR Registry.registry_value_data=Bypass)) by Registry.action Registry.dest Registry.process_guid

--- a/detections/endpoint/set_default_powershell_execution_policy_to_unrestricted_or_bypass.yml
+++ b/detections/endpoint/set_default_powershell_execution_policy_to_unrestricted_or_bypass.yml
@@ -1,7 +1,8 @@
 name: Set Default PowerShell Execution Policy To Unrestricted or Bypass
 id: c2590137-0b08-4985-9ec5-6ae23d92f63d
 version: 17
-date: '2025-06-10'
+version: 18
+date: '2026-01-30'
 author: Steven Dick, Patrick Bareiss, Splunk
 status: production
 type: TTP


### PR DESCRIPTION
### Details

Adding missing fields `firstTime `and `lastTime` for **Set Default PowerShell Execution Policy To Unrestricted or Bypass**

### Checklist

- [x] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [x] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [x] Validated SPL logic.
- [x] Validated tags, description, and how to implement.
- [x] Verified references match analytic.
- [x] Confirm updates to lookups are handled properly.