### PR TITLE
Update IF's Message

### DIFF
--- a/detections/endpoint/powershell_domain_enumeration.yml
+++ b/detections/endpoint/powershell_domain_enumeration.yml
@@ -1,19 +1,32 @@
 name: PowerShell Domain Enumeration
 id: e1866ce2-ca22-11eb-8e44-acde48001122
-version: 15
+version: 16
 creation_date: '2021-06-15'
-modification_date: '2026-05-13'
+modification_date: '2026-06-28'
 author: Michael Haag, Splunk
 status: production
-type: TTP
-description: The following analytic detects the execution of PowerShell commands used for domain enumeration, such as `get-netdomaintrust` and `get-adgroupmember`. It leverages PowerShell Script Block Logging (EventCode=4104) to capture and analyze the full command sent to PowerShell. This activity is significant as it often indicates reconnaissance efforts by an attacker to map out the domain structure and identify key users and groups. If confirmed malicious, this behavior could lead to further targeted attacks, privilege escalation, and unauthorized access to sensitive information within the domain.
+type: Anomaly
+description: |-
+    The following analytic detects the execution of PowerShell commands used for domain enumeration, such as `get-netdomaintrust` and `get-adgroupmember`.
+    It leverages PowerShell Script Block Logging (EventCode=4104) to capture and analyze the full command sent to PowerShell.
+    This activity is significant as it often indicates reconnaissance efforts by an attacker to map out the domain structure and identify key users and groups.
+    If confirmed malicious, this behavior could lead to further targeted attacks, privilege escalation, and unauthorized access to sensitive information within the domain.
 data_source:
     - Powershell Script Block Logging 4104
 search: |-
-    `powershell` EventCode=4104 ScriptBlockText IN (*get-netdomaintrust*, *get-netforesttrust*, *get-addomain*, *get-adgroupmember*, *get-domainuser*)
-      | fillnull
-      | stats count min(_time) as firstTime max(_time) as lastTime
-        BY dest signature signature_id
+    `powershell`
+    EventCode=4104
+    ScriptBlockText IN (
+        *get-netdomaintrust*,
+        *get-netforesttrust*,
+        *get-addomain*,
+        *get-adgroupmember*,
+        *get-domainuser*
+    )
+    | fillnull
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+      BY dest signature signature_id
            user_id vendor_product EventID
            Guid Opcode Name
            Path ProcessID ScriptBlockId
@@ -22,7 +35,7 @@ search: |-
       | `security_content_ctime(lastTime)`
       | `powershell_domain_enumeration_filter`
 how_to_implement: To successfully implement this analytic, you will need to enable PowerShell Script Block Logging on some or all endpoints. Additional setup here https://help.splunk.com/en/security-offerings/splunk-user-behavior-analytics/get-data-in/5.4.1/add-other-data-to-splunk-uba/configure-powershell-logging-to-see-powershell-anomalies-in-splunk-uba.
-known_false_positives: It is possible there will be false positives, filter as needed.
+known_false_positives: Legitimate use can be common or expected in certain environments. Filter as needed.
 references:
     - https://help.splunk.com/en/security-offerings/splunk-user-behavior-analytics/get-data-in/5.4.1/add-other-data-to-splunk-uba/configure-powershell-logging-to-see-powershell-anomalies-in-splunk-uba.
     - https://blog.palantir.com/tampering-with-windows-event-tracing-background-offense-and-defense-4be7ac62ac63
@@ -38,18 +51,12 @@ drilldown_searches:
       search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$", "$user_id$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
       earliest_offset: 7d
       latest_offset: "0"
-finding:
-    title: A suspicious powershell script contains domain enumeration command in $ScriptBlockText$ in host $dest$
-    entity:
-        field: user_id
-        type: user
-        score: 50
 intermediate_findings:
     entities:
         - field: dest
           type: system
-          score: 50
-          message: A suspicious powershell script contains domain enumeration command in $ScriptBlockText$ in host $dest$
+          score: 20
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] contains domain enumeration commands executed on host $dest$
 analytic_story:
     - Hermetic Wiper
     - Malicious PowerShell

--- a/detections/endpoint/powershell_environment_variable_execution.yml
+++ b/detections/endpoint/powershell_environment_variable_execution.yml
@@ -1,12 +1,16 @@
 name: PowerShell Environment Variable Execution
 id: 02c1d8e9-044c-401f-906c-cc95445af8bd
-version: 2
+version: 3
 creation_date: '2026-04-29'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
 status: production
 type: Anomaly
-description: The following analytic detects the execution of PowerShell scripts that combine environment variable access (`$env:` or `[Environment]::SetEnvironmentVariable`) with `Invoke-Expression` or its alias `iex` to dynamically construct and run code at runtime. This technique is commonly used by adversaries to stage and execute payloads by embedding commands or encoded content inside environment variables, then evaluating them on the fly — effectively hiding the true execution intent from static inspection. Detection is based on PowerShell Script Block Logging (Event ID 4104), which captures the de-obfuscated script block before it executes. Triggering this analytic indicates a potential attempt to execute environment-variable-stored code, a behavior observed in malware loaders and stagers, including those associated with the VIP Keylogger campaign.
+description: |-
+    The following analytic detects the execution of PowerShell scripts that combine environment variable access (`$env:` or `[Environment]::SetEnvironmentVariable`) with `Invoke-Expression` or its alias `iex` to dynamically construct and run code at runtime.
+    This technique is commonly used by adversaries to stage and execute payloads by embedding commands or encoded content inside environment variables, then evaluating them on the fly — effectively hiding the true execution intent from static inspection.
+    Detection is based on PowerShell Script Block Logging (Event ID 4104), which captures the de-obfuscated script block before it executes.
+    Triggering this analytic indicates a potential attempt to execute environment-variable-stored code, a behavior observed in malware loaders and stagers, including those associated with the VIP Keylogger campaign.
 data_source:
     - Powershell Script Block Logging 4104
 search: |-
@@ -22,8 +26,12 @@ search: |-
     ScriptBlockText="*[Environment]::SetEnvironmentVariable*"
     | regex ScriptBlockText="(?i)((invoke-expression|iex\s+|\biex\b).*\$env:|\[scriptblock\]::create\s*\(\s*\$env:[^)]+\)\s*(?:\.\s*invoke\s*\(\s*\))?)"
     | fillnull
-    | stats count min(_time) as firstTime max(_time) as lastTime
-    by dest signature signature_id user_id vendor_product EventID Guid Opcode Name Path ProcessID ScriptBlockId ScriptBlockText
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+      by dest signature signature_id user_id
+         vendor_product EventID Guid
+         Opcode Name Path ProcessID
+         ScriptBlockId ScriptBlockText
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `powershell_environment_variable_execution_filter`
@@ -49,7 +57,7 @@ intermediate_findings:
         - field: dest
           type: system
           score: 20
-          message: A suspicious powershell script execute environment variable in [$ScriptBlockText$] on host [$dest$]
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] executed an environment variable on host $dest$
 analytic_story:
     - VIP Keylogger
 asset_type: Endpoint

--- a/detections/endpoint/powershell_loading_dotnet_into_memory_via_reflection.yml
+++ b/detections/endpoint/powershell_loading_dotnet_into_memory_via_reflection.yml
@@ -1,12 +1,16 @@
 name: PowerShell Loading DotNET into Memory via Reflection
 id: 85bc3f30-ca28-11eb-bd21-acde48001122
-version: 18
+version: 19
 creation_date: '2021-06-15'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Michael Haag, Teoderick Contreras Splunk
 status: production
 type: Anomaly
-description: The following analytic detects the use of PowerShell scripts to load .NET assemblies into memory via reflection, a technique often used in malicious activities such as those by Empire and Cobalt Strike. It leverages PowerShell Script Block Logging (EventCode=4104) to capture and analyze the full command executed. This behavior is significant as it can indicate advanced attack techniques aiming to execute code in memory, bypassing traditional defenses. If confirmed malicious, this activity could lead to unauthorized code execution, privilege escalation, and persistent access within the environment.
+description: |-
+    The following analytic detects the use of PowerShell scripts to load .NET assemblies into memory via reflection, a technique often used in malicious activities such as those by Empire and Cobalt Strike.
+    It leverages PowerShell Script Block Logging (EventCode=4104) to capture and analyze the full command executed.
+    This behavior is significant as it can indicate advanced attack techniques aiming to execute code in memory, bypassing traditional defenses.
+    If confirmed malicious, this activity could lead to unauthorized code execution, privilege escalation, and persistent access within the environment.
 data_source:
     - Powershell Script Block Logging 4104
 search: |-
@@ -55,11 +59,11 @@ intermediate_findings:
         - field: dest
           type: system
           score: 20
-          message: A suspicious powershell script contains reflective class assembly command in $ScriptBlockText$ to load .net code in memory in host $dest$
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing reflective class assembly commands to load .net code in memory was executed on host $dest$
         - field: user_id
           type: user
           score: 20
-          message: A suspicious powershell script contains reflective class assembly command in $ScriptBlockText$ to load .net code in memory in host $dest$
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing reflective class assembly commands to load .net code in memory was executed on host $dest$ by user $user_id$
 analytic_story:
     - Winter Vivern
     - AgentTesla

--- a/detections/endpoint/powershell_processing_stream_of_data.yml
+++ b/detections/endpoint/powershell_processing_stream_of_data.yml
@@ -1,23 +1,34 @@
 name: Powershell Processing Stream Of Data
 id: 0d718b52-c9f1-11eb-bc61-acde48001122
-version: 18
+version: 19
 creation_date: '2021-06-14'
-modification_date: '2026-06-08'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
 status: production
-type: TTP
-description: The following analytic detects suspicious PowerShell script execution involving compressed stream data processing, identified via EventCode 4104. It leverages PowerShell Script Block Logging to flag scripts using `IO.Compression`, `IO.StreamReader`, or decompression methods. This activity is significant as it often indicates obfuscated PowerShell or embedded .NET/binary execution, which are common tactics for evading detection. If confirmed malicious, this behavior could allow attackers to execute hidden code, escalate privileges, or maintain persistence within the environment.
+type: Anomaly
+description: |-
+    The following analytic detects suspicious PowerShell script execution involving compressed stream data processing, identified via EventCode 4104.
+    It leverages PowerShell Script Block Logging to flag scripts using `IO.Compression`, `IO.StreamReader`, or decompression methods.
+    This activity is significant as it often indicates obfuscated PowerShell or embedded .NET/binary execution, which are common tactics for evading detection.
+    If confirmed malicious, this behavior could allow attackers to execute hidden code, escalate privileges, or maintain persistence within the environment.
 data_source:
     - Powershell Script Block Logging 4104
 search: |-
-    `powershell` EventCode=4104 ScriptBlockText = "*IO.Compression.*" OR ScriptBlockText = "*IO.StreamReader*" OR ScriptBlockText = "*]::Decompress*"
-      | fillnull
-      | stats count min(_time) as firstTime max(_time) as lastTime
-        BY dest signature signature_id
-           user_id vendor_product EventID
-           Guid Opcode Name
-           Path ProcessID ScriptBlockId
-           ScriptBlockText
+    `powershell`
+    EventCode=4104
+    ScriptBlockText IN (
+        "*IO.Compression.*",
+        "*IO.StreamReader*",
+        "*]::Decompress*"
+    )
+    | fillnull
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+      by dest signature signature_id
+         user_id vendor_product EventID
+         Guid Opcode Name
+         Path ProcessID ScriptBlockId
+         ScriptBlockText
       | `security_content_ctime(firstTime)`
       | `security_content_ctime(lastTime)`
       | `powershell_processing_stream_of_data_filter`
@@ -40,18 +51,12 @@ drilldown_searches:
       search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$Computer$", "$user$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
       earliest_offset: 7d
       latest_offset: "0"
-finding:
-    title: A suspicious powershell script contains stream command in $ScriptBlockText$ commonly for processing compressed or to decompressed binary file with EventCode $EventID$ in host $dest$
-    entity:
-        field: user_id
-        type: user
-        score: 50
 intermediate_findings:
     entities:
         - field: dest
           type: system
-          score: 50
-          message: A suspicious powershell script contains stream command in $ScriptBlockText$ commonly for processing compressed or to decompressed binary file with EventCode $EventID$ in host $dest$
+          score: 20
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing stream commands to process compressed or decompressed binary file was executed on host $dest$
 analytic_story:
     - Hellcat Ransomware
     - Malicious PowerShell

--- a/detections/endpoint/powershell_remove_windows_defender_directory.yml
+++ b/detections/endpoint/powershell_remove_windows_defender_directory.yml
@@ -1,15 +1,33 @@
 name: Powershell Remove Windows Defender Directory
 id: adf47620-79fa-11ec-b248-acde48001122
-version: 16
+version: 17
 creation_date: '2022-01-20'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
 status: production
-type: TTP
-description: The following analytic detects a suspicious PowerShell command attempting to delete the Windows Defender directory. It leverages PowerShell Script Block Logging to identify commands containing "rmdir" and targeting the Windows Defender path. This activity is significant as it may indicate an attempt to disable or corrupt Windows Defender, a key security component. If confirmed malicious, this action could allow an attacker to bypass endpoint protection, facilitating further malicious activities without detection.
+type: Anomaly
+description: |-
+    The following analytic detects a suspicious PowerShell command attempting to delete the Windows Defender directory.
+    It leverages PowerShell Script Block Logging to identify commands containing "rmdir" and targeting the Windows Defender path.
+    This activity is significant as it may indicate an attempt to disable or corrupt Windows Defender, a key security component.
+    If confirmed malicious, this action could allow an attacker to bypass endpoint protection, facilitating further malicious activities without detection.
 data_source:
     - Powershell Script Block Logging 4104
-search: '`powershell` EventCode=4104 ScriptBlockText = "*rmdir *" AND ScriptBlockText = "*\\Microsoft\\Windows Defender*" | fillnull | stats count min(_time) as firstTime max(_time) as lastTime by dest signature signature_id user_id vendor_product EventID Guid Opcode Name Path ProcessID ScriptBlockId ScriptBlockText | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `powershell_remove_windows_defender_directory_filter`'
+search: |-
+    `powershell`
+    EventCode=4104
+    ScriptBlockText = "*rmdir *"
+    ScriptBlockText = "*\\Microsoft\\Windows Defender*"
+    | fillnull
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+      by dest signature signature_id user_id
+         vendor_product EventID Guid Opcode
+         Name Path ProcessID
+         ScriptBlockId ScriptBlockText
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `powershell_remove_windows_defender_directory_filter`
 how_to_implement: To successfully implement this analytic, you will need to enable PowerShell Script Block Logging on some or all endpoints. Additional setup here https://help.splunk.com/en/security-offerings/splunk-user-behavior-analytics/get-data-in/5.4.1/add-other-data-to-splunk-uba/configure-powershell-logging-to-see-powershell-anomalies-in-splunk-uba.
 known_false_positives: No false positives have been identified at this time.
 references:
@@ -23,18 +41,16 @@ drilldown_searches:
       search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$Computer$", "$user$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
       earliest_offset: 7d
       latest_offset: "0"
-finding:
-    title: suspicious powershell script $ScriptBlockText$ was executed on the $dest$
-    entity:
-        field: user_id
-        type: user
-        score: 50
 intermediate_findings:
     entities:
         - field: dest
           type: system
-          score: 50
-          message: suspicious powershell script $ScriptBlockText$ was executed on the $dest$
+          score: 20
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing rmdir commands to potentially delete the Windows Defender directory was executed on host $dest$ by user $user_id$
+        - field: user_id
+          type: user
+          score: 20
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing rmdir commands to potentially delete the Windows Defender directory was executed on host $dest$ by user $user_id$
 analytic_story:
     - Data Destruction
     - WhisperGate

--- a/detections/endpoint/powershell_windows_defender_exclusion_commands.yml
+++ b/detections/endpoint/powershell_windows_defender_exclusion_commands.yml
@@ -1,26 +1,37 @@
 name: Powershell Windows Defender Exclusion Commands
 id: 907ac95c-4dd9-11ec-ba2c-acde48001122
-version: 16
+version: 17
 creation_date: '2021-11-25'
-modification_date: '2026-06-08'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
 status: production
-type: TTP
-description: The following analytic detects the use of PowerShell commands to add or set Windows Defender exclusions. It leverages EventCode 4104 to identify suspicious `Add-MpPreference` or `Set-MpPreference` commands with exclusion parameters. This activity is significant because adversaries often use it to bypass Windows Defender, allowing malicious code to execute without detection. If confirmed malicious, this behavior could enable attackers to evade antivirus defenses, maintain persistence, and execute further malicious activities undetected.
+type: Anomaly
+description: |-
+    The following analytic detects the use of PowerShell commands to add or set Windows Defender exclusions.
+    It leverages EventCode 4104 to identify suspicious `Add-MpPreference` or `Set-MpPreference` commands with exclusion parameters.
+    This activity is significant because adversaries often use it to bypass Windows Defender, allowing malicious code to execute without detection.
+    If confirmed malicious, this behavior could enable attackers to evade antivirus defenses, maintain persistence, and execute further malicious activities undetected.
 data_source:
     - Powershell Script Block Logging 4104
 search: |-
-    `powershell` EventCode=4104 (ScriptBlockText = "*Add-MpPreference *" OR ScriptBlockText = "*Set-MpPreference *") AND ScriptBlockText = "*-exclusion*"
-      | fillnull
-      | stats count min(_time) as firstTime max(_time) as lastTime
-        BY dest signature signature_id
-           user_id vendor_product EventID
-           Guid Opcode Name
-           Path ProcessID ScriptBlockId
-           ScriptBlockText
-      | `security_content_ctime(firstTime)`
-      | `security_content_ctime(lastTime)`
-      | `powershell_windows_defender_exclusion_commands_filter`
+    `powershell`
+    EventCode=4104
+    ScriptBlockText IN (
+        "*Add-MpPreference *",
+        "*Set-MpPreference *"
+    )
+    ScriptBlockText = "*-exclusion*"
+    | fillnull
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+      by dest signature signature_id
+         user_id vendor_product EventID
+         Guid Opcode Name
+         Path ProcessID ScriptBlockId
+         ScriptBlockText
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `powershell_windows_defender_exclusion_commands_filter`
 how_to_implement: To successfully implement this search you need to be ingesting information on process that include the name of the process responsible for the changes from your endpoints into the `Endpoint` datamodel in the `Registry` node. Also make sure that this registry was included in your config files ex. sysmon config to be monitored.
 known_false_positives: admin or user may choose to use this windows features.
 references:
@@ -36,18 +47,16 @@ drilldown_searches:
       search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$user_id$", "$dest$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
       earliest_offset: 7d
       latest_offset: "0"
-finding:
-    title: Exclusion command $ScriptBlockText$ executed on $dest$
-    entity:
-        field: user_id
-        type: user
-        score: 50
 intermediate_findings:
     entities:
         - field: dest
           type: system
-          score: 50
-          message: Exclusion command $ScriptBlockText$ executed on $dest$
+          score: 20
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing exclusion commands to add or set Windows Defender exclusions was executed on host $dest$
+        - field: user_id
+          type: user
+          score: 20
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing exclusion commands to add or set Windows Defender exclusions was executed on host $dest$ by user $user_id$
 analytic_story:
     - CISA AA22-320A
     - AgentTesla

--- a/detections/endpoint/windows_clipboard_data_via_get_clipboard.yml
+++ b/detections/endpoint/windows_clipboard_data_via_get_clipboard.yml
@@ -1,26 +1,33 @@
 name: Windows ClipBoard Data via Get-ClipBoard
 id: ab73289e-2246-4de0-a14b-67006c72a893
-version: 11
+version: 12
 creation_date: '2022-12-06'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly
-description: The following analytic detects the execution of the PowerShell command 'Get-Clipboard' to retrieve clipboard data. It leverages PowerShell Script Block Logging (EventCode 4104) to identify instances where this command is used. This activity is significant because it can indicate an attempt to steal sensitive information such as usernames, passwords, or other confidential data copied to the clipboard. If confirmed malicious, this behavior could lead to unauthorized access to sensitive information, potentially compromising user accounts and other critical assets.
+description: |-
+    The following analytic detects the execution of the PowerShell command 'Get-Clipboard' to retrieve clipboard data.
+    It leverages PowerShell Script Block Logging (EventCode 4104) to identify instances where this command is used.
+    This activity is significant because it can indicate an attempt to steal sensitive information such as usernames, passwords, or other confidential data copied to the clipboard.
+    If confirmed malicious, this behavior could lead to unauthorized access to sensitive information, potentially compromising user accounts and other critical assets.
 data_source:
     - Powershell Script Block Logging 4104
 search: |-
-    `powershell` EventCode=4104 ScriptBlockText = "*Get-Clipboard*"
-      | fillnull
-      | stats count min(_time) as firstTime max(_time) as lastTime
-        BY dest signature signature_id
-           user_id vendor_product EventID
-           Guid Opcode Name
-           Path ProcessID ScriptBlockId
-           ScriptBlockText
-      | `security_content_ctime(firstTime)`
-      | `security_content_ctime(lastTime)`
-      | `windows_clipboard_data_via_get_clipboard_filter`
+    `powershell`
+    EventCode=4104
+    ScriptBlockText = "*Get-Clipboard*"
+    | fillnull
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+      by dest signature signature_id
+         user_id vendor_product EventID
+         Guid Opcode Name
+         Path ProcessID ScriptBlockId
+         ScriptBlockText
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `windows_clipboard_data_via_get_clipboard_filter`
 how_to_implement: To successfully implement this analytic, you will need to enable PowerShell Script Block Logging on some or all endpoints. Additional setup here https://help.splunk.com/en/security-offerings/splunk-user-behavior-analytics/get-data-in/5.4.1/add-other-data-to-splunk-uba/configure-powershell-logging-to-see-powershell-anomalies-in-splunk-uba.
 known_false_positives: It is possible there will be false positives, filter as needed.
 references:
@@ -41,11 +48,11 @@ intermediate_findings:
         - field: dest
           type: system
           score: 20
-          message: Powershell script $ScriptBlockText$ execute Get-Clipboard commandlet on $dest$
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing Get-Clipboard commandlet to retrieve clipboard data was executed on host $dest$
         - field: user_id
           type: user
           score: 20
-          message: Powershell script $ScriptBlockText$ execute Get-Clipboard commandlet on $dest$
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing Get-Clipboard commandlet to retrieve clipboard data was executed on host $dest$ by user $user_id$
 analytic_story:
     - Windows Post-Exploitation
     - Prestige Ransomware

--- a/detections/endpoint/windows_powershell_import_applocker_policy.yml
+++ b/detections/endpoint/windows_powershell_import_applocker_policy.yml
@@ -1,26 +1,35 @@
 name: Windows Powershell Import Applocker Policy
 id: 102af98d-0ca3-4aa4-98d6-7ab2b98b955a
-version: 13
+version: 14
 creation_date: '2022-06-30'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
 status: production
-type: TTP
-description: The following analytic detects the import of Windows PowerShell Applocker cmdlets, specifically identifying the use of "Import-Module Applocker" and "Set-AppLockerPolicy" with an XML policy. It leverages PowerShell Script Block Logging (EventCode 4104) to capture and analyze script block text. This activity is significant as it may indicate an attempt to enforce restrictive Applocker policies, potentially used by malware like Azorult to disable antivirus products. If confirmed malicious, this could allow an attacker to bypass security controls, leading to further system compromise and persistence.
+type: Anomaly
+description: |-
+    The following analytic detects the import of Windows PowerShell Applocker cmdlets, specifically identifying the use of "Import-Module Applocker" and "Set-AppLockerPolicy" with an XML policy.
+    It leverages PowerShell Script Block Logging (EventCode 4104) to capture and analyze script block text.
+    This activity is significant as it may indicate an attempt to enforce restrictive Applocker policies, potentially used by malware like Azorult to disable antivirus products.
+    If confirmed malicious, this could allow an attacker to bypass security controls, leading to further system compromise and persistence.
 data_source:
     - Powershell Script Block Logging 4104
 search: |-
-    `powershell` EventCode=4104 ScriptBlockText="*Import-Module Applocker*" ScriptBlockText="*Set-AppLockerPolicy*" ScriptBlockText="* -XMLPolicy *"
-      | fillnull
-      | stats count min(_time) as firstTime max(_time) as lastTime
-        BY dest signature signature_id
-           user_id vendor_product EventID
-           Guid Opcode Name
-           Path ProcessID ScriptBlockId
-           ScriptBlockText
-      | `security_content_ctime(firstTime)`
-      | `security_content_ctime(lastTime)`
-      | `windows_powershell_import_applocker_policy_filter`
+    `powershell`
+    EventCode=4104
+    ScriptBlockText="*Import-Module Applocker*"
+    ScriptBlockText="*Set-AppLockerPolicy*"
+    ScriptBlockText="* -XMLPolicy *"
+    | fillnull
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+      by dest signature signature_id
+         user_id vendor_product EventID
+         Guid Opcode Name
+         Path ProcessID ScriptBlockId
+         ScriptBlockText
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `windows_powershell_import_applocker_policy_filter`
 how_to_implement: To successfully implement this analytic, you will need to enable PowerShell Script Block Logging on some or all endpoints. Additional setup here https://help.splunk.com/en/security-offerings/splunk-user-behavior-analytics/get-data-in/5.4.1/add-other-data-to-splunk-uba/configure-powershell-logging-to-see-powershell-anomalies-in-splunk-uba.
 known_false_positives: administrators may execute this command that may cause some false positive.
 references:
@@ -34,18 +43,16 @@ drilldown_searches:
       search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$", "$user_id$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
       earliest_offset: 7d
       latest_offset: "0"
-finding:
-    title: A PowerShell script contains Import Applocker Policy command $ScriptBlockText$ on host $dest$
-    entity:
-        field: user_id
-        type: user
-        score: 50
 intermediate_findings:
     entities:
         - field: dest
           type: system
-          score: 50
-          message: A PowerShell script contains Import Applocker Policy command $ScriptBlockText$ on host $dest$
+          score: 20
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing Import-Module Applocker and Set-AppLockerPolicy commands to import Applocker policy was executed on host $dest$
+        - field: user_id
+          type: user
+          score: 20
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing Import-Module Applocker and Set-AppLockerPolicy commands to import Applocker policy was executed on host $dest$ by user $user_id$
 analytic_story:
     - Azorult
 asset_type: Endpoint

--- a/detections/endpoint/windows_powershell_logoff_user_via_quser.yml
+++ b/detections/endpoint/windows_powershell_logoff_user_via_quser.yml
@@ -1,26 +1,32 @@
 name: Windows Powershell Logoff User via Quser
 id: 6d70780d-4cfe-4820-bafd-1b43941986b5
-version: 8
+version: 9
 creation_date: '2024-12-13'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
 status: production
 type: Anomaly
-description: "The following analytic detects the process of logging off a user through the use of the quser and logoff commands. By monitoring for these commands, the analytic identifies actions where a user session is forcibly terminated, which could be part of an administrative task or a potentially unauthorized access attempt. This detection helps identify potential misuse or malicious activity where a user’s access is revoked without proper authorization, providing insight into potential security incidents involving account management or session manipulation."
+description: |-
+    The following analytic detects the process of logging off a user through the use of the quser and logoff commands.
+    By monitoring for these commands, the analytic identifies actions where a user session is forcibly terminated, which could be part of an administrative task or a potentially unauthorized access attempt.
+    This detection helps identify potential misuse or malicious activity where a user's access is revoked without proper authorization, providing insight into potential security incidents involving account management or session manipulation.
 data_source:
     - Powershell Script Block Logging 4104
 search: |-
-    `powershell` EventCode=4104 ScriptBlockText = "*quser*logoff*"
-      | fillnull
-      | stats count min(_time) as firstTime max(_time) as lastTime
-        BY dest signature signature_id
-           user_id vendor_product EventID
-           Guid Opcode Name
-           Path ProcessID ScriptBlockId
-           ScriptBlockText
-      | `security_content_ctime(firstTime)`
-      | `security_content_ctime(lastTime)`
-      | `windows_powershell_logoff_user_via_quser_filter`
+    `powershell`
+    EventCode=4104
+    ScriptBlockText = "*quser*logoff*"
+    | fillnull
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+      by dest signature signature_id
+         user_id vendor_product EventID
+         Guid Opcode Name
+         Path ProcessID ScriptBlockId
+         ScriptBlockText
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `windows_powershell_logoff_user_via_quser_filter`
 how_to_implement: The following Hunting analytic requires PowerShell operational logs to be imported. Modify the powershell macro as needed to match the sourcetype or add index. This analytic is specific to 4104, or PowerShell Script Block Logging.
 known_false_positives: Administrators or power users may use this command.
 references:
@@ -39,7 +45,11 @@ intermediate_findings:
         - field: dest
           type: system
           score: 20
-          message: Powershell process having commandline [$ScriptBlockText$] used to logoff user on [$dest$].
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing quser and logoff commands to potentially logoff user was executed on host $dest$
+        - field: user_id
+          type: user
+          score: 20
+          message: A suspicious powershell script with the ScriptBlockId [$ScriptBlockId$] containing quser and logoff commands to potentially logoff user was executed on host $dest$ by user $user_id$
 analytic_story:
     - Crypto Stealer
 asset_type: Endpoint


### PR DESCRIPTION
This PR updates the IF's message for analytics leveraging the Pwsh ScriptBlock datasource.
Due to a visual bug that could occur with large ScriptBlockText fields, its preferable to not omit it as part of the Finding/IF message.

I also took the opportunity to update the type of these analytics to anomaly as as well as adjust their message description.

### Updated Analytics [9]

- powershell_domain_enumeration
- powershell_environment_variable_execution
- powershell_loading_dotnet_into_memory_via_reflection
- powershell_processing_stream_of_data
- powershell_remove_windows_defender_directory
- powershell_windows_defender_exclusion_commands
- windows_clipboard_data_via_get_clipboard
- windows_powershell_import_applocker_policy
- windows_powershell_logoff_user_via_quser

> See TR-4471