### PR TITLE
data sources dependabot bug

### DIFF
--- a/.github/workflows/datasource-dependabot.yml
+++ b/.github/workflows/datasource-dependabot.yml
@@ -55,3 +55,4 @@ jobs:
           body: "This PR contains updates to Splunk TAs made by GitHub Actions workflow."
           add-paths: |
             data_sources/**
+            contentctl.yml

--- a/.github/workflows/datasource-dependabot.yml
+++ b/.github/workflows/datasource-dependabot.yml
@@ -54,4 +54,4 @@ jobs:
           title: Automated Splunk TA Update ${{ github.run_number }}
           body: "This PR contains updates to Splunk TAs made by GitHub Actions workflow."
           add-paths: |
-            security_content/data_sources/**
+            data_sources/**


### PR DESCRIPTION
The data sources dependabot has been failing to create PRs : 

https://github.com/splunk/security_content/actions/runs/24553210889/job/71822777288

Solution : It seems like the modified files are not getting staged into a commit and need to explicitly add paths from the root of the repo . Will test this after this is merged!  

AI notes : 
```
Root cause: The actions/checkout@v6 checks out the security_content repo to the runner's workspace root (/home/runner/work/security_content/security_content). From that working directory, the data source files are at data_sources/..., not security_content/data_sources/.... The security_content/ prefix was an extra level that doesn't exist in the working tree.

The peter-evans/create-pull-request action uses add-paths to filter which changed files to stage and commit. Since security_content/data_sources/** matched nothing, it staged nothing, committed nothing, and correctly reported "Branch is not ahead of base" -- so no PR was created.

Changing add-paths to data_sources/** will match the actual modified files, allowing the action to stage, commit, and create the PR.
```