### PR TITLE
[PATCHED] Automated Splunk TA Update 610

### DIFF
--- a/contentctl.yml
+++ b/contentctl.yml
@@ -38,9 +38,9 @@ apps:
 - uid: 6553
   title: Splunk Add-on for Okta Identity Cloud
   appid: Splunk_TA_okta_identity_cloud
-  version: 5.0.1
+  version: 5.0.2
   description: description of app
-  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-okta-identity-cloud_501.tgz
+  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-okta-identity-cloud_502.tgz
 - uid: 7404
   title: Cisco Security Cloud
   appid: CiscoSecurityCloud
@@ -143,9 +143,9 @@ apps:
 - uid: 1876
   title: Splunk Add-on for AWS
   appid: Splunk_TA_aws
-  version: 8.1.0
+  version: 8.1.1
   description: description of app
-  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-amazon-web-services-aws_810.tgz
+  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-amazon-web-services-aws_811.tgz
 - uid: 3088
   title: Splunk Add-on for Google Cloud Platform
   appid: SPLUNK_ADD_ON_FOR_GOOGLE_CLOUD_PLATFORM

--- a/contentctl.yml
+++ b/contentctl.yml
@@ -32,9 +32,9 @@ apps:
 - uid: 1621
   title: Splunk_SA_CIM
   appid: Splunk_SA_CIM
-  version: 6.4.0
+  version: 8.5.0
   description: description of app
-  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-common-information-model-cim_640.tgz
+  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-common-information-model-cim_850.tgz
 - uid: 6553
   title: Splunk Add-on for Okta Identity Cloud
   appid: Splunk_TA_okta_identity_cloud

--- a/contentctl.yml
+++ b/contentctl.yml
@@ -145,7 +145,7 @@ apps:
   appid: Splunk_TA_aws
   version: 8.1.1
   description: description of app
-  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-amazon-web-services-aws_811.tgz
+  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-add-on-for-amazon-web-services-(aws)_811.tgz
 - uid: 3088
   title: Splunk Add-on for Google Cloud Platform
   appid: SPLUNK_ADD_ON_FOR_GOOGLE_CLOUD_PLATFORM

--- a/contentctl.yml
+++ b/contentctl.yml
@@ -32,9 +32,9 @@ apps:
 - uid: 1621
   title: Splunk_SA_CIM
   appid: Splunk_SA_CIM
-  version: 8.5.0
+  version: 6.4.0
   description: description of app
-  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-common-information-model-cim_850.tgz
+  hardcoded_path: https://attack-range-appbinaries.s3.us-west-2.amazonaws.com/splunk-common-information-model-cim_640.tgz
 - uid: 6553
   title: Splunk Add-on for Okta Identity Cloud
   appid: Splunk_TA_okta_identity_cloud

--- a/data_sources/asl_aws_cloudtrail.yml
+++ b/data_sources/asl_aws_cloudtrail.yml
@@ -23,7 +23,7 @@ separator: api.operation
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 output_fields:
 - dest
 - user

--- a/data_sources/aws_cloudfront.yml
+++ b/data_sources/aws_cloudfront.yml
@@ -17,7 +17,7 @@ sourcetype: aws:cloudfront:accesslogs
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail.yml
+++ b/data_sources/aws_cloudtrail.yml
@@ -10,4 +10,4 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1

--- a/data_sources/aws_cloudtrail_assumerolewithsaml.yml
+++ b/data_sources/aws_cloudtrail_assumerolewithsaml.yml
@@ -18,7 +18,7 @@ separator_value: AssumeRoleWithSAML
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_consolelogin.yml
+++ b/data_sources/aws_cloudtrail_consolelogin.yml
@@ -18,7 +18,7 @@ separator_value: ConsoleLogin
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_copyobject.yml
+++ b/data_sources/aws_cloudtrail_copyobject.yml
@@ -17,7 +17,7 @@ separator_value: CopyObject
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - additionalEventData.AuthenticationMethod

--- a/data_sources/aws_cloudtrail_createaccesskey.yml
+++ b/data_sources/aws_cloudtrail_createaccesskey.yml
@@ -17,7 +17,7 @@ separator_value: CreateAccessKey
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_createkey.yml
+++ b/data_sources/aws_cloudtrail_createkey.yml
@@ -17,7 +17,7 @@ separator_value: CreateKey
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_createloginprofile.yml
+++ b/data_sources/aws_cloudtrail_createloginprofile.yml
@@ -17,7 +17,7 @@ separator_value: CreateLoginProfile
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_createnetworkaclentry.yml
+++ b/data_sources/aws_cloudtrail_createnetworkaclentry.yml
@@ -17,7 +17,7 @@ separator_value: CreateNetworkAclEntry
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_createpolicyversion.yml
+++ b/data_sources/aws_cloudtrail_createpolicyversion.yml
@@ -17,7 +17,7 @@ separator_value: CreatePolicyVersion
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_createsnapshot.yml
+++ b/data_sources/aws_cloudtrail_createsnapshot.yml
@@ -17,7 +17,7 @@ separator_value: CreateSnapshot
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_createtask.yml
+++ b/data_sources/aws_cloudtrail_createtask.yml
@@ -17,7 +17,7 @@ separator_value: CreateTask
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_createvirtualmfadevice.yml
+++ b/data_sources/aws_cloudtrail_createvirtualmfadevice.yml
@@ -17,7 +17,7 @@ separator_value: CreateVirtualMFADevice
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deactivatemfadevice.yml
+++ b/data_sources/aws_cloudtrail_deactivatemfadevice.yml
@@ -17,7 +17,7 @@ separator_value: DeactivateMFADevice
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deleteaccountpasswordpolicy.yml
+++ b/data_sources/aws_cloudtrail_deleteaccountpasswordpolicy.yml
@@ -15,7 +15,7 @@ separator_value: DeleteAccountPasswordPolicy
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletealarms.yml
+++ b/data_sources/aws_cloudtrail_deletealarms.yml
@@ -17,7 +17,7 @@ separator_value: DeleteAlarms
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletedetector.yml
+++ b/data_sources/aws_cloudtrail_deletedetector.yml
@@ -17,7 +17,7 @@ separator_value: DeleteDetector
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_deletegroup.yml
+++ b/data_sources/aws_cloudtrail_deletegroup.yml
@@ -17,7 +17,7 @@ separator_value: DeleteGroup
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deleteguardrail.yml
+++ b/data_sources/aws_cloudtrail_deleteguardrail.yml
@@ -13,7 +13,7 @@ separator_value: DeleteGuardrail
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deleteipset.yml
+++ b/data_sources/aws_cloudtrail_deleteipset.yml
@@ -16,7 +16,7 @@ separator_value: DeleteIPSet
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_deleteknowledgebase.yml
+++ b/data_sources/aws_cloudtrail_deleteknowledgebase.yml
@@ -13,7 +13,7 @@ separator_value: DeleteKnowledgeBase
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deleteloggingconfiguration.yml
+++ b/data_sources/aws_cloudtrail_deleteloggingconfiguration.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 example_log: ''

--- a/data_sources/aws_cloudtrail_deleteloggroup.yml
+++ b/data_sources/aws_cloudtrail_deleteloggroup.yml
@@ -17,7 +17,7 @@ separator_value: DeleteLogGroup
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - apiVersion

--- a/data_sources/aws_cloudtrail_deletelogstream.yml
+++ b/data_sources/aws_cloudtrail_deletelogstream.yml
@@ -17,7 +17,7 @@ separator_value: DeleteLogStream
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - apiVersion

--- a/data_sources/aws_cloudtrail_deletemodelinvocationloggingconfiguration.yml
+++ b/data_sources/aws_cloudtrail_deletemodelinvocationloggingconfiguration.yml
@@ -14,7 +14,7 @@ separator_value: DeleteModelInvocationLoggingConfiguration
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletenetworkaclentry.yml
+++ b/data_sources/aws_cloudtrail_deletenetworkaclentry.yml
@@ -16,7 +16,7 @@ separator_value: DeleteNetworkAclEntry
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletepolicy.yml
+++ b/data_sources/aws_cloudtrail_deletepolicy.yml
@@ -15,7 +15,7 @@ separator_value: DeletePolicy
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deleterule.yml
+++ b/data_sources/aws_cloudtrail_deleterule.yml
@@ -17,7 +17,7 @@ separator_value: DeleteRule
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - apiVersion

--- a/data_sources/aws_cloudtrail_deleterulegroup.yml
+++ b/data_sources/aws_cloudtrail_deleterulegroup.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 example_log: ''

--- a/data_sources/aws_cloudtrail_deletesnapshot.yml
+++ b/data_sources/aws_cloudtrail_deletesnapshot.yml
@@ -17,7 +17,7 @@ separator_value: DeleteSnapshot
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletetrail.yml
+++ b/data_sources/aws_cloudtrail_deletetrail.yml
@@ -17,7 +17,7 @@ separator_value: DeleteTrail
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_deletevirtualmfadevice.yml
+++ b/data_sources/aws_cloudtrail_deletevirtualmfadevice.yml
@@ -15,7 +15,7 @@ separator_value: DeleteVirtualMFADevice
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_deletewebacl.yml
+++ b/data_sources/aws_cloudtrail_deletewebacl.yml
@@ -15,7 +15,7 @@ separator_value: DeleteWebACL
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - apiVersion

--- a/data_sources/aws_cloudtrail_describeeventaggregates.yml
+++ b/data_sources/aws_cloudtrail_describeeventaggregates.yml
@@ -15,7 +15,7 @@ separator_value: DescribeEventAggregates
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_describeimagescanfindings.yml
+++ b/data_sources/aws_cloudtrail_describeimagescanfindings.yml
@@ -16,7 +16,7 @@ separator_value: DescribeImageScanFindings
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_describesnapshotattribute.yml
+++ b/data_sources/aws_cloudtrail_describesnapshotattribute.yml
@@ -10,7 +10,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - action
 - app

--- a/data_sources/aws_cloudtrail_getaccountpasswordpolicy.yml
+++ b/data_sources/aws_cloudtrail_getaccountpasswordpolicy.yml
@@ -15,7 +15,7 @@ separator_value: GetAccountPasswordPolicy
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_getobject.yml
+++ b/data_sources/aws_cloudtrail_getobject.yml
@@ -16,7 +16,7 @@ separator_value: GetObject
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - additionalEventData.AuthenticationMethod

--- a/data_sources/aws_cloudtrail_getpassworddata.yml
+++ b/data_sources/aws_cloudtrail_getpassworddata.yml
@@ -15,7 +15,7 @@ separator_value: GetPasswordData
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_invokemodel.yml
+++ b/data_sources/aws_cloudtrail_invokemodel.yml
@@ -13,7 +13,7 @@ separator_value: InvokeModel
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_jobcreated.yml
+++ b/data_sources/aws_cloudtrail_jobcreated.yml
@@ -14,7 +14,7 @@ separator_value: JobCreated
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_listfoundationmodels.yml
+++ b/data_sources/aws_cloudtrail_listfoundationmodels.yml
@@ -14,7 +14,7 @@ separator_value: ListFoundationModels
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_modifydbinstance.yml
+++ b/data_sources/aws_cloudtrail_modifydbinstance.yml
@@ -16,7 +16,7 @@ separator_value: ModifyDBInstance
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_modifyimageattribute.yml
+++ b/data_sources/aws_cloudtrail_modifyimageattribute.yml
@@ -15,7 +15,7 @@ separator_value: ModifyImageAttribute
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_modifysnapshotattribute.yml
+++ b/data_sources/aws_cloudtrail_modifysnapshotattribute.yml
@@ -14,7 +14,7 @@ separator_value: ModifySnapshotAttribute
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_putbucketacl.yml
+++ b/data_sources/aws_cloudtrail_putbucketacl.yml
@@ -15,7 +15,7 @@ separator_value: PutBucketAcl
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_putbucketlifecycle.yml
+++ b/data_sources/aws_cloudtrail_putbucketlifecycle.yml
@@ -15,7 +15,7 @@ separator_value: PutBucketLifecycle
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - additionalEventData.AuthenticationMethod

--- a/data_sources/aws_cloudtrail_putbucketreplication.yml
+++ b/data_sources/aws_cloudtrail_putbucketreplication.yml
@@ -14,7 +14,7 @@ separator_value: PutBucketReplication
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - additionalEventData.AuthenticationMethod

--- a/data_sources/aws_cloudtrail_putbucketversioning.yml
+++ b/data_sources/aws_cloudtrail_putbucketversioning.yml
@@ -14,7 +14,7 @@ separator_value: PutBucketVersioning
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - additionalEventData.AuthenticationMethod

--- a/data_sources/aws_cloudtrail_putimage.yml
+++ b/data_sources/aws_cloudtrail_putimage.yml
@@ -15,7 +15,7 @@ separator_value: PutImage
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_putkeypolicy.yml
+++ b/data_sources/aws_cloudtrail_putkeypolicy.yml
@@ -11,7 +11,7 @@ separator: eventName
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_replacenetworkaclentry.yml
+++ b/data_sources/aws_cloudtrail_replacenetworkaclentry.yml
@@ -14,7 +14,7 @@ separator_value: ReplaceNetworkAclEntry
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_setdefaultpolicyversion.yml
+++ b/data_sources/aws_cloudtrail_setdefaultpolicyversion.yml
@@ -15,7 +15,7 @@ separator_value: SetDefaultPolicyVersion
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_stoplogging.yml
+++ b/data_sources/aws_cloudtrail_stoplogging.yml
@@ -14,7 +14,7 @@ separator_value: StopLogging
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudtrail_updateaccountpasswordpolicy.yml
+++ b/data_sources/aws_cloudtrail_updateaccountpasswordpolicy.yml
@@ -14,7 +14,7 @@ separator_value: UpdateAccountPasswordPolicy
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_updateloginprofile.yml
+++ b/data_sources/aws_cloudtrail_updateloginprofile.yml
@@ -14,7 +14,7 @@ separator_value: UpdateLoginProfile
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_updatesamlprovider.yml
+++ b/data_sources/aws_cloudtrail_updatesamlprovider.yml
@@ -15,7 +15,7 @@ separator_value: UpdateSAMLProvider
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - action

--- a/data_sources/aws_cloudtrail_updatetrail.yml
+++ b/data_sources/aws_cloudtrail_updatetrail.yml
@@ -15,7 +15,7 @@ separator_value: UpdateTrail
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - app

--- a/data_sources/aws_cloudwatchlogs_vpcflow.yml
+++ b/data_sources/aws_cloudwatchlogs_vpcflow.yml
@@ -13,7 +13,7 @@ source: aws_cloudwatchlogs_vpcflow
 sourcetype: aws:cloudwatchlogs:vpcflow
 supported_TA:
 - name: Splunk Add-on for AWS
-  version: 8.1.0
+  version: 8.1.1
   url: https://splunkbase.splunk.com/app/1876
 fields:
 - _raw

--- a/data_sources/aws_security_hub.yml
+++ b/data_sources/aws_security_hub.yml
@@ -15,7 +15,7 @@ sourcetype: aws:securityhub:finding
 supported_TA:
 - name: Splunk Add-on for AWS
   url: https://splunkbase.splunk.com/app/1876
-  version: 8.1.0
+  version: 8.1.1
 fields:
 - _time
 - AwsAccountId

--- a/data_sources/okta.yml
+++ b/data_sources/okta.yml
@@ -16,7 +16,7 @@ sourcetype: OktaIM2:log
 supported_TA:
 - name: Splunk Add-on for Okta Identity Cloud
   url: https://splunkbase.splunk.com/app/6553
-  version: 5.0.1
+  version: 5.0.2
 output_fields:
 - dest
 - src


### PR DESCRIPTION
This PR contains all the changes in the following PR:
https://github.com/splunk/security_content/pull/4029

However, these is currently an issue with how contentctl handles the CIM 8.5.0 Release.
To unblock all these other updates, I suggest merging this PR as we work to address the underlying contentctl issue.

Once that issue with contentctl is addressed, we should merge the CIM 6.4-->8.5 update in the PR above.


Update: There may be other issues at play here - keeping this PR as DRAFT while we work to troubleshoot.