### PR TITLE
Palo Alto Ta 3.0.0 was pulled from Splukbase. Bump to 3.0.1

### DIFF
--- a/contentctl.yml
+++ b/contentctl.yml
@@ -125,9 +125,9 @@ apps:
 - uid: 2757
   title: Splunk Add-on for Palo Alto Networks
   appid: SPLUNK_ADD_ON_FOR_PALO_ALTO_NETWORKS
-  version: 3.0.0
+  version: 3.0.1
   description: description of app
-  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-palo-alto-networks_300.tgz
+  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-palo-alto-networks_301.tgz
 - uid: 3865
   title: Zscaler Technical Add-On for Splunk
   appid: Zscaler_CIM

--- a/data_sources/palo_alto_network_threat.yml
+++ b/data_sources/palo_alto_network_threat.yml
@@ -1,7 +1,7 @@
 name: Palo Alto Network Threat
 id: 375c2b0e-d216-41ad-9406-200464595209
-version: 3
-date: '2026-03-23'
+version: 4
+date: '2026-03-31'
 author: Patrick Bareiss, Splunk
 description: Logs detected threats identified by Palo Alto Networks devices, including
   details about malware, intrusion attempts, and malicious network activity.
@@ -16,7 +16,7 @@ sourcetype: pan:threat
 supported_TA:
 - name: Palo Alto Networks Add-on
   url: https://splunkbase.splunk.com/app/7523
-  version: 3.0.0
+  version: 3.0.1
 field_mappings:
 - data_model: cim
   data_set: Web

--- a/data_sources/palo_alto_network_traffic.yml
+++ b/data_sources/palo_alto_network_traffic.yml
@@ -1,7 +1,7 @@
 name: Palo Alto Network Traffic
 id: 182a83bc-c31a-4817-8c7a-263744cec52a
-version: 3
-date: '2026-03-23'
+version: 4
+date: '2026-03-31'
 author: Patrick Bareiss, Splunk
 description: Logs network traffic events captured by Palo Alto Networks devices, including
   details about sessions, protocols, and source and destination IPs.
@@ -16,7 +16,7 @@ sourcetype: pan:traffic
 supported_TA:
 - name: Palo Alto Networks Add-on
   url: https://splunkbase.splunk.com/app/7523
-  version: 3.0.0
+  version: 3.0.1
 fields:
 - _time
 - date_hour


### PR DESCRIPTION
Version 3.0.0 of the Palo Alto TA was pulled from Splunkbase.
https://splunkbase.splunk.com/app/7523

The TA has now been bumped to the latest, and ONLY available, version, 3.0.1.
I have manually mirrored the app as well to 
https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-palo-alto-networks_301.tgz