### PR TITLE
bump to contentctl-ng 1.0.2 in

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-contentctl-ng==0.7.0
+contentctl-ng==1.0.2


### PR DESCRIPTION
bump to contentctl-ng 1.0.2 in prep for release. 