### PR TITLE
Don't quote the file name, only the link

### DIFF
--- a/.github/workflows/response_templates/template_script.py
+++ b/.github/workflows/response_templates/template_script.py
@@ -22,10 +22,11 @@ import json
 import urllib.parse
 from pathlib import Path
 
-def _get_out_template_name(template_name, quote=True):
-    if quote:
-        return f"{urllib.parse.quote(template_name)}.json"
-    return f"{template_name}.json"
+def _get_out_template_name(template_name, double_quote=False):
+    quoted_template_name = urllib.parse.quote(template_name)
+    if double_quote:
+        return f"{urllib.parse.quote(quoted_template_name)}.json"
+    return f"{quoted_template_name}.json"
 
 def generate_manifest(template_mapping, prefix, output_dir):
     # Code to generate the manifest file
@@ -36,7 +37,7 @@ def generate_manifest(template_mapping, prefix, output_dir):
     }
     try:
         for template_name, template_list in sorted(template_mapping.items(), key=lambda x: x[0]):
-            out_template_name = _get_out_template_name(template_name)
+            out_template_name = _get_out_template_name(template_name, double_quote=True)
             curr_template_name = template_name
 
             templates_version= []
@@ -120,7 +121,7 @@ def _get_template_mapping(directory):
 def merge_files(template_mapping, output_dir):
     try:
         for template_name, template_list in sorted(template_mapping.items(), key=lambda x: x[0]):
-            out_template_name = _get_out_template_name(template_name, quote=False)
+            out_template_name = _get_out_template_name(template_name)
 
             templates = []
             for _, file in template_list:

--- a/.github/workflows/response_templates/template_script.py
+++ b/.github/workflows/response_templates/template_script.py
@@ -22,8 +22,10 @@ import json
 import urllib.parse
 from pathlib import Path
 
-def _get_out_template_name(template_name):
-    return f"{urllib.parse.quote(template_name)}.json"
+def _get_out_template_name(template_name, quote=True):
+    if quote:
+        return f"{urllib.parse.quote(template_name)}.json"
+    return f"{template_name}.json"
 
 def generate_manifest(template_mapping, prefix, output_dir):
     # Code to generate the manifest file
@@ -118,7 +120,7 @@ def _get_template_mapping(directory):
 def merge_files(template_mapping, output_dir):
     try:
         for template_name, template_list in sorted(template_mapping.items(), key=lambda x: x[0]):
-            out_template_name = _get_out_template_name(template_name)
+            out_template_name = _get_out_template_name(template_name, quote=False)
 
             templates = []
             for _, file in template_list:


### PR DESCRIPTION
### Details
AWS quotes the files automatically. The script previously quoted the file name as well, so the link ended up being incorrect. The fix is to only quote the file name.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/9.3.2411/manage-apps-and-add-ons-in-splunk-cloud-platform/manage-private-apps-on-your-splunk-cloud-platform-deployment#ariaid-title7) but the short version is that any changes to lookup files need to bump the the date and version in the associated YAML file.
