### PR TITLE
Remove EXTRA fields

### DIFF
--- a/detections/application/mcp_prompt_injection.yml
+++ b/detections/application/mcp_prompt_injection.yml
@@ -36,7 +36,6 @@ drilldown_searches:
       latest_offset: $info_max_time$
 rba:
     message: 'A prompt injection attempt was detected on $dest$ via MCP server. An attacker attempted to override AI instructions using phrases like IGNORE PREVIOUS INSTRUCTIONS or SYSTEM PROMPT OVERRIDE. This technique (AML.T0051) attempts to manipulate the LLM into bypassing security controls or executing unauthorized actions. Payload detected: $injection_payload$'
-    risk_score: 80
     risk_objects:
         - field: dest
           type: system

--- a/detections/application/ollama_abnormal_network_connectivity.yml
+++ b/detections/application/ollama_abnormal_network_connectivity.yml
@@ -43,7 +43,6 @@ rba:
     threat_objects:
         - field: src
           type: system
-          score: 10
 tags:
     analytic_story:
         - Suspicious Ollama Activities

--- a/detections/endpoint/shai_hulud_2_exfiltration_artifact_files.yml
+++ b/detections/endpoint/shai_hulud_2_exfiltration_artifact_files.yml
@@ -66,7 +66,6 @@ rba:
     threat_objects:
         - field: file_name
           type: file_name
-          score: 25
 tags:
     analytic_story:
         - NPM Supply Chain Compromise

--- a/detections/endpoint/shai_hulud_workflow_file_creation_or_modification.yml
+++ b/detections/endpoint/shai_hulud_workflow_file_creation_or_modification.yml
@@ -81,7 +81,6 @@ rba:
     threat_objects:
         - field: file_path
           type: file_path
-          score: 20
 tags:
     analytic_story:
         - NPM Supply Chain Compromise


### PR DESCRIPTION
A number of ymls have extra fields that are not part of the model. 
This should be a contentctl validate exception, but is not.

I have intentionally not bumped the versions/dates for these detections because these changes should not impact how the content is serialized into CONF file, meaning they should not require a new version in the metadata field for ES8 versioning purposes.