### PR TITLE
Adding dynamic information to static rba messages

### DIFF
--- a/detections/cloud/detect_new_open_gcp_storage_buckets.yml
+++ b/detections/cloud/detect_new_open_gcp_storage_buckets.yml
@@ -23,7 +23,7 @@ how_to_implement: This search relies on the Splunk Add-on for Google Cloud Platf
 known_false_positives: While this search has no known false positives, it is possible that a GCP admin has legitimately created a public bucket for a specific purpose. That said, GCP strongly advises against granting full control to the "allUsers" group.
 references: []
 rba:
-    message: New Public GCP Storage Bucket Detected
+    message: "allUser" member added to $bucketName$ by $user$ making the bucket available to the public
     risk_objects:
         - field: user
           type: user

--- a/detections/cloud/detect_new_open_gcp_storage_buckets.yml
+++ b/detections/cloud/detect_new_open_gcp_storage_buckets.yml
@@ -23,7 +23,8 @@ how_to_implement: This search relies on the Splunk Add-on for Google Cloud Platf
 known_false_positives: While this search has no known false positives, it is possible that a GCP admin has legitimately created a public bucket for a specific purpose. That said, GCP strongly advises against granting full control to the "allUsers" group.
 references: []
 rba:
-    message: "allUser" member added to $bucketName$ by $user$ making the bucket available to the public
+    message: |
+        "allUser" member added to $bucketName$ by $user$ making the bucket available to the public
     risk_objects:
         - field: user
           type: user

--- a/detections/cloud/detect_new_open_gcp_storage_buckets.yml
+++ b/detections/cloud/detect_new_open_gcp_storage_buckets.yml
@@ -1,7 +1,7 @@
 name: Detect New Open GCP Storage Buckets
 id: f6ea3466-d6bb-11ea-87d0-0242ac130003
-version: 7
-date: '2026-03-10'
+version: 8
+date: '2026-03-12'
 author: Shannon Davis, Splunk
 status: experimental
 type: TTP

--- a/detections/cloud/detect_spike_in_blocked_outbound_traffic_from_your_aws.yml
+++ b/detections/cloud/detect_spike_in_blocked_outbound_traffic_from_your_aws.yml
@@ -32,7 +32,7 @@ how_to_implement: You must install the AWS App for Splunk (version 5.1.0 or late
 known_false_positives: The false-positive rate may vary based on the values of`dataPointThreshold` and `deviationThreshold`. Additionally, false positives may result when AWS administrators roll out policies enforcing network blocks, causing sudden increases in the number of blocked outbound connections.
 references: []
 rba:
-    message: Blocked outbound traffic from your AWS VPC
+    message: Blocked $numberOfBlockedConnections$ outbound connections from your AWS VPC $src_ip$
     risk_objects:
         - field: src_ip
           type: system

--- a/detections/cloud/detect_spike_in_blocked_outbound_traffic_from_your_aws.yml
+++ b/detections/cloud/detect_spike_in_blocked_outbound_traffic_from_your_aws.yml
@@ -1,7 +1,7 @@
 name: Detect Spike in blocked Outbound Traffic from your AWS
 id: d3fffa37-492f-487b-a35d-c60fcb2acf01
-version: 7
-date: '2026-03-10'
+version: 8
+date: '2026-03-12'
 author: Bhavin Patel, Splunk
 status: experimental
 type: Anomaly

--- a/detections/cloud/gcp_detect_gcploit_framework.yml
+++ b/detections/cloud/gcp_detect_gcploit_framework.yml
@@ -17,7 +17,7 @@ references:
     - https://github.com/dxa4481/gcploit
     - https://www.youtube.com/watch?v=Ml09R38jpok
 rba:
-    message: Possible use of gcploit framework
+    message: Possible use of gcploit framework from $src$ by $src_user$
     risk_objects:
         - field: src_user
           type: user

--- a/detections/cloud/gcp_detect_gcploit_framework.yml
+++ b/detections/cloud/gcp_detect_gcploit_framework.yml
@@ -1,7 +1,7 @@
 name: GCP Detect gcploit framework
 id: a1c5a85e-a162-410c-a5d9-99ff639e5a52
-version: 7
-date: '2026-03-10'
+version: 8
+date: '2026-03-12'
 author: Rod Soto, Splunk
 status: experimental
 type: TTP

--- a/detections/endpoint/excessive_usage_of_sc_service_utility.yml
+++ b/detections/endpoint/excessive_usage_of_sc_service_utility.yml
@@ -35,7 +35,7 @@ drilldown_searches:
       earliest_offset: $info_min_time$
       latest_offset: $info_max_time$
 rba:
-    message: Excessive Usage Of SC Service Utility
+    message: Excessive Usage Of SC Service Utility on $dest$ by $user$
     risk_objects:
         - field: dest
           type: system

--- a/detections/endpoint/excessive_usage_of_sc_service_utility.yml
+++ b/detections/endpoint/excessive_usage_of_sc_service_utility.yml
@@ -1,7 +1,7 @@
 name: Excessive Usage Of SC Service Utility
 id: cb6b339e-d4c6-11eb-a026-acde48001122
-version: 9
-date: '2026-03-10'
+version: 10
+date: '2026-03-12'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly

--- a/detections/endpoint/get_domainpolicy_with_powershell_script_block.yml
+++ b/detections/endpoint/get_domainpolicy_with_powershell_script_block.yml
@@ -1,7 +1,7 @@
 name: Get DomainPolicy with Powershell Script Block
 id: a360d2b2-065a-11ec-b0bf-acde48001122
-version: 9
-date: '2026-03-10'
+version: 10
+date: '2026-03-12'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP

--- a/detections/endpoint/get_domainpolicy_with_powershell_script_block.yml
+++ b/detections/endpoint/get_domainpolicy_with_powershell_script_block.yml
@@ -36,7 +36,7 @@ drilldown_searches:
       earliest_offset: $info_min_time$
       latest_offset: $info_max_time$
 rba:
-    message: Powershell process with command line indicative of querying domain policy.
+    message: Powershell process indicative of querying domain policy, spawned by $user_id$ on $dest$
     risk_objects:
         - field: dest
           type: system

--- a/detections/endpoint/windows_adfind_exe.yml
+++ b/detections/endpoint/windows_adfind_exe.yml
@@ -1,7 +1,7 @@
 name: Windows AdFind Exe
 id: bd3b0187-189b-46c0-be45-f52da2bae67f
-version: 12
-date: '2026-03-10'
+version: 13
+date: '2026-03-12'
 author: Jose Hernandez, Bhavin Patel, Nasreddine Bencherchali, Splunk
 status: production
 type: TTP

--- a/detections/endpoint/windows_adfind_exe.yml
+++ b/detections/endpoint/windows_adfind_exe.yml
@@ -75,7 +75,7 @@ drilldown_searches:
       earliest_offset: $info_min_time$
       latest_offset: $info_max_time$
 rba:
-    message: Windows AdFind Exe detected with command-line arguments associated with Active Directory queries on machine - [dest]
+    message: $user$ spawned $process$ indicative of Active Directory discovery on machine - [$dest$]
     risk_objects:
         - field: user
           type: user

--- a/detections/endpoint/windows_excel_activemicrosoftapp_child_process.yml
+++ b/detections/endpoint/windows_excel_activemicrosoftapp_child_process.yml
@@ -1,7 +1,7 @@
 name: Windows Excel ActiveMicrosoftApp Child Process
 id: 4dfd6a58-93b2-4012-bb33-038bb63652b3
-version: 3
-date: '2026-03-10'
+version: 4
+date: '2026-03-12'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly

--- a/detections/endpoint/windows_excel_activemicrosoftapp_child_process.yml
+++ b/detections/endpoint/windows_excel_activemicrosoftapp_child_process.yml
@@ -38,7 +38,7 @@ drilldown_searches:
       earliest_offset: $info_min_time$
       latest_offset: $info_max_time$
 rba:
-    message: Risk Message goes here
+    message: $parent_process_name$ spawned $process_name$ on $dest$, indicative of ActivateMicrosoftApp() use
     risk_objects:
         - field: dest
           type: system

--- a/detections/endpoint/windows_rdp_server_registry_entry_created.yml
+++ b/detections/endpoint/windows_rdp_server_registry_entry_created.yml
@@ -1,7 +1,7 @@
 name: Windows RDP Server Registry Entry Created
 id: 61f10919-c360-4e56-9cda-f1f34500cfda
-version: 2
-date: '2026-03-10'
+version: 3
+date: '2026-03-12'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly

--- a/detections/endpoint/windows_rdp_server_registry_entry_created.yml
+++ b/detections/endpoint/windows_rdp_server_registry_entry_created.yml
@@ -24,7 +24,7 @@ drilldown_searches:
       earliest_offset: $info_min_time$
       latest_offset: $info_max_time$
 rba:
-    message: Risk Message goes here
+    message: RDP related registry key $registry_key_name$ created on $dest$
     risk_objects:
         - field: dest
           type: system

--- a/detections/endpoint/windows_rundll32_load_dll_in_temp_dir.yml
+++ b/detections/endpoint/windows_rundll32_load_dll_in_temp_dir.yml
@@ -1,7 +1,7 @@
 name: Windows Rundll32 Load DLL in Temp Dir
 id: 520da6fa-7d5d-4a3b-9c61-1087517b8d0f
-version: 4
-date: '2026-03-10'
+version: 5
+date: '2026-03-12'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly

--- a/detections/endpoint/windows_rundll32_load_dll_in_temp_dir.yml
+++ b/detections/endpoint/windows_rundll32_load_dll_in_temp_dir.yml
@@ -23,7 +23,7 @@ drilldown_searches:
       earliest_offset: $info_min_time$
       latest_offset: $info_max_time$
 rba:
-    message: Risk Message goes here
+    message: $parent_process_name$ spawned $process_name$ with a DLL from a temporary directory
     risk_objects:
         - field: dest
           type: system


### PR DESCRIPTION
### Details

Some detections are currently without dynamic rba messages, this is leaves a bit of unused potential. Adding suggestions for detections in cloud/ and endpoint/. 

There is still a few in `web/` and `network/` without field refs in the messages, however a few of the ones I looked at were experimental with little data in the resulting events. The ones I'm aware of are:
```
web/detect_f5_tmui_rce_cve_2020_5902.yml:    message: Potential F5 TMUI RCE traffic
web/detect_malicious_requests_to_exploit_jboss_servers.yml:    message: Potentially malicious traffic exploiting JBoss servers
web/detect_attackers_scanning_for_vulnerable_jboss_servers.yml:    message: Potential Scanning for Vulnerable JBoss Servers
web/monitor_web_traffic_for_brand_abuse.yml:    message: Potential Brand Abus discovered in web logs
network/dns_query_length_outliers___mltk.yml:    message: DNS Query Length Outliers
network/detect_zerologon_via_zeek.yml:    message: Potential Zerologon activity detected
network/protocol_or_port_mismatch.yml:    message: Port or Protocol Traffic Mismatch
network/detect_windows_dns_sigred_via_zeek.yml:    message: Potential SIGRed activity detected
network/detect_unauthorized_assets_by_mac_address.yml:    message: Potentially Unauthorized Device observed
network/prohibited_network_traffic_allowed.yml:    message: Potentially Prohibited Network Traffic allowed
network/detect_windows_dns_sigred_via_splunk_stream.yml:    message: Potential SIGRed activity detected
```

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.
