### PR TITLE
Add PreAuthType filter to PetitPotam Kerberos TGT detection

### DIFF
--- a/detections/endpoint/petitpotam_suspicious_kerberos_tgt_request.yml
+++ b/detections/endpoint/petitpotam_suspicious_kerberos_tgt_request.yml
@@ -1,8 +1,8 @@
 name: PetitPotam Suspicious Kerberos TGT Request
 id: e3ef244e-0a67-11ec-abf2-acde48001122
-version: 10
+version: 11
 creation_date: '2021-09-01'
-modification_date: '2026-05-13'
+modification_date: '2026-07-04'
 author: Michael Haag, Mauricio Velazco, Splunk
 status: production
 type: TTP
@@ -10,7 +10,7 @@ description: The following analytic detects a suspicious Kerberos Ticket Grantin
 data_source:
     - Windows Event Log Security 4768
 search: |-
-    `wineventlog_security` EventCode=4768 src!="::1" TargetUserName=*$ CertThumbprint!=""
+    `wineventlog_security` EventCode=4768 src!="::1" TargetUserName=*$ CertThumbprint!="" PreAuthType=2
       | stats count min(_time) as firstTime max(_time) as lastTime
         BY dest, TargetUserName, src,
            action
@@ -18,7 +18,7 @@ search: |-
       | `security_content_ctime(lastTime)`
       | `petitpotam_suspicious_kerberos_tgt_request_filter`
 how_to_implement: The following analytic requires Event Code 4768. Ensure that it is logging no Domain Controllers and appearing in Splunk.
-known_false_positives: False positives are possible if the environment is using certificates for authentication.
+known_false_positives: False positives are possible if the environment is using certificates for authentication, since PreAuthType 2 can appear on some initial or fallback authentication flows alongside a populated certificate field. Tune further based on observed authentication patterns in the environment.
 references:
     - https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4768
     - https://isc.sans.edu/forums/diary/Active+Directory+Certificate+Services+ADCS+PKI+domain+admin+vulnerability/27668/

--- a/detections/endpoint/petitpotam_suspicious_kerberos_tgt_request.yml
+++ b/detections/endpoint/petitpotam_suspicious_kerberos_tgt_request.yml
@@ -10,18 +10,27 @@ description: The following analytic detects a suspicious Kerberos Ticket Grantin
 data_source:
     - Windows Event Log Security 4768
 search: |-
-    `wineventlog_security` EventCode=4768 src!="::1" TargetUserName=*$ CertThumbprint!="" PreAuthType=2
-      | stats count min(_time) as firstTime max(_time) as lastTime
-        BY dest, TargetUserName, src,
-           action
-      | `security_content_ctime(firstTime)`
-      | `security_content_ctime(lastTime)`
-      | `petitpotam_suspicious_kerberos_tgt_request_filter`
-how_to_implement: The following analytic requires Event Code 4768. Ensure that it is logging no Domain Controllers and appearing in Splunk.
-known_false_positives: False positives are possible if the environment is using certificates for authentication, since PreAuthType 2 can appear on some initial or fallback authentication flows alongside a populated certificate field. Tune further based on observed authentication patterns in the environment.
+    `wineventlog_security`
+    EventCode=4768
+    src!="::1"
+    TargetUserName=*$
+    CertThumbprint!=""
+    PreAuthType=2
+    | stats count min(_time) as firstTime
+                  max(_time) as lastTime
+      BY dest TargetUserName PreAuthType CertThumbprint src action
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `petitpotam_suspicious_kerberos_tgt_request_filter`
+how_to_implement: |-
+    The following analytic requires Event Code 4768. Ensure that it is logging no Domain Controllers and appearing in Splunk.
+known_false_positives: |-
+    False positives are possible if the environment is using certificates for authentication, since PreAuthType 2 can appear on some initial or fallback authentication flows alongside a populated certificate field.
+    Tune further based on observed authentication patterns in the environment.
 references:
     - https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4768
     - https://isc.sans.edu/forums/diary/Active+Directory+Certificate+Services+ADCS+PKI+domain+admin+vulnerability/27668/
+    - https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/event-4768#kerberos-preauthentication-types
 drilldown_searches:
     - name: View the detection results for - "$dest$"
       search: '%original_detection_search% | search  dest = "$dest$"'


### PR DESCRIPTION
### Details

Closes #4141.

The PetitPotam Suspicious Kerberos TGT Request analytic (`detections/endpoint/petitpotam_suspicious_kerberos_tgt_request.yml`) only filters on `CertThumbprint!=""`, which also matches ordinary smart card / PKI logons. Those show up as Event 4768 with a populated cert thumbprint too, so the rule fires on legitimate authentication in any environment that uses certificate-based logon.

The project's own attack data for this technique (`windows-xml-1.log` under `T1187/petitpotam`) has `PreAuthType` set to 2 alongside the cert thumbprint. That's the actual signature of the PetitPotam/ESC8 coercion path: password-style pre-auth (type 2) showing up with a certificate field populated. Normal smart card sign-in uses PreAuthType 15, 16, or 17 instead. I pulled the log myself and confirmed the field values rather than taking the issue's word for it.

Added `PreAuthType=2` to the search so it only matches on that specific combination.

### Testing

- Confirmed the current gap exists on `develop` HEAD by reading the detection file directly.
- Downloaded the referenced attack data log and verified `PreAuthType=2` and `CertThumbprint=xyz` are both present in the sample event, confirming the fix matches real data rather than a hypothetical.
- Ran `yamllint -c .yamllint` against the modified file. Passes clean.
- Ran a full `contentctl-ng build` against the repo with the change in place (2115 detections parsed, this one included). Built successfully, and the compiled `savedsearches.conf` shows the `PreAuthType=2` filter carried through correctly.
- Bumped `version` to 11 and `modification_date` to today, matching how other recent SPL-selection fixes in this repo have been versioned (e.g. #4112).

### Checklist

- [x] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature (unchanged, name/id preserved)
- [ ] CI/CD jobs passed (pending, see local build results above)
- [x] Validated SPL logic
- [x] Validated tags, description, and how to implement
- [x] Verified references match analytic
- [x] Confirm updates to lookups are handled properly (no lookup changes in this PR)
