### PR TITLE
bump okta ta to 5.0.1

### DIFF
--- a/contentctl.yml
+++ b/contentctl.yml
@@ -38,9 +38,9 @@ apps:
 - uid: 6553
   title: Splunk Add-on for Okta Identity Cloud
   appid: Splunk_TA_okta_identity_cloud
-  version: 5.0.0
+  version: 5.0.1
   description: description of app
-  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-okta-identity-cloud_500.tgz
+  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-okta-identity-cloud_501.tgz
 - uid: 7404
   title: Cisco Security Cloud
   appid: CiscoSecurityCloud

--- a/data_sources/okta.yml
+++ b/data_sources/okta.yml
@@ -16,7 +16,7 @@ sourcetype: OktaIM2:log
 supported_TA:
 - name: Splunk Add-on for Okta Identity Cloud
   url: https://splunkbase.splunk.com/app/6553
-  version: 5.0.0
+  version: 5.0.1
 output_fields:
 - dest
 - src


### PR DESCRIPTION
Bump okta ta to 5.0.1.
5.0.0 was yanked from Splunkbase, 5.0.1 already exists on the mirror