### PR TITLE
Remote Thread Analytics Update

### DIFF
--- a/data_sources/sysmon_eventid_8.yml
+++ b/data_sources/sysmon_eventid_8.yml
@@ -1,8 +1,8 @@
 name: Sysmon EventID 8
 id: df7a786c-ade0-48f0-8596-26f10d169f7d
-version: 4
+version: 5
 creation_date: '2024-05-22'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Patrick Bareiss, Splunk
 description: Logs the creation of a new thread in a process, including details about the thread ID, start address, and source process.
 mitre_components:
@@ -102,18 +102,17 @@ fields:
     - vendor_product
 output_fields:
     - dest
-    - parent_process_exec
-    - parent_process_guid
-    - parent_process_id
-    - parent_process_name
-    - parent_process_path
-    - process_exec
-    - process_guid
-    - process_id
-    - process_name
-    - process_path
-    - signature
     - signature_id
-    - user_id
+    - signature
+    - SourceProcessGuid
+    - SourceProcessId
+    - SourceImage
+    - TargetProcessGuid
+    - TargetProcessId
+    - TargetImage
+    - StartModule
+    - StartFunction
+    - SourceUser
+    - TargetUser
     - vendor_product
 example_log: <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385F-C22A-43E0-BF4C-06F5698FFBD9}'/><EventID>8</EventID><Version>2</Version><Level>4</Level><Task>8</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2022-10-27T13:59:12.440938600Z'/><EventRecordID>362233</EventRecordID><Correlation/><Execution ProcessID='2656' ThreadID='2360'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>win-dc-ctus-attack-range-487.attackrange.local</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>-</Data><Data Name='UtcTime'>2022-10-27 13:59:12.427</Data><Data Name='SourceProcessGuid'>{3381F800-8EB0-635A-1306-000000008A02}</Data><Data Name='SourceProcessId'>4864</Data><Data Name='SourceImage'>C:\Windows\SysWOW64\wermgr.exe</Data><Data Name='TargetProcessGuid'>{3381F800-8085-635A-2701-000000008A02}</Data><Data Name='TargetProcessId'>5572</Data><Data Name='TargetImage'>C:\Windows\System32\Taskmgr.exe</Data><Data Name='NewThreadId'>4964</Data><Data Name='StartAddress'>0x0000000000C20000</Data><Data Name='StartModule'>-</Data><Data Name='StartFunction'>-</Data></EventData></Event>

--- a/detections/deprecated/rundll32_createremotethread_in_browser.yml
+++ b/detections/deprecated/rundll32_createremotethread_in_browser.yml
@@ -1,15 +1,40 @@
 name: Rundll32 CreateRemoteThread In Browser
 id: f8a22586-ee2d-11eb-a193-acde48001122
-version: 10
+version: 11
 creation_date: '2021-07-29'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
-status: production
+status: deprecated
 type: TTP
-description: The following analytic detects the suspicious creation of a remote thread by rundll32.exe targeting browser processes such as firefox.exe, chrome.exe, iexplore.exe, and microsoftedgecp.exe. This detection leverages Sysmon EventCode 8, focusing on SourceImage and TargetImage fields to identify the behavior. This activity is significant as it is commonly associated with malware like IcedID, which hooks browsers to steal sensitive information such as banking details. If confirmed malicious, this could allow attackers to intercept and exfiltrate sensitive user data, leading to potential financial loss and privacy breaches.
+description: |-
+    The following analytic detects the suspicious creation of a remote thread by rundll32.exe targeting browser processes such as firefox.exe, chrome.exe, iexplore.exe, and microsoftedgecp.exe.
+    This detection leverages Sysmon EventCode 8, focusing on SourceImage and TargetImage fields to identify the behavior.
+    This activity is significant as it is commonly associated with malware like IcedID, which hooks browsers to steal sensitive information such as banking details.
+    If confirmed malicious, this could allow attackers to intercept and exfiltrate sensitive user data, leading to potential financial loss and privacy breaches.
 data_source:
     - Sysmon EventID 8
-search: '`sysmon` EventCode=8 SourceImage = "*\\rundll32.exe" TargetImage IN ("*\\firefox.exe", "*\\chrome.exe", "*\\iexplore.exe","*\\microsoftedgecp.exe") | stats count min(_time) as firstTime max(_time) as lastTime by EventID Guid NewThreadId ProcessID SecurityID SourceImage SourceProcessGuid SourceProcessId StartAddress StartFunction StartModule TargetImage TargetProcessGuid TargetProcessId UserID dest parent_process_exec parent_process_guid parent_process_id parent_process_name parent_process_path process_exec process_guid process_id process_name process_path signature signature_id user_id vendor_product | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `rundll32_createremotethread_in_browser_filter`'
+search: |-
+    `sysmon`
+    EventCode=8
+    SourceImage="*\\rundll32.exe"
+    TargetImage IN (
+        "*\\chrome.exe",
+        "*\\firefox.exe",
+        "*\\iexplore.exe",
+        "*\\microsoftedgecp.exe"
+    )
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+                  values(NewThreadId) as "NewThreadId"
+                  values(StartAddress) as "StartAddress"
+      by dest signature_id signature
+         SourceProcessGuid SourceProcessId SourceImage
+         TargetProcessGuid TargetProcessId TargetImage
+         StartModule StartFunction
+         SourceUser TargetUser vendor_product
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `rundll32_createremotethread_in_browser_filter`
 how_to_implement: To successfully implement this search, you need to be ingesting logs with the SourceImage, TargetImage, and EventCode executions from your endpoints related to create remote thread or injecting codes. If you are using Sysmon, you must have at least version 6.0.4 of the Sysmon TA.
 known_false_positives: No false positives have been identified at this time.
 references:
@@ -51,3 +76,8 @@ tests:
           source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
           sourcetype: XmlWinEventLog
       test_type: unit
+deprecation_info:
+    reason: Detection has been deprecated. The search is being replaced with a more generic detection that captures the behavior instead of relying on specific source processes.
+    removed_in_version: 6.4.0
+    replacement_content:
+        - Uncommon Remote Thread Creation In Browser Process

--- a/detections/deprecated/rundll32_createremotethread_in_browser.yml
+++ b/detections/deprecated/rundll32_createremotethread_in_browser.yml
@@ -80,4 +80,4 @@ deprecation_info:
     reason: Detection has been deprecated. The search is being replaced with a more generic detection that captures the behavior instead of relying on specific source processes.
     removed_in_version: 6.4.0
     replacement_content:
-        - Uncommon Remote Thread Creation In Browser Process
+        - Windows Uncommon Remote Thread Creation In Browser Process

--- a/detections/deprecated/windows_process_injection_of_wermgr_to_known_browser.yml
+++ b/detections/deprecated/windows_process_injection_of_wermgr_to_known_browser.yml
@@ -1,15 +1,31 @@
 name: Windows Process Injection Of Wermgr to Known Browser
 id: aec755a5-3a2c-4be0-ab34-6540e68644e9
-version: 11
+version: 12
 creation_date: '2022-10-28'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
-status: production
+status: deprecated
 type: TTP
 description: The following analytic identifies the suspicious remote thread execution of the wermgr.exe process into known browsers such as firefox.exe, chrome.exe, and others. It leverages Sysmon EventCode 8 logs to detect this behavior by monitoring SourceImage and TargetImage fields. This activity is significant because it is indicative of Qakbot malware, which injects malicious code into legitimate processes to steal information. If confirmed malicious, this activity could allow attackers to execute arbitrary code, escalate privileges, and exfiltrate sensitive data from the compromised host.
 data_source:
     - Sysmon EventID 8
-search: '`sysmon` EventCode=8 SourceImage = "*\\wermgr.exe" TargetImage IN ("*\\firefox.exe", "*\\chrome.exe", "*\\iexplore.exe","*\\microsoftedgecp.exe") | stats count min(_time) as firstTime max(_time) as lastTime by EventID Guid NewThreadId ProcessID SecurityID SourceImage SourceProcessGuid SourceProcessId StartAddress StartFunction StartModule TargetImage TargetProcessGuid TargetProcessId UserID dest parent_process_exec parent_process_guid parent_process_id parent_process_name parent_process_path process_exec process_guid process_id process_name process_path signature signature_id user_id vendor_product | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `windows_process_injection_of_wermgr_to_known_browser_filter`'
+search: |-
+    `sysmon`
+    EventCode=8
+    SourceImage="*\\wermgr.exe"
+    TargetImage IN ("*\\firefox.exe", "*\\chrome.exe", "*\\iexplore.exe","*\\microsoftedgecp.exe")
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+                  values(NewThreadId) as "NewThreadId"
+                  values(StartAddress) as "StartAddress"
+      by dest signature_id signature
+         SourceProcessGuid SourceProcessId SourceImage
+         TargetProcessGuid TargetProcessId TargetImage
+         StartModule StartFunction
+         SourceUser TargetUser vendor_product
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `windows_process_injection_of_wermgr_to_known_browser_filter`
 how_to_implement: To successfully implement this search, you need to be ingesting logs with the SourceImage, TargetImage, and EventCode executions from your endpoints related to create remote thread or injecting codes. If you are using Sysmon, you must have at least version 6.0.4 of the Sysmon TA.
 known_false_positives: No false positives have been identified at this time.
 references:
@@ -48,3 +64,8 @@ tests:
           source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
           sourcetype: XmlWinEventLog
       test_type: unit
+deprecation_info:
+    reason: Detection has been deprecated. The search is being replaced with a more generic detection that captures the behavior instead of relying on specific source processes.
+    removed_in_version: 6.4.0
+    replacement_content:
+        - Uncommon Remote Thread Creation In Browser Process

--- a/detections/deprecated/windows_process_injection_of_wermgr_to_known_browser.yml
+++ b/detections/deprecated/windows_process_injection_of_wermgr_to_known_browser.yml
@@ -68,4 +68,4 @@ deprecation_info:
     reason: Detection has been deprecated. The search is being replaced with a more generic detection that captures the behavior instead of relying on specific source processes.
     removed_in_version: 6.4.0
     replacement_content:
-        - Uncommon Remote Thread Creation In Browser Process
+        - Windows Uncommon Remote Thread Creation In Browser Process

--- a/detections/deprecated/windows_process_injection_with_public_source_path.yml
+++ b/detections/deprecated/windows_process_injection_with_public_source_path.yml
@@ -2,9 +2,9 @@ name: Windows Process Injection With Public Source Path
 id: 492f09cf-5d60-4d87-99dd-0bc325532dda
 version: 11
 creation_date: '2022-09-05'
-modification_date: '2026-06-25'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
-status: production
+status: deprecated
 type: Hunting
 description: The following analytic detects a process from a non-standard file path on Windows attempting to create a remote thread in another process. This is identified using Sysmon EventCode 8, focusing on processes not originating from typical system directories. This behavior is significant as it often indicates process injection, a technique used by adversaries to evade detection or escalate privileges. If confirmed malicious, this activity could allow an attacker to execute arbitrary code within another process, potentially leading to unauthorized actions and further compromise of the system.
 data_source:
@@ -34,3 +34,7 @@ tests:
           source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
           sourcetype: XmlWinEventLog
       test_type: unit
+deprecation_info:
+    reason: Detection has been deprecated. The search is not helpful for the user to implement nor use, as it will generate too many false positives.
+    removed_in_version: 6.4.0
+    replacement_content: []

--- a/detections/endpoint/create_remote_thread_in_shell_application.yml
+++ b/detections/endpoint/create_remote_thread_in_shell_application.yml
@@ -29,8 +29,7 @@ search: |-
       by dest signature_id signature
          SourceProcessGuid SourceProcessId SourceImage
          TargetProcessGuid TargetProcessId TargetImage
-         StartModule StartFunction
-         SourceUser TargetUser vendor_product
+         StartModule StartFunction vendor_product
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `create_remote_thread_in_shell_application_filter`

--- a/detections/endpoint/create_remote_thread_in_shell_application.yml
+++ b/detections/endpoint/create_remote_thread_in_shell_application.yml
@@ -1,15 +1,39 @@
 name: Create Remote Thread In Shell Application
 id: 10399c1e-f51e-11eb-b920-acde48001122
-version: 12
+version: 13
 creation_date: '2021-08-05'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
-description: The following analytic detects suspicious process injection in command shell applications, specifically targeting `cmd.exe` and `powershell.exe`. It leverages Sysmon EventCode 8 to identify the creation of remote threads within these shell processes. This activity is significant because it is a common technique used by malware, such as IcedID, to inject malicious code and execute it within legitimate processes. If confirmed malicious, this behavior could allow an attacker to execute arbitrary code, escalate privileges, or maintain persistence within the environment, posing a severe threat to system security.
+description: |-
+    The following analytic detects suspicious process injection in command shell applications, specifically targeting `cmd.exe` and `powershell.exe`.
+    It leverages Sysmon EventCode 8 to identify the creation of remote threads within these shell processes.
+    This activity is significant because it is a common technique used by malware, such as IcedID, to inject malicious code and execute it within legitimate processes.
+    If confirmed malicious, this behavior could allow an attacker to execute arbitrary code, escalate privileges, or maintain persistence within the environment, posing a severe threat to system security.
 data_source:
     - Sysmon EventID 8
-search: '`sysmon` EventCode=8 TargetImage IN ("*\\cmd.exe", "*\\powershell*", "*\\pwsh.exe") | stats count min(_time) as firstTime max(_time) as lastTime by EventID Guid NewThreadId ProcessID SecurityID SourceImage SourceProcessGuid SourceProcessId StartAddress StartFunction StartModule TargetImage TargetProcessGuid TargetProcessId UserID dest parent_process_exec parent_process_guid parent_process_id parent_process_name parent_process_path process_exec process_guid process_id process_name process_path signature signature_id user_id vendor_product | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `create_remote_thread_in_shell_application_filter`'
+search: |-
+    `sysmon`
+    EventCode=8
+    TargetImage IN (
+        "*\\cmd.exe",
+        "*\\powershell_ise.exe",
+        "*\\powershell.exe",
+        "*\\pwsh.exe"
+    )
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+                  values(NewThreadId) as "NewThreadId"
+                  values(StartAddress) as "StartAddress"
+      by dest signature_id signature
+         SourceProcessGuid SourceProcessId SourceImage
+         TargetProcessGuid TargetProcessId TargetImage
+         StartModule StartFunction
+         SourceUser TargetUser vendor_product
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `create_remote_thread_in_shell_application_filter`
 how_to_implement: To successfully implement this search, you need to be ingesting logs with the process name, parent process, and command-line executions from your endpoints. If you are using Sysmon, you must have at least version 6.0.4 of the Sysmon TA.
 known_false_positives: No false positives have been identified at this time.
 references:
@@ -24,13 +48,15 @@ drilldown_searches:
       earliest_offset: 7d
       latest_offset: "0"
 finding:
-    title: process $process_name$ create a remote thread to shell app process $TargetImage$ in host $dest$
+    title: The process $SourceImage$ created a remote thread into the shell app process $TargetImage$ in host $dest$
     entity:
         field: dest
         type: system
         score: 50
 threat_objects:
-    - field: process_name
+    - field: SourceImage
+      type: process_name
+    - field: TargetImage
       type: process_name
 analytic_story:
     - IcedID

--- a/detections/endpoint/create_remote_thread_into_lsass.yml
+++ b/detections/endpoint/create_remote_thread_into_lsass.yml
@@ -25,8 +25,7 @@ search: |-
       by dest signature_id signature
          SourceProcessGuid SourceProcessId SourceImage
          TargetProcessGuid TargetProcessId TargetImage
-         StartModule StartFunction
-         SourceUser TargetUser vendor_product
+         StartModule StartFunction vendor_product
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `create_remote_thread_into_lsass_filter`

--- a/detections/endpoint/create_remote_thread_into_lsass.yml
+++ b/detections/endpoint/create_remote_thread_into_lsass.yml
@@ -1,30 +1,35 @@
 name: Create Remote Thread into LSASS
 id: 67d4dbef-9564-4699-8da8-03a151529edc
-version: 14
+version: 15
 creation_date: '2019-12-11'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Patrick Bareiss, Splunk
 status: production
 type: TTP
-description: The following analytic detects the creation of a remote thread in the Local Security Authority Subsystem Service (LSASS). This behavior is identified using Sysmon EventID 8 logs, focusing on processes that create remote threads in lsass.exe. This activity is significant because it is commonly associated with credential dumping, a tactic used by adversaries to steal user authentication credentials. If confirmed malicious, this could allow attackers to gain unauthorized access to sensitive information, leading to potential compromise of the entire network. Analysts should investigate to differentiate between legitimate tools and potential threats.
+description: |-
+    The following analytic detects the creation of a remote thread in the Local Security Authority Subsystem Service (LSASS).
+    This behavior is identified using Sysmon EventID 8 logs, focusing on processes that create remote threads in lsass.exe.
+    This activity is significant because it is commonly associated with credential dumping, a tactic used by adversaries to steal user authentication credentials.
+    If confirmed malicious, this could allow attackers to gain unauthorized access to sensitive information, leading to potential compromise of the entire network.
+    Analysts should investigate to differentiate between legitimate tools and potential threats.
 data_source:
     - Sysmon EventID 8
 search: |-
-    `sysmon` EventID=8 TargetImage=*lsass.exe
-      | stats count min(_time) as firstTime max(_time) as lastTime
-        BY EventID Guid NewThreadId
-           ProcessID SecurityID SourceImage
-           SourceProcessGuid SourceProcessId StartAddress
-           StartFunction StartModule TargetImage
-           TargetProcessGuid TargetProcessId UserID
-           dest parent_process_exec parent_process_guid
-           parent_process_id parent_process_name parent_process_path
-           process_exec process_guid process_id
-           process_name process_path signature
-           signature_id user_id vendor_product
-      | `security_content_ctime(firstTime)`
-      | `security_content_ctime(lastTime)`
-      | `create_remote_thread_into_lsass_filter`
+    `sysmon`
+    EventID=8
+    TargetImage="*\\lsass.exe"
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+                  values(NewThreadId) as "NewThreadId"
+                  values(StartAddress) as "StartAddress"
+      by dest signature_id signature
+         SourceProcessGuid SourceProcessId SourceImage
+         TargetProcessGuid TargetProcessId TargetImage
+         StartModule StartFunction
+         SourceUser TargetUser vendor_product
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `create_remote_thread_into_lsass_filter`
 how_to_implement: This search needs Sysmon Logs with a Sysmon configuration, which includes EventCode 8 with lsass.exe. This search uses an input macro named `sysmon`. We strongly recommend that you specify your environment-specific configurations (index, source, sourcetype, etc.) for Windows Sysmon logs. Replace the macro definition with configurations for your Splunk environment. The search also uses a post-filter macro designed to filter out known false positives.
 known_false_positives: Other tools can access LSASS for legitimate reasons and generate an event. In these cases, tweaking the search may help eliminate noise.
 references:

--- a/detections/endpoint/powershell_remote_thread_to_known_windows_process.yml
+++ b/detections/endpoint/powershell_remote_thread_to_known_windows_process.yml
@@ -1,15 +1,51 @@
 name: Powershell Remote Thread To Known Windows Process
 id: ec102cb2-a0f5-11eb-9b38-acde48001122
-version: 11
+version: 12
 creation_date: '2021-04-26'
-modification_date: '2026-05-13'
+modification_date: '2026-07-01'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
-description: The following analytic detects suspicious PowerShell processes attempting to inject code into critical Windows processes using CreateRemoteThread. It leverages Sysmon EventCode 8 to identify instances where PowerShell spawns threads in processes like svchost.exe, csrss.exe, and others. This activity is significant as it is commonly used by malware such as TrickBot and offensive tools like Cobalt Strike to execute malicious payloads, establish reverse shells, or download additional malware. If confirmed malicious, this behavior could lead to unauthorized code execution, privilege escalation, and persistent access within the environment.
+description: |-
+    The following analytic detects suspicious PowerShell processes attempting to inject code into critical Windows processes using CreateRemoteThread.
+    It leverages Sysmon EventCode 8 to identify instances where PowerShell spawns threads in processes like svchost.exe, csrss.exe, and others.
+    This activity is significant as it is commonly used by malware such as TrickBot and offensive tools like Cobalt Strike to execute malicious payloads, establish reverse shells, or download additional malware.
+    If confirmed malicious, this behavior could lead to unauthorized code execution, privilege escalation, and persistent access within the environment.
 data_source:
     - Sysmon EventID 8
-search: '`sysmon` EventCode = 8 parent_process_name IN ("powershell_ise.exe", "powershell.exe") TargetImage IN ("*\\svchost.exe","*\\csrss.exe" "*\\gpupdate.exe", "*\\explorer.exe","*\\services.exe","*\\winlogon.exe","*\\smss.exe","*\\wininit.exe","*\\userinit.exe","*\\spoolsv.exe","*\\taskhost.exe") | stats count min(_time) as firstTime max(_time) as lastTime by EventID Guid NewThreadId ProcessID SecurityID SourceImage SourceProcessGuid SourceProcessId StartAddress StartFunction StartModule TargetImage TargetProcessGuid TargetProcessId UserID dest parent_process_exec parent_process_guid parent_process_id parent_process_name parent_process_path process_exec process_guid process_id process_name process_path signature signature_id user_id vendor_product | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `powershell_remote_thread_to_known_windows_process_filter`'
+search: |-
+    `sysmon`
+    EventCode=8
+    SourceImage IN (
+        "*\\powershell_ise.exe",
+        "*\\powershell.exe",
+        "*\\pwsh.exe"
+    )
+    TargetImage IN (
+        "*\\csrss.exe",
+        "*\\explorer.exe",
+        "*\\gpupdate.exe",
+        "*\\services.exe",
+        "*\\smss.exe",
+        "*\\spoolsv.exe",
+        "*\\svchost.exe",
+        "*\\taskhost.exe",
+        "*\\userinit.exe",
+        "*\\wininit.exe",
+        "*\\winlogon.exe"
+    )
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+                  values(NewThreadId) as "NewThreadId"
+                  values(StartAddress) as "StartAddress"
+      by dest signature_id signature
+         SourceProcessGuid SourceProcessId SourceImage
+         TargetProcessGuid TargetProcessId TargetImage
+         StartModule StartFunction
+         SourceUser TargetUser vendor_product
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `powershell_remote_thread_to_known_windows_process_filter`
 how_to_implement: To successfully implement this search, you need to be ingesting logs with the process name, Create Remote thread from your endpoints. If you are using Sysmon, you must have at least version 6.0.4 of the Sysmon TA. Tune and filter known instances of create remote thread may be used.
 known_false_positives: No false positives have been identified at this time.
 references:
@@ -24,13 +60,15 @@ drilldown_searches:
       earliest_offset: 7d
       latest_offset: "0"
 finding:
-    title: A suspicious powershell process $process_name$ that tries to create a remote thread on target process $TargetImage$ on host $dest$
+    title: A suspicious powershell process $SourceImage$ created a remote thread into the target process $TargetImage$ on host $dest$
     entity:
         field: dest
         type: system
         score: 50
 threat_objects:
-    - field: process_name
+    - field: SourceImage
+      type: process_name
+    - field: TargetImage
       type: process_name
 analytic_story:
     - Trickbot

--- a/detections/endpoint/powershell_remote_thread_to_known_windows_process.yml
+++ b/detections/endpoint/powershell_remote_thread_to_known_windows_process.yml
@@ -41,8 +41,7 @@ search: |-
       by dest signature_id signature
          SourceProcessGuid SourceProcessId SourceImage
          TargetProcessGuid TargetProcessId TargetImage
-         StartModule StartFunction
-         SourceUser TargetUser vendor_product
+         StartModule StartFunction vendor_product
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `powershell_remote_thread_to_known_windows_process_filter`

--- a/detections/endpoint/rundll32_create_remote_thread_to_a_process.yml
+++ b/detections/endpoint/rundll32_create_remote_thread_to_a_process.yml
@@ -1,15 +1,34 @@
 name: Rundll32 Create Remote Thread To A Process
 id: 2dbeee3a-f067-11eb-96c0-acde48001122
-version: 10
+version: 11
 creation_date: '2021-07-29'
-modification_date: '2026-05-13'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
-description: The following analytic detects the creation of a remote thread by rundll32.exe into another process. It leverages Sysmon EventCode 8 logs, specifically monitoring SourceImage and TargetImage fields. This activity is significant as it is a common technique used by malware, such as IcedID, to execute malicious code within legitimate processes, aiding in defense evasion and data theft. If confirmed malicious, this behavior could allow an attacker to execute arbitrary code, escalate privileges, and exfiltrate sensitive information from the compromised host.
+description: |-
+    The following analytic detects the creation of a remote thread by rundll32.exe into another process. It leverages Sysmon EventCode 8 logs, specifically monitoring SourceImage and TargetImage fields.
+    This activity is significant as it is a common technique used by malware, such as IcedID, to execute malicious code within legitimate processes, aiding in defense evasion and data theft.
+    If confirmed malicious, this behavior could allow an attacker to execute arbitrary code, escalate privileges, and exfiltrate sensitive information from the compromised host.
 data_source:
     - Sysmon EventID 8
-search: '`sysmon` EventCode=8 SourceImage = "*\\rundll32.exe" TargetImage = "*.exe" | stats count min(_time) as firstTime max(_time) as lastTime by EventID Guid NewThreadId ProcessID SecurityID SourceImage SourceProcessGuid SourceProcessId StartAddress StartFunction StartModule TargetImage TargetProcessGuid TargetProcessId UserID dest parent_process_exec parent_process_guid parent_process_id parent_process_name parent_process_path process_exec process_guid process_id process_name process_path signature signature_id user_id vendor_product | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `rundll32_create_remote_thread_to_a_process_filter`'
+search: |-
+    `sysmon`
+    EventCode=8
+    SourceImage="*\\rundll32.exe"
+    TargetImage = "*.exe"
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+                  values(NewThreadId) as "NewThreadId"
+                  values(StartAddress) as "StartAddress"
+      by dest signature_id signature
+         SourceProcessGuid SourceProcessId SourceImage
+         TargetProcessGuid TargetProcessId TargetImage
+         StartModule StartFunction
+         SourceUser TargetUser vendor_product
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `rundll32_create_remote_thread_to_a_process_filter`
 how_to_implement: To successfully implement this search, you need to be ingesting logs with the SourceImage, TargetImage, and EventCode executions from your endpoints related to create remote thread or injecting codes. If you are using Sysmon, you must have at least version 6.0.4 of the Sysmon TA.
 known_false_positives: No false positives have been identified at this time.
 references:

--- a/detections/endpoint/rundll32_create_remote_thread_to_a_process.yml
+++ b/detections/endpoint/rundll32_create_remote_thread_to_a_process.yml
@@ -24,8 +24,7 @@ search: |-
       by dest signature_id signature
          SourceProcessGuid SourceProcessId SourceImage
          TargetProcessGuid TargetProcessId TargetImage
-         StartModule StartFunction
-         SourceUser TargetUser vendor_product
+         StartModule StartFunction vendor_product
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `rundll32_create_remote_thread_to_a_process_filter`

--- a/detections/endpoint/windows_process_injection_remote_thread.yml
+++ b/detections/endpoint/windows_process_injection_remote_thread.yml
@@ -38,8 +38,7 @@ search: |-
       by dest signature_id signature
          SourceProcessGuid SourceProcessId SourceImage
          TargetProcessGuid TargetProcessId TargetImage
-         StartModule StartFunction
-         SourceUser TargetUser vendor_product
+         StartModule StartFunction vendor_product
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `windows_process_injection_remote_thread_filter`

--- a/detections/endpoint/windows_process_injection_remote_thread.yml
+++ b/detections/endpoint/windows_process_injection_remote_thread.yml
@@ -2,7 +2,7 @@ name: Windows Process Injection Remote Thread
 id: 8a618ade-ca8f-4d04-b972-2d526ba59924
 version: 14
 creation_date: '2022-10-28'
-modification_date: '2026-06-25'
+modification_date: '2026-06-29'
 author: Teoderick Contreras, Splunk
 status: production
 type: TTP
@@ -33,14 +33,13 @@ search: |-
     )
     | stats count min(_time) as firstTime
                   max(_time) as lastTime
-    by EventID Guid NewThreadId ProcessID SecurityID SourceImage
-       SourceProcessGuid SourceProcessId StartAddress StartFunction
-       StartModule TargetImage TargetProcessGuid TargetProcessId UserID
-       dest parent_process_exec parent_process_guid parent_process_id
-       parent_process_name parent_process_path process_exec process_guid
-       process_id process_name process_path signature signature_id
-       user_id vendor_product
-
+                  values(NewThreadId) as "NewThreadId"
+                  values(StartAddress) as "StartAddress"
+      by dest signature_id signature
+         SourceProcessGuid SourceProcessId SourceImage
+         TargetProcessGuid TargetProcessId TargetImage
+         StartModule StartFunction
+         SourceUser TargetUser vendor_product
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `windows_process_injection_remote_thread_filter`

--- a/detections/endpoint/windows_uncommon_remote_thread_creation_in_browser_process.yml
+++ b/detections/endpoint/windows_uncommon_remote_thread_creation_in_browser_process.yml
@@ -1,4 +1,4 @@
-name: Uncommon Remote Thread Creation In Browser Process
+name: Windows Uncommon Remote Thread Creation In Browser Process
 id: aec755a5-3a2c-4be0-ab34-6540e68644e9
 version: 1
 creation_date: '2026-06-29'
@@ -122,7 +122,7 @@ search: |-
          SourceUser TargetUser vendor_product
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
-    | `windows_process_injection_of_wermgr_to_known_browser_filter`
+    | `windows_uncommon_remote_thread_creation_in_browser_process_filter`
 how_to_implement: |-
     To successfully implement this search, you need to be ingesting logs with the SourceImage, TargetImage, and EventCode executions from your endpoints related to create remote thread or injecting codes. If you are using Sysmon, you must have at least version 6.0.4 of the Sysmon TA.
 known_false_positives: No false positives have been identified at this time.

--- a/detections/endpoint/windows_uncommon_remote_thread_creation_in_browser_process.yml
+++ b/detections/endpoint/windows_uncommon_remote_thread_creation_in_browser_process.yml
@@ -1,0 +1,178 @@
+name: Uncommon Remote Thread Creation In Browser Process
+id: aec755a5-3a2c-4be0-ab34-6540e68644e9
+version: 1
+creation_date: '2026-06-29'
+modification_date: '2026-06-29'
+author: Teoderick Contreras, Nasreddine Bencherchali, Splunk
+status: production
+type: Anomaly
+description: |-
+    The following analytic identifies the creation of a remote thread by a process such as wermgr.exe or rundll32.exe into a browser process such as firefox.exe, chrome.exe, and others.
+    These processes do not typically create remote threads, in browser processes.
+    It leverages Sysmon EventID 8 to detect this behavior by monitoring SourceImage and TargetImage fields.
+    This activity is significant because it is commonly associated with malware like Qakbot and IcedID, which injects malicious code into legitimate processes to steal information.
+    If confirmed malicious, this activity could allow attackers to execute arbitrary code, escalate privileges, and exfiltrate sensitive data from the compromised host.
+data_source:
+    - Sysmon EventID 8
+search: |-
+    `sysmon`
+    EventCode=8
+    SourceImage IN (
+        "*\\rundll32.exe",
+        "*\\wermgr.exe"
+    )
+    TargetImage IN (
+        "*\\Sputnik.exe",
+        "*\\ChromePlus.exe",
+        "*\\QIP Surf.exe",
+        "*\\BlackHawk.exe",
+        "*\\7Star.exe",
+        "*\\Sleipnir5.exe",
+        "*\\Citrio.exe",
+        "*\\Chrome SxS.exe",
+        "*\\Chrome.exe",
+        "*\\Coowon.exe",
+        "*\\CocCocBrowser.exe",
+        "*\\Uran.exe",
+        "*\\QQBrowser.exe",
+        "*\\Orbitum.exe",
+        "*\\Slimjet.exe",
+        "*\\Iridium.exe",
+        "*\\Vivaldi.exe",
+        "*\\Chromium.exe",
+        "*\\GhostBrowser.exe",
+        "*\\CentBrowser.exe",
+        "*\\Xvast.exe",
+        "*\\Chedot.exe",
+        "*\\SuperBird.exe",
+        "*\\360Browser.exe",
+        "*\\360Chrome.exe",
+        "*\\dragon.exe",
+        "*\\brave.exe",
+        "*\\torch.exe",
+        "*\\UCBrowser.exe",
+        "*\\BliskBrowser.exe",
+        "*\\Epic Privacy Browser.exe",
+        "*\\nichrome.exe",
+        "*\\AmigoBrowser.exe",
+        "*\\KometaBrowser.exe",
+        "*\\XpomBrowser.exe",
+        "*\\msedge.exe",
+        "*\\LiebaoBrowser.exe",
+        "*\\AvastBrowser.exe",
+        "*\\Kinza.exe",
+        "*\\seamonkey.exe",
+        "*\\icedragon.exe",
+        "*\\cyberfox.exe",
+        "*\\SlimBrowser.exe",
+        "*\\palemoon.exe",
+        "*\\opera.exe",
+        "*\\yandex.exe",
+        "*\\atom.exe",
+        "*\\Chromodo.exe",
+        "*\\360chrome.exe",
+        "*\\360se.exe",
+        "*\\Maxthon.exe",
+        "*\\k-meleon.exe",
+        "*\\SLBrowser.exe",
+        "*\\Go!.exe",
+        "*\\Secure Browser.exe",
+        "*\\Elements Browser.exe",
+        "*\\Mustang.exe",
+        "*\\Suhba.exe",
+        "*\\TorBro.exe",
+        "*\\RockMelt.exe",
+        "*\\Bromium.exe",
+        "*\\Twinkstar.exe",
+        "*\\iTop Private Browser.exe",
+        "*\\CCleaner Browser.exe",
+        "*\\AcWebBrowser.exe",
+        "*\\CoolNovo.exe",
+        "*\\spark.exe",
+        "*\\iron.exe",
+        "*\\Titan Browser.exe",
+        "*\\AVG Browser.exe",
+        "*\\UR Browser.exe",
+        "*\\Flock.exe",
+        "*\\CryptoTab Browser.exe",
+        "*\\Sidekick.exe",
+        "*\\SwingBrowser.exe",
+        "*\\SalamWeb.exe",
+        "*\\NetboxBrowser.exe",
+        "*\\GarenaPlus.exe",
+        "*\\InsomniacBrowser.exe",
+        "*\\Viasat Browser.exe",
+        "*\\whale.exe",
+        "*\\falkon.exe",
+        "*\\SogouExplorer.exe",
+        "*\\firefox.exe",
+        "*\\waterfox.exe",
+        "*\\thunderbird.exe",
+        "*\\basilisk.exe",
+        "*\\BitTubeBrowser.exe"
+    )
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+                  values(NewThreadId) as "NewThreadId"
+                  values(StartAddress) as "StartAddress"
+      by dest signature_id signature
+         SourceProcessGuid SourceProcessId SourceImage
+         TargetProcessGuid TargetProcessId TargetImage
+         StartModule StartFunction
+         SourceUser TargetUser vendor_product
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `windows_process_injection_of_wermgr_to_known_browser_filter`
+how_to_implement: |-
+    To successfully implement this search, you need to be ingesting logs with the SourceImage, TargetImage, and EventCode executions from your endpoints related to create remote thread or injecting codes. If you are using Sysmon, you must have at least version 6.0.4 of the Sysmon TA.
+known_false_positives: No false positives have been identified at this time.
+references:
+    - https://news.sophos.com/en-us/2022/03/10/qakbot-decoded/
+    - https://www.trellix.com/en-us/about/newsroom/stories/research/demystifying-qbot-malware.html
+    - https://www.joesandbox.com/analysis/380662/0/html
+drilldown_searches:
+    - name: View the detection results for - "$dest$"
+      search: '%original_detection_search% | search  dest = "$dest$"'
+      earliest_offset: $info_min_time$
+      latest_offset: $info_max_time$
+    - name: View risk events for the last 7 days for - "$dest$"
+      search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+      earliest_offset: 7d
+      latest_offset: "0"
+intermediate_findings:
+    entities:
+        - field: dest
+          type: system
+          score: 20
+          message: The process [$SourceImage$] created a remote thread into the browser process [$TargetImage$] in host $dest$.
+threat_objects:
+    - field: SourceImage
+      type: process_name
+    - field: TargetImage
+      type: process_name
+analytic_story:
+    - Qakbot
+    - IcedID
+    - Living Off The Land
+asset_type: Endpoint
+mitre_attack_id:
+    - T1055.001
+product:
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
+category: endpoint
+security_domain: endpoint
+tests:
+    - name: True Positive Test - Wermgr
+      attack_data:
+        - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/qakbot/remote_thread/sysmon_wermgr_remote.log
+          source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+          sourcetype: XmlWinEventLog
+      test_type: unit
+    - name: True Positive Test - Rundll32
+      attack_data:
+        - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/malware/icedid/inf_icedid/windows-sysmon.log
+          source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+          sourcetype: XmlWinEventLog
+      test_type: unit

--- a/detections/endpoint/windows_uncommon_remote_thread_creation_in_browser_process.yml
+++ b/detections/endpoint/windows_uncommon_remote_thread_creation_in_browser_process.yml
@@ -118,8 +118,7 @@ search: |-
       by dest signature_id signature
          SourceProcessGuid SourceProcessId SourceImage
          TargetProcessGuid TargetProcessId TargetImage
-         StartModule StartFunction
-         SourceUser TargetUser vendor_product
+         StartModule StartFunction vendor_product
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `windows_uncommon_remote_thread_creation_in_browser_process_filter`

--- a/detections/endpoint/windows_uncommon_remote_thread_creation_in_browser_process.yml
+++ b/detections/endpoint/windows_uncommon_remote_thread_creation_in_browser_process.yml
@@ -1,5 +1,5 @@
 name: Windows Uncommon Remote Thread Creation In Browser Process
-id: aec755a5-3a2c-4be0-ab34-6540e68644e9
+id: 634cce27-a3a6-4079-b0d6-3ced361a0aa9
 version: 1
 creation_date: '2026-06-29'
 modification_date: '2026-06-29'


### PR DESCRIPTION
This PR revisits some the analytics that leverage Sysmon EID 8. In order to update following:

- Update the output fields of the data source to reflect meaningful output that is aligned with what the event report.
- Use the raw field names, due to a miss-attribution done by the Sysmon TA (for example, calling source/target processes as parent/child). A bug has been filed internally to address these issues.
- Deprecation of content that is super prone to FPs as well as merge content where it make sense to ease management.

### New Analytics [1]

- detections/endpoint/windows_uncommon_remote_thread_creation_in_browser_process.yml

### Updated Analytics [5]

- detections/endpoint/create_remote_thread_in_shell_application.yml
- detections/endpoint/create_remote_thread_into_lsass.yml
- detections/endpoint/powershell_remote_thread_to_known_windows_process.yml
- detections/endpoint/rundll32_create_remote_thread_to_a_process.yml
- detections/endpoint/windows_process_injection_remote_thread.yml


### Updated Data Source [1]

- data_sources/sysmon_eventid_8.yml

### Deprecated Analytics [3]

- detections/deprecated/rundll32_createremotethread_in_browser.yml
- detections/deprecated/windows_process_injection_of_wermgr_to_known_browser.yml
- detections/deprecated/windows_process_injection_with_public_source_path.yml