### PR TITLE
Remove missing fields in Windows Event Log Cleared detection

### DIFF
--- a/data_sources/windows_event_log_security_1102.yml
+++ b/data_sources/windows_event_log_security_1102.yml
@@ -1,7 +1,7 @@
 name: Windows Event Log Security 1102
 id: 8db7b91a-6d7a-40e7-bfac-06f8e901a9cb
-version: 3
-date: '2025-07-10'
+version: 4
+date: '2026-04-15'
 author: Patrick Bareiss, Splunk
 description: Logs an event when the audit log is cleared.
 mitre_components:
@@ -85,18 +85,13 @@ fields:
 - vendor_product
 output_fields:
 - action
-- app
 - change_type
 - dest
 - dvc
 - name
-- object_attrs
 - object_category
-- signature
 - signature_id
-- src_user
 - status
-- subject
 - user
 - vendor_product
 example_log: <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider

--- a/data_sources/windows_event_log_security_1102.yml
+++ b/data_sources/windows_event_log_security_1102.yml
@@ -88,7 +88,6 @@ output_fields:
 - change_type
 - dest
 - dvc
-- name
 - object_category
 - signature_id
 - status

--- a/data_sources/windows_event_log_system_104.yml
+++ b/data_sources/windows_event_log_system_104.yml
@@ -1,10 +1,10 @@
 name: Windows Event Log System 104
 id: 577b9b41-6b37-44c4-9016-3d890b909050
-version: 2
-date: '2025-07-10'
+version: 3
+date: '2026-04-08'
 author: Bhavin Patel, Splunk
 description: Data source object for Windows Event Log System 104
-source: XmlWinEventLog:Security
+source: XmlWinEventLog:System
 sourcetype: XmlWinEventLog
 separator: EventCode
 supported_TA:

--- a/detections/endpoint/windows_event_log_cleared.yml
+++ b/detections/endpoint/windows_event_log_cleared.yml
@@ -58,8 +58,13 @@ tags:
         - Splunk Cloud
     security_domain: endpoint
 tests:
-    - name: True Positive Test
+    - name: True Positive Test - Security
       attack_data:
-        - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1070.001/windows_event_log_cleared/windows-xml.log
+        - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1070.001/windows_event_log_cleared/windows-security.log
           source: XmlWinEventLog:Security
+          sourcetype: XmlWinEventLog
+    - name: True Positive Test - System
+      attack_data:
+        - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1070.001/windows_event_log_cleared/windows-system.log
+          source: XmlWinEventLog:System
           sourcetype: XmlWinEventLog

--- a/detections/endpoint/windows_event_log_cleared.yml
+++ b/detections/endpoint/windows_event_log_cleared.yml
@@ -1,7 +1,7 @@
 name: Windows Event Log Cleared
 id: ad517544-aff9-4c96-bd99-d6eb43bfbb6a
-version: 17
-date: '2026-03-10'
+version: 18
+date: '2026-04-08'
 author: Rico Valdez, Michael Haag, Splunk
 status: production
 type: TTP
@@ -14,9 +14,7 @@ search: |-
     OR
     (`wineventlog_system` EventCode=104)
     | stats count min(_time) as firstTime max(_time) as lastTime
-      by action app change_type dest dvc name object_attrs object_category
-         signature signature_id src_user status subject user
-         vendor_product object EventCode
+      by action change_type dest dvc object_category signature_id status user vendor_product object EventCode
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `windows_event_log_cleared_filter`


### PR DESCRIPTION
As described in #4000, I believe these fields should be removed since the aggregation will miss results for `EventCode=104`.