### PR TITLE
XML Windows Event Log Cleanup continued

### DIFF
--- a/detections/endpoint/kerberos_pre_authentication_flag_disabled_in_useraccountcontrol.yml
+++ b/detections/endpoint/kerberos_pre_authentication_flag_disabled_in_useraccountcontrol.yml
@@ -1,11 +1,12 @@
 name: Kerberos Pre-Authentication Flag Disabled in UserAccountControl
 id: 0cb847ee-9423-11ec-b2df-acde48001122
-version: 8
-date: '2026-01-14'
+version: 9
+date: '2026-02-02'
 author: Mauricio Velazco, Splunk
 status: production
 type: TTP
-description: The following analytic detects when the Kerberos Pre-Authentication flag
+description:
+  The following analytic detects when the Kerberos Pre-Authentication flag
   is disabled in a user account, using Windows Security Event 4738. This event indicates
   a change in the UserAccountControl property of a domain user object. Disabling this
   flag allows adversaries to perform offline brute force attacks on the user's password
@@ -14,57 +15,59 @@ description: The following analytic detects when the Kerberos Pre-Authentication
   If confirmed malicious, this could lead to unauthorized access and potential compromise
   of sensitive information.
 data_source:
-- Windows Event Log Security 4738
+  - Windows Event Log Security 4738
 search: >
-  `wineventlog_security` EventCode=4738 MSADChangedAttributes="*\'Don\'t Require Preauth\'
-  - Enabled*" |rename Account_Name as user | table EventCode, user, dest, Security_ID,
-  MSADChangedAttributes | `kerberos_pre_authentication_flag_disabled_in_useraccountcontrol_filter`
-how_to_implement: To successfully implement this search, you need to be ingesting
+  `wineventlog_security` EventCode=4738 UserAccountControl="*%%2096*"
+  | rename Account_Name as user, SubjectUserName as actor | stats count earliest(_time) as firstTime latest(_time) as lastTime by actor, user, dest
+  | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
+  | `kerberos_pre_authentication_flag_disabled_in_useraccountcontrol_filter`
+how_to_implement:
+  To successfully implement this search, you need to be ingesting
   Domain Controller events. The Advanced Security Audit policy setting `User Account
   Management` within `Account Management` needs to be enabled.
 known_false_positives: No false positives have been identified at this time.
 references:
-- https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
-- https://m0chan.github.io/2019/07/31/How-To-Attack-Kerberos-101.html
-- https://stealthbits.com/blog/cracking-active-directory-passwords-with-as-rep-roasting/
+  - https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
+  - https://m0chan.github.io/2019/07/31/How-To-Attack-Kerberos-101.html
+  - https://stealthbits.com/blog/cracking-active-directory-passwords-with-as-rep-roasting/
 drilldown_searches:
-- name: View the detection results for - "$user$"
-  search: '%original_detection_search% | search  user = "$user$"'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
-- name: View risk events for the last 7 days for - "$user$"
-  search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$")
-    starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
-    values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
-    as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
-    as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
-    | `security_content_ctime(lastTime)`'
-  earliest_offset: $info_min_time$
-  latest_offset: $info_max_time$
+  - name: View the detection results for - "$user$"
+    search: '%original_detection_search% | search  user = "$user$"'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
+  - name: View risk events for the last 7 days for - "$user$"
+    search:
+      '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user$")
+      starthoursago=168  | stats count min(_time) as firstTime max(_time) as lastTime
+      values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories)
+      as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic)
+      as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)`
+      | `security_content_ctime(lastTime)`'
+    earliest_offset: $info_min_time$
+    latest_offset: $info_max_time$
 rba:
   message: Kerberos Pre Authentication was Disabled for $user$
   risk_objects:
-  - field: user
-    type: user
-    score: 45
+    - field: user
+      type: user
+      score: 45
   threat_objects: []
 tags:
   analytic_story:
-  - Active Directory Kerberos Attacks
-  - BlackSuit Ransomware
+    - Active Directory Kerberos Attacks
+    - BlackSuit Ransomware
   asset_type: Endpoint
   mitre_attack_id:
-  - T1558.004
+    - T1558.004
   product:
-  - Splunk Enterprise
-  - Splunk Enterprise Security
-  - Splunk Cloud
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
   security_domain: endpoint
 tests:
-- name: True Positive Test
-  attack_data:
-  - data: 
-      https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1558.004/powershell/windows-security.log
-    source: WinEventLog:Security
-    sourcetype: WinEventLog
-
+  - name: True Positive Test
+    attack_data:
+      - data: https://media.githubusercontent.com/media/splunk/attack_data/refs/heads/master/datasets/attack_techniques/T1558.004/powershell/windows-security-xml.log
+        source: XmlWinEventLog:Security
+        sourcetype: XmlWinEventLog

--- a/detections/endpoint/kerberos_pre_authentication_flag_disabled_in_useraccountcontrol.yml
+++ b/detections/endpoint/kerberos_pre_authentication_flag_disabled_in_useraccountcontrol.yml
@@ -18,7 +18,7 @@ data_source:
   - Windows Event Log Security 4738
 search: >
   `wineventlog_security` EventCode=4738 UserAccountControl="*%%2096*"
-  | rename Account_Name as user, SubjectUserName as actor | stats count earliest(_time) as firstTime latest(_time) as lastTime by actor, user, dest
+  | rename TargetUserName as user, SubjectUserName as actor | stats count earliest(_time) as firstTime latest(_time) as lastTime by actor, user, dest
   | `security_content_ctime(firstTime)`
   | `security_content_ctime(lastTime)`
   | `kerberos_pre_authentication_flag_disabled_in_useraccountcontrol_filter`


### PR DESCRIPTION
### Details

Previous PR was stale and contained currently unnecessary changes. Ported one detection to XmlWinEventLog

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/9.3.2411/manage-apps-and-add-ons-in-splunk-cloud-platform/manage-private-apps-on-your-splunk-cloud-platform-deployment#ariaid-title7) but the short version is that any changes to lookup files need to bump the the date and version in the associated YAML file.
