### PR TITLE
explicitly list all apps in this repo's install.yml

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -25,9 +25,6 @@ apps:
   - appid: Splunk_TA_google-cloudplatform
     url: https://splunkbase.splunk.com/app/3088
     version: 5.0.3
-  - appid: Splunk_ML_Toolkit
-    url: https://splunkbase.splunk.com/app/2890
-    version: 5.7.4
   - appid: utbox
     url: https://splunkbase.splunk.com/app/2734
     version: 1.9.4
@@ -37,9 +34,6 @@ apps:
   - appid: TA-crowdstrike-falcon-event-streams
     url: https://splunkbase.splunk.com/app/5082
     version: 3.7.2
-  - appid: Splunk_SA_Scientific_Python_linux_x86_64
-    url: https://splunkbase.splunk.com/app/2882
-    version: 4.3.2
   - appid: SA-VMWIndex
     url: https://splunkbase.splunk.com/app/5640
     version: 4.0.4

--- a/install.yml
+++ b/install.yml
@@ -1,3 +1,48 @@
 apps:
-    - appid: DA-ESS-ContentUpdate
-      hardcoded_path: dist/DA-ESS-ContentUpdate.tar.gz
+  - appid: DA-ESS-ContentUpdate
+    hardcoded_path: dist/DA-ESS-ContentUpdate.tar.gz
+  - appid: SplunkEnterpriseSecuritySuite
+    url: https://splunkbase.splunk.com/app/263
+    version: 8.5.1
+  - appid: Splunk_TA_microsoft-iis
+    url: https://splunkbase.splunk.com/app/3185
+    version: 2.0.0
+  - appid: TA-suricata-4
+    url: https://splunkbase.splunk.com/app/4242
+    version: 2.3.4
+  - appid: Splunk_TA_stream
+    url: https://splunkbase.splunk.com/app/5238
+    version: 8.1.6
+  - appid: Splunk_TA_stream_wire_data
+    url: https://splunkbase.splunk.com/app/5234
+    version: 8.1.6
+  - appid: TA-Zscaler_CIM
+    url: https://splunkbase.splunk.com/app/3865
+    version: 4.1.5
+  - appid: Splunk_TA_aws-kinesis-firehose
+    url: https://splunkbase.splunk.com/app/3719
+    version: 1.3.2
+  - appid: Splunk_TA_google-cloudplatform
+    url: https://splunkbase.splunk.com/app/3088
+    version: 5.0.3
+  - appid: Splunk_ML_Toolkit
+    url: https://splunkbase.splunk.com/app/2890
+    version: 5.7.4
+  - appid: utbox
+    url: https://splunkbase.splunk.com/app/2734
+    version: 1.9.4
+  - appid: SA-admon
+    url: https://splunkbase.splunk.com/app/6853
+    version: 1.1.2
+  - appid: TA-crowdstrike-falcon-event-streams
+    url: https://splunkbase.splunk.com/app/5082
+    version: 3.7.2
+  - appid: Splunk_SA_Scientific_Python_linux_x86_64
+    url: https://splunkbase.splunk.com/app/2882
+    version: 4.3.2
+  - appid: SA-VMWIndex
+    url: https://splunkbase.splunk.com/app/5640
+    version: 4.0.4
+  - appid: Splunk_SA_CIM
+    url: https://splunkbase.splunk.com/app/1621
+    version: 8.5.0


### PR DESCRIPTION
This is part of a migration to remove install.yml apps that are hardcoded in contentctl-ng's install.yml and move them into the scope of the security_content repo for clarity and control.
