### PR TITLE
Flag mitre_attack_id keys in YMLs

### DIFF
--- a/detections/application/cisco_ai_defense_security_alerts_by_application_name.yml
+++ b/detections/application/cisco_ai_defense_security_alerts_by_application_name.yml
@@ -62,6 +62,8 @@ tags:
     analytic_story:
         - Critical Alerts
     asset_type: Web Application
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/application/detect_new_login_attempts_to_routers.yml
+++ b/detections/application/detect_new_login_attempts_to_routers.yml
@@ -35,6 +35,8 @@ tags:
         - Router and Infrastructure Security
         - Scattered Lapsus$ Hunters
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/application/email_attachments_with_lots_of_spaces.yml
+++ b/detections/application/email_attachments_with_lots_of_spaces.yml
@@ -35,6 +35,8 @@ tags:
         - Hermetic Wiper
         - Suspicious Emails
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/application/monitor_email_for_brand_abuse.yml
+++ b/detections/application/monitor_email_for_brand_abuse.yml
@@ -35,6 +35,8 @@ tags:
         - Suspicious Emails
         - Scattered Lapsus$ Hunters
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/application/no_windows_updates_in_a_time_frame.yml
+++ b/detections/application/no_windows_updates_in_a_time_frame.yml
@@ -27,6 +27,8 @@ tags:
     analytic_story:
         - Monitor for Updates
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/application/splunk_appdynamics_secure_application_alerts.yml
+++ b/detections/application/splunk_appdynamics_secure_application_alerts.yml
@@ -69,7 +69,8 @@ tags:
     analytic_story:
         - Critical Alerts
     asset_type: Web Application
-    mitre_attack_id: []
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/application/suspicious_java_classes.yml
+++ b/detections/application/suspicious_java_classes.yml
@@ -34,6 +34,8 @@ tags:
     analytic_story:
         - Apache Struts Vulnerability
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/cloud/cloud_compute_instance_created_with_previously_unseen_image.yml
+++ b/detections/cloud/cloud_compute_instance_created_with_previously_unseen_image.yml
@@ -49,6 +49,8 @@ tags:
     analytic_story:
         - Cloud Cryptomining
     asset_type: Cloud Compute Instance
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/cloud/cloud_compute_instance_created_with_previously_unseen_instance_type.yml
+++ b/detections/cloud/cloud_compute_instance_created_with_previously_unseen_instance_type.yml
@@ -49,6 +49,8 @@ tags:
     analytic_story:
         - Cloud Cryptomining
     asset_type: Cloud Compute Instance
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/cloud/detect_spike_in_aws_security_hub_alerts_for_ec2_instance.yml
+++ b/detections/cloud/detect_spike_in_aws_security_hub_alerts_for_ec2_instance.yml
@@ -43,6 +43,8 @@ tags:
         - AWS Security Hub Alerts
         - Critical Alerts
     asset_type: AWS Instance
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/cloud/detect_spike_in_aws_security_hub_alerts_for_user.yml
+++ b/detections/cloud/detect_spike_in_aws_security_hub_alerts_for_user.yml
@@ -35,6 +35,8 @@ tags:
         - AWS Security Hub Alerts
         - Critical Alerts
     asset_type: AWS Instance
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/cloud/detect_spike_in_blocked_outbound_traffic_from_your_aws.yml
+++ b/detections/cloud/detect_spike_in_blocked_outbound_traffic_from_your_aws.yml
@@ -44,6 +44,8 @@ tags:
         - Suspicious AWS Traffic
         - Command And Control
     asset_type: AWS Instance
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/cloud/kubernetes_aws_detect_suspicious_kubectl_calls.yml
+++ b/detections/cloud/kubernetes_aws_detect_suspicious_kubectl_calls.yml
@@ -33,6 +33,8 @@ tags:
     analytic_story:
         - Kubernetes Security
     asset_type: Kubernetes
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/deprecated/unusually_long_command_line___mltk.yml
+++ b/detections/deprecated/unusually_long_command_line___mltk.yml
@@ -49,6 +49,8 @@ tags:
         - Possible Backdoor Activity Associated With MUDCARP Espionage Campaigns
         - Ransomware
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/endpoint/certutil_exe_certificate_extraction.yml
+++ b/detections/endpoint/certutil_exe_certificate_extraction.yml
@@ -61,6 +61,8 @@ tags:
         - Windows Certificate Services
         - Storm-2460 CLFS Zero Day Exploitation
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/endpoint/file_with_samsam_extension.yml
+++ b/detections/endpoint/file_with_samsam_extension.yml
@@ -70,6 +70,8 @@ tags:
         - SamSam Ransomware
         - Hellcat Ransomware
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/endpoint/macos___re_opened_applications.yml
+++ b/detections/endpoint/macos___re_opened_applications.yml
@@ -34,6 +34,8 @@ tags:
     analytic_story:
         - ColdRoot MacOS RAT
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/endpoint/processes_tapping_keyboard_events.yml
+++ b/detections/endpoint/processes_tapping_keyboard_events.yml
@@ -30,6 +30,8 @@ tags:
         - ColdRoot MacOS RAT
         - APT37 Rustonotto and FadeStealer
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/endpoint/spike_in_file_writes.yml
+++ b/detections/endpoint/spike_in_file_writes.yml
@@ -36,6 +36,8 @@ tags:
         - Ransomware
         - Rhysida Ransomware
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/endpoint/unusually_long_command_line.yml
+++ b/detections/endpoint/unusually_long_command_line.yml
@@ -50,6 +50,8 @@ tags:
         - Possible Backdoor Activity Associated With MUDCARP Espionage Campaigns
         - Ransomware
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/network/cisco_secure_firewall___bits_network_activity.yml
+++ b/detections/network/cisco_secure_firewall___bits_network_activity.yml
@@ -54,7 +54,8 @@ tags:
     analytic_story:
         - Cisco Secure Firewall Threat Defense Analytics
     asset_type: Network
-    mitre_attack_id: []
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/network/detect_unauthorized_assets_by_mac_address.yml
+++ b/detections/network/detect_unauthorized_assets_by_mac_address.yml
@@ -33,6 +33,8 @@ tags:
     analytic_story:
         - Asset Tracking
     asset_type: Infrastructure
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/network/protocols_passing_authentication_in_cleartext.yml
+++ b/detections/network/protocols_passing_authentication_in_cleartext.yml
@@ -61,6 +61,8 @@ tags:
         - Cisco Secure Firewall Threat Defense Analytics
         - Scattered Lapsus$ Hunters
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/web/detect_malicious_requests_to_exploit_jboss_servers.yml
+++ b/detections/web/detect_malicious_requests_to_exploit_jboss_servers.yml
@@ -37,6 +37,8 @@ tags:
         - JBoss Vulnerability
         - SamSam Ransomware
     asset_type: Web Server
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/web/f5_tmui_authentication_bypass.yml
+++ b/detections/web/f5_tmui_authentication_bypass.yml
@@ -45,6 +45,8 @@ tags:
     analytic_story:
         - F5 Authentication Bypass with TMUI
     asset_type: Network
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     atomic_guid: []
     cve:
         - CVE-2023-46747

--- a/detections/web/monitor_web_traffic_for_brand_abuse.yml
+++ b/detections/web/monitor_web_traffic_for_brand_abuse.yml
@@ -32,6 +32,8 @@ tags:
     analytic_story:
         - Brand Monitoring
     asset_type: Endpoint
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security

--- a/detections/web/unusually_long_content_type_length.yml
+++ b/detections/web/unusually_long_content_type_length.yml
@@ -32,6 +32,8 @@ tags:
     analytic_story:
         - Apache Struts Vulnerability
     asset_type: Web Server
+    mitre_attack_id:
+        - DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)
     product:
         - Splunk Enterprise
         - Splunk Enterprise Security


### PR DESCRIPTION
A number of detection ymls are either missing the `mitre_attack_id` key altogether or
have declared `mitre_attack_id: []`, but do not dynamically calculate `annotations.mitre_attack.mitre_technique_id` in the SPL of the detection (nor extract it from another field at runtime). 

Thi PR is marked as draft, and should fail contentctl validate, until this content is updated (if desired).
Missing tags can easily be found by searching for the string 
`DOES NOT DYANMICALLY CALCULATE MITRE_ATTACK_ID, PLEASE ADD APPROPRIATE HARDCODED MITRE ATTACK ID(S)`
