### PR TITLE
Detections for CVE-2026-46331 linux priv esc

### DIFF
--- a/detections/endpoint/linux_apparmor_bypass_via_aaexec.yml
+++ b/detections/endpoint/linux_apparmor_bypass_via_aaexec.yml
@@ -1,0 +1,72 @@
+name: Linux Apparmor Bypass Via Aaexec
+id: b6d2a2b8-ad52-4a12-8956-dbf10012d1b8
+version: 1
+creation_date: '2026-06-30'
+modification_date: '2026-06-30'
+author: Raven Tait, Splunk
+status: production
+type: TTP
+description: The following analytic detects aa-exec being used to launch a binary under the trinity, chrome, or flatpak AppArmor profiles where the executed target is not the legitimate application those profiles are intended to confine. This behavior is consistent with abuse of userns,-carrying AppArmor profiles to bypass Ubuntu's unprivileged user namespace restrictions as seen in the CVE-2026-46331 privilege escalation exploit. The analytic flags execution when the target command following -- is invoked via a relative path, resolves outside standard trusted  install directories for these applications, or shares the same binary name as the calling parent process. Adversaries and red teams may abuse this technique to escalate privileges by tricking aa-exec into granting a namespace-creation capability to an arbitrary binary rather than the trusted application the profile was written for.
+data_source:
+    - Sysmon for Linux EventID 1
+    - Cisco Isovalent Process Exec
+search: |-
+    | tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime
+    from datamodel=Endpoint.Processes where
+        Processes.process_name="*aa-exec"
+        AND Processes.process="* -p *"
+        AND Processes.process="*--*"
+        AND Processes.process IN ("*trinity*","*chrome*","*flatpak*")
+        AND NOT Processes.process_name IN ("/user*","/opt*","/snap*","/var/lib/flatpak*")
+    by Processes.action Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec
+    Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path
+    Processes.process Processes.process_exec Processes.process_guid Processes.process_hash Processes.process_id
+    Processes.process_integrity_level Processes.process_name Processes.process_path Processes.user Processes.user_id
+    Processes.vendor_product
+    | `drop_dm_object_name(Processes)`
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `linux_apt_privilege_escalation_filter`'
+how_to_implement: The detection is based on data that originates from Endpoint Detection and Response (EDR) agents. These agents are designed to provide security-related telemetry from the endpoints where the agent is installed. To implement this search, you must ingest logs that contain the process GUID, process name, and parent process. Additionally, you must ingest complete command-line executions. These logs must be processed using the appropriate Splunk Technology Add-ons that are specific to the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint` data model. Use the Splunk Common Information Model (CIM) to normalize the field names and speed up the data modeling process.
+known_false_positives: Chrome, Flatpak, and the trinity profile are never legitimately re-executed with extraneious arguments from a non-browser binary path
+references:
+    - https://github.com/sgkdev/packet_edit_meme
+    - https://tuxcare.com/blog/pedit-cow-cve/
+drilldown_searches:
+    - name: View the detection results for - "$dest$"
+      search: '%original_detection_search% | search  dest = "$dest$"'
+      earliest_offset: $info_min_time$
+      latest_offset: $info_max_time$
+    - name: View risk events for the last 7 days for - "$dest$"
+      search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+      earliest_offset: 7d
+      latest_offset: "0"
+finding:
+    title: AppArmor bypass leveraging aa-exec was observed on $dest$.
+    entity:
+        field: dest
+        type: system
+        score: 50
+threat_objects:
+    - field: parent_process_name
+      type: process
+analytic_story:
+    - Linux Privilege Escalation
+asset_type: Endpoint
+cve:
+    - CVE-2026-46331
+mitre_attack_id:
+    - T1068
+product:
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
+category: endpoint
+security_domain: endpoint
+tests:
+    - name: True Positive Test
+      attack_data:
+        - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1068/linux_pedit/sysmon_linux.log
+          source: Syslog:Linux-Sysmon/Operational
+          sourcetype: sysmon:linux
+      test_type: unit

--- a/detections/endpoint/linux_apparmor_bypass_via_aaexec.yml
+++ b/detections/endpoint/linux_apparmor_bypass_via_aaexec.yml
@@ -26,7 +26,7 @@ search: |-
     | `drop_dm_object_name(Processes)`
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
-    | `linux_apt_privilege_escalation_filter`'
+    | `linux_apparmor_bypass_via_aaexec_filter`'
 how_to_implement: The detection is based on data that originates from Endpoint Detection and Response (EDR) agents. These agents are designed to provide security-related telemetry from the endpoints where the agent is installed. To implement this search, you must ingest logs that contain the process GUID, process name, and parent process. Additionally, you must ingest complete command-line executions. These logs must be processed using the appropriate Splunk Technology Add-ons that are specific to the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint` data model. Use the Splunk Common Information Model (CIM) to normalize the field names and speed up the data modeling process.
 known_false_positives: Chrome, Flatpak, and the trinity profile are never legitimately re-executed with extraneious arguments from a non-browser binary path
 references:

--- a/detections/endpoint/linux_auditd_possible_setuid_execve_privesc.yml
+++ b/detections/endpoint/linux_auditd_possible_setuid_execve_privesc.yml
@@ -1,0 +1,64 @@
+name: Linux Auditd Possible Setuid Execve Privesc
+id: e958e6ee-7c73-4eff-a4d9-43232d719b26
+version: 1
+creation_date: '2026-07-06'
+modification_date: '2026-07-06'
+author: Raven Tait, Splunk
+status: production
+type: Anomaly
+description: The following detects privilege escalation via execve (syscall 59) where a process transitions from a non-root uid to euid=0 without a corresponding successful PAM authentication event (USER_AUTH, USER_ACCT, or CRED_ACQ) in the same audit session. Legitimate privilege elevation mechanisms such as sudo, su, and pkexec authenticate through PAM and generate these audit records tied to the session ID before granting elevated privileges. The absence of a matching successful PAM event alongside an effective UID change to root is anomalous and may indicate exploitation of a setuid binary, a kernel vulnerability, or another mechanism used to escalate privileges outside the normal authentication flow.
+data_source:
+    - Linux Auditd Execve
+search: >-
+    `linux_auditd` type=SYSCALL syscall="59" uid!="0" euid="0"
+    NOT [search `linux_auditd` type IN ("USER_AUTH","USER_ACCT","CRED_ACQ") res="success"
+         | stats values(ses) as ses
+         | mvexpand ses
+         | fields ses
+         | format]
+    | rename comm as process_name, exe as process_path, ses as session_id
+    | stats count min(_time) as firstTime max(_time) as lastTime
+        by host uid euid session_id pid ppid process_name process_path
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `linux_auditd_possible_setuid_execve_privesc_filter`
+how_to_implement: To implement this detection, the process begins by ingesting auditd data, that consist SYSCALL, TYPE, EXECVE and PROCTITLE events, which captures command-line executions and process details on Unix/Linux systems. These logs should be ingested and processed using Splunk Add-on for Unix and Linux (https://splunkbase.splunk.com/app/833), which is essential for correctly parsing and categorizing the data. The next step involves normalizing the field names  to match the field names set by the Splunk Common Information Model (CIM) to ensure consistency across different data sources and enhance the efficiency of data modeling. This approach enables effective monitoring and detection of linux endpoints where auditd is deployed.
+known_false_positives: Processes with an unset audit session, such as cron jobs, that legitimately drop and reacquire root privileges outside of PAM, may trigger this detection and require filtering.
+references:
+    - https://github.com/sgkdev/packet_edit_meme
+    - https://tuxcare.com/blog/pedit-cow-cve/
+drilldown_searches:
+    - name: View the detection results for - "$dest$"
+      search: '%original_detection_search% | search  dest = "$dest$"'
+      earliest_offset: $info_min_time$
+      latest_offset: $info_max_time$
+    - name: View risk events for the last 7 days for - "$dest$"
+      search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+      earliest_offset: 7d
+      latest_offset: "0"
+intermediate_findings:
+    entities:
+        - field: dest
+          type: system
+          score: 20
+          message: $process_name$ was launched with euid 0 on [$dest$] without PAM auth.
+analytic_story:
+    - Linux Privilege Escalation
+asset_type: Endpoint
+cve:
+    - CVE-2026-46331
+mitre_attack_id:
+    - T1068
+product:
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
+category: endpoint
+security_domain: endpoint
+tests:
+    - name: True Positive Test
+      attack_data:
+        - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1068/linux_pedit/linux_auditd.log
+          source: auditd
+          sourcetype: auditd
+      test_type: unit

--- a/detections/endpoint/linux_auditd_possible_setuid_execve_privesc.yml
+++ b/detections/endpoint/linux_auditd_possible_setuid_execve_privesc.yml
@@ -16,9 +16,9 @@ search: >-
          | mvexpand ses
          | fields ses
          | format]
-    | rename comm as process_name, exe as process_path, ses as session_id
+    | rename comm as process_name, exe as process_path, ses as session_id, host as dest
     | stats count min(_time) as firstTime max(_time) as lastTime
-        by host uid euid session_id pid ppid process_name process_path
+        by dest uid euid session_id pid ppid process_name process_path
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `linux_auditd_possible_setuid_execve_privesc_filter`

--- a/detections/endpoint/linux_pedit_offset_out_of_bounds.yml
+++ b/detections/endpoint/linux_pedit_offset_out_of_bounds.yml
@@ -1,4 +1,4 @@
-name: Linux Pedit Out Of Bounds
+name: Linux Pedit Offset Out Of Bounds
 id: 749d9bbf-cfa5-42d0-90e0-eb9300f7750a
 version: 1
 creation_date: '2026-07-06'
@@ -17,7 +17,7 @@ search: >-
     | stats count min(_time) as firstTime max(_time) as lastTime by host message
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
-    | `linux_pedit_out_of_bounds_filter`
+    | `linux_pedit_offset_out_of_bounds_filter`
 how_to_implement: To successfully implement this search, you need to have relevant kernel logs ingested with the Splunk Add-On for Unix and Linux (https://splunkbase.splunk.com/app/833).
 known_false_positives: This is generated only when the kernel's act_pedit module encounters a write outside the writable SKB region. This never occurs in normal tc pedit usage.
 references:

--- a/detections/endpoint/linux_pedit_offset_out_of_bounds.yml
+++ b/detections/endpoint/linux_pedit_offset_out_of_bounds.yml
@@ -6,7 +6,7 @@ modification_date: '2026-07-06'
 author: Raven Tait, Splunk
 status: production
 type: TTP
-description:
+description: The following detects a Linux kernel warning message containing "tc action pedit offset" and "out of bounds" logged to syslog, which indicates the act_pedit attempted to write past the bounds of an allocated packet buffer. This condition is associated with CVE-2026-46331, a kernel vulnerability that can be exploited via crafted pedit netlink configurations combined with page cache poisoning to achieve privilege escalation. The presence of this message on a host is a strong indicator that exploitation of this vulnerability, or triggering of the underlying vulnerable code path, has occurred.
 data_source:
     - Linux Messages Syslog
 search: >-

--- a/detections/endpoint/linux_pedit_offset_out_of_bounds.yml
+++ b/detections/endpoint/linux_pedit_offset_out_of_bounds.yml
@@ -14,7 +14,8 @@ search: >-
     message="*tc action pedit offset*"
     AND
     message="*out of bounds*"
-    | stats count min(_time) as firstTime max(_time) as lastTime by host message
+    | rename host as dest
+    | stats count min(_time) as firstTime max(_time) as lastTime by dest message
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
     | `linux_pedit_offset_out_of_bounds_filter`

--- a/detections/endpoint/linux_pedit_out_of_bounds.yml
+++ b/detections/endpoint/linux_pedit_out_of_bounds.yml
@@ -1,0 +1,60 @@
+name: Linux Pedit Out Of Bounds
+id: 749d9bbf-cfa5-42d0-90e0-eb9300f7750a
+version: 1
+creation_date: '2026-07-06'
+modification_date: '2026-07-06'
+author: Raven Tait, Splunk
+status: production
+type: TTP
+description:
+data_source:
+    - Linux Messages Syslog
+search: >-
+    `syslog`
+    message="*tc action pedit offset*"
+    AND
+    message="*out of bounds*"
+    | stats count min(_time) as firstTime max(_time) as lastTime by host message
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `linux_pedit_out_of_bounds_filter`
+how_to_implement: To successfully implement this search, you need to have relevant kernel logs ingested with the Splunk Add-On for Unix and Linux (https://splunkbase.splunk.com/app/833).
+known_false_positives: This is generated only when the kernel's act_pedit module encounters a write outside the writable SKB region. This never occurs in normal tc pedit usage.
+references:
+    - https://tuxcare.com/blog/pedit-cow-cve/
+    - https://github.com/sgkdev/packet_edit_meme
+drilldown_searches:
+    - name: View the detection results for - "$dest$"
+      search: '%original_detection_search% | search  dest = "$dest$"'
+      earliest_offset: $info_min_time$
+      latest_offset: $info_max_time$
+    - name: View risk events for the last 7 days for - "$dest$"
+      search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+      earliest_offset: 7d
+      latest_offset: "0"
+finding:
+    title: Out-of-bounds write by act_pedit on $dest$ indicating possible privilege escalation.
+    entity:
+        field: dest
+        type: system
+        score: 50
+analytic_story:
+    - Linux Privilege Escalation
+asset_type: Endpoint
+cve:
+    - CVE-2026-46331
+mitre_attack_id:
+    - T1068
+product:
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
+category: endpoint
+security_domain: endpoint
+tests:
+    - name: True Positive Test
+      attack_data:
+        - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1068/linux_pedit/syslog.log
+          source: /var/log/syslog
+          sourcetype: linux_messages_syslog
+      test_type: unit


### PR DESCRIPTION
### Details
 Three new detections based around CVE-2026-46331
 
 - Linux Apparmor Bypass Via Aaexec
 - Linux Auditd Possible Setuid Execve Privesc
 - Linux Pedit Offset Out Of Bounds