### PR TITLE
Bug Fix - Suspicious Process Executed From Container File

### DIFF
--- a/detections/endpoint/suspicious_process_executed_from_container_file.yml
+++ b/detections/endpoint/suspicious_process_executed_from_container_file.yml
@@ -19,21 +19,13 @@ search: |-
     from datamodel=Endpoint.Processes
     where Processes.process IN (
         "*.ZIP\\*",
-        "*.zip\\*",
         "*.ISO\\*",
-        "*.iso\\*",
         "*.IMG\\*",
-        "*.img\\*",
         "*.CAB\\*",
-        "*.cab\\*",
         "*.TAR\\*",
-        "*.tar\\*",
         "*.GZ\\*",
-        "*.gz\\*",
         "*.RAR\\*",
-        "*.rar\\*",
-        "*.7Z\\*",
-        "*.7z\\*"
+        "*.7Z\\*"
         )
         AND Processes.action="allowed"
     by

--- a/detections/endpoint/suspicious_process_executed_from_container_file.yml
+++ b/detections/endpoint/suspicious_process_executed_from_container_file.yml
@@ -14,33 +14,54 @@ data_source:
 search: |-
     | tstats `security_content_summariesonly`
     count
-    values(Processes.process_name) as process_name
     min(_time) as firstTime
     max(_time) as lastTime
     from datamodel=Endpoint.Processes
     where Processes.process IN (
         "*.ZIP\\*",
+        "*.zip\\*",
         "*.ISO\\*",
+        "*.iso\\*",
         "*.IMG\\*",
+        "*.img\\*",
         "*.CAB\\*",
+        "*.cab\\*",
         "*.TAR\\*",
+        "*.tar\\*",
         "*.GZ\\*",
+        "*.gz\\*",
         "*.RAR\\*",
-        "*.7Z\\*"
+        "*.rar\\*",
+        "*.7Z\\*",
+        "*.7z\\*"
         )
         AND Processes.action="allowed"
     by
-        Processes.action Processes.dest Processes.original_file_name Processes.parent_process Processes.process_name Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path Processes.process_exec Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_path Processes.user Processes.user_id Processes.vendor_product
-
+        Processes.action
+        Processes.dest
+        Processes.original_file_name
+        Processes.parent_process
+        Processes.parent_process_exec
+        Processes.parent_process_guid
+        Processes.parent_process_id
+        Processes.parent_process_name
+        Processes.parent_process_path
+        Processes.process
+        Processes.process_exec
+        Processes.process_guid
+        Processes.process_hash
+        Processes.process_id
+        Processes.process_integrity_level
+        Processes.process_name
+        Processes.process_path
+        Processes.user
+        Processes.user_id
+        Processes.vendor_product
     | `drop_dm_object_name(Processes)`
-
-    | regex process="(?i).*(ZIP|ISO|IMG|CAB|TAR|GZ|RAR|7Z)\\\\.+\.(BAT|BIN|CAB|CMD|COM|CPL|EX_|EXE|GADGET|INF1|INS|INX|HTM|HTML|ISU|JAR|JOB|JS|JSE|LNK|MSC|MSI|MSP|MST|PAF|PIF|PS1|REG|RGS|SCR|SCT|SHB|SHS|U3P|VB|VBE|VBS|VBSCRIPT|WS|WSF|WSH)\"?$"
-
-    | rex field=process "(?i).+\\\\(?<file_name>[^\\\\]+\.(ZIP|ISO|IMG|CAB|TAR|GZ|RAR|7Z))\\\\((.+\\\\)+)?(?<container_file_name>.+\.(BAT|BIN|CAB|CMD|COM|CPL|EX_|EXE|GADGET|INF1|INS|INX|HTM|HTML|ISU|JAR|JOB|JS|JSE|LNK|MSC|MSI|MSP|MST|PAF|PIF|PS1|REG|RGS|SCR|SCT|SHB|SHS|U3P|VB|VBE|VBS|VBSCRIPT|WS|WSF|WSH))\"?$"
-
+    | regex process="(?i).*\.(zip|iso|img|cab|tar|gz|rar|7z)\\\\.+\.(bat|bin|cab|cmd|com|cpl|ex_|exe|gadget|inf1|ins|inx|htm|html|isu|jar|job|js|jse|lnk|msc|msi|msp|mst|paf|pif|ps1|reg|rgs|scr|sct|shb|shs|u3p|vb|vbe|vbs|vbscript|ws|wsf|wsh)\"?$"
+    | rex field=process "(?i).+\\\\(?<file_name>[^\\\\]+\.(?:zip|iso|img|cab|tar|gz|rar|7z))\\\\(?:.+\\\\)?(?<container_file_name>[^\\\\\"]+\.(?:bat|bin|cab|cmd|com|cpl|ex_|exe|gadget|inf1|ins|inx|htm|html|isu|jar|job|js|jse|lnk|msc|msi|msp|mst|paf|pif|ps1|reg|rgs|scr|sct|shb|shs|u3p|vb|vbe|vbs|vbscript|ws|wsf|wsh))\"?$"
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
-
     | `suspicious_process_executed_from_container_file_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection and Response (EDR) agents. These agents are designed to provide security-related telemetry from the endpoints where the agent is installed. To implement this search, you must ingest logs that contain the process GUID, process name, and parent process. Additionally, you must ingest complete command-line executions. These logs must be processed using the appropriate Splunk Technology Add-ons that are specific to the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint` data model. Use the Splunk Common Information Model (CIM) to normalize the field names and speed up the data modeling process.
 known_false_positives: Various business process or userland applications and behavior.

--- a/detections/endpoint/suspicious_process_executed_from_container_file.yml
+++ b/detections/endpoint/suspicious_process_executed_from_container_file.yml
@@ -1,8 +1,8 @@
 name: Suspicious Process Executed From Container File
 id: d8120352-3b62-411c-8cb6-7b47584dd5e8
-version: 11
+version: 12
 creation_date: '2023-07-11'
-modification_date: '2026-05-13'
+modification_date: '2026-07-09'
 author: Steven Dick
 status: production
 type: TTP
@@ -11,7 +11,37 @@ data_source:
     - Sysmon EventID 1
     - Windows Event Log Security 4688
     - CrowdStrike ProcessRollup2
-search: '| tstats `security_content_summariesonly` count values(Processes.process_name) as process_name min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where Processes.process IN ("*.ZIP\\*","*.ISO\\*","*.IMG\\*","*.CAB\\*","*.TAR\\*","*.GZ\\*","*.RAR\\*","*.7Z\\*") AND Processes.action="allowed" by Processes.action Processes.dest Processes.original_file_name Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path Processes.process Processes.process_exec Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_name Processes.process_path Processes.user Processes.user_id Processes.vendor_product | `drop_dm_object_name(Processes)` | regex process="(?i).*(ZIP|ISO|IMG|CAB|TAR|GZ|RAR|7Z)\\\\.+\.(BAT|BIN|CAB|CMD|COM|CPL|EX_|EXE|GADGET|INF1|INS|INX||HTM|HTML|ISU|JAR|JOB|JS|JSE|LNK|MSC|MSI|MSP|MST|PAF|PIF|PS1|REG|RGS|SCR|SCT|SHB|SHS|U3P|VB|VBE|VBS|VBSCRIPT|WS|WSF|WSH)\"?$" | rex field=process "(?i).+\\\\(?<file_name>[^\\\]+\.(ZIP|ISO|IMG|CAB|TAR|GZ|RAR|7Z))\\\\((.+\\\\)+)?(?<process_name>.+\.(BAT|BIN|CAB|CMD|COM|CPL|EX_|EXE|GADGET|INF1|INS|INX||HTM|HTML|ISU|JAR|JOB|JS|JSE|LNK|MSC|MSI|MSP|MST|PAF|PIF|PS1|REG|RGS|SCR|SCT|SHB|SHS|U3P|VB|VBE|VBS|VBSCRIPT|WS|WSF|WSH))\"?$"| `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | `suspicious_process_executed_from_container_file_filter`'
+search: |-
+    | tstats `security_content_summariesonly`
+    count
+    values(Processes.process_name) as process_name
+    min(_time) as firstTime
+    max(_time) as lastTime
+    from datamodel=Endpoint.Processes
+    where Processes.process IN (
+        "*.ZIP\\*",
+        "*.ISO\\*",
+        "*.IMG\\*",
+        "*.CAB\\*",
+        "*.TAR\\*",
+        "*.GZ\\*",
+        "*.RAR\\*",
+        "*.7Z\\*"
+        )
+        AND Processes.action="allowed"
+    by
+        Processes.action Processes.dest Processes.original_file_name Processes.parent_process Processes.process_name Processes.parent_process_guid Processes.parent_process_id Processes.parent_process_name Processes.parent_process_path Processes.process_exec Processes.process_guid Processes.process_hash Processes.process_id Processes.process_integrity_level Processes.process_path Processes.user Processes.user_id Processes.vendor_product
+
+    | `drop_dm_object_name(Processes)`
+
+    | regex process="(?i).*(ZIP|ISO|IMG|CAB|TAR|GZ|RAR|7Z)\\\\.+\.(BAT|BIN|CAB|CMD|COM|CPL|EX_|EXE|GADGET|INF1|INS|INX|HTM|HTML|ISU|JAR|JOB|JS|JSE|LNK|MSC|MSI|MSP|MST|PAF|PIF|PS1|REG|RGS|SCR|SCT|SHB|SHS|U3P|VB|VBE|VBS|VBSCRIPT|WS|WSF|WSH)\"?$"
+
+    | rex field=process "(?i).+\\\\(?<file_name>[^\\\\]+\.(ZIP|ISO|IMG|CAB|TAR|GZ|RAR|7Z))\\\\((.+\\\\)+)?(?<container_file_name>.+\.(BAT|BIN|CAB|CMD|COM|CPL|EX_|EXE|GADGET|INF1|INS|INX|HTM|HTML|ISU|JAR|JOB|JS|JSE|LNK|MSC|MSI|MSP|MST|PAF|PIF|PS1|REG|RGS|SCR|SCT|SHB|SHS|U3P|VB|VBE|VBS|VBSCRIPT|WS|WSF|WSH))\"?$"
+
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+
+    | `suspicious_process_executed_from_container_file_filter`
 how_to_implement: The detection is based on data that originates from Endpoint Detection and Response (EDR) agents. These agents are designed to provide security-related telemetry from the endpoints where the agent is installed. To implement this search, you must ingest logs that contain the process GUID, process name, and parent process. Additionally, you must ingest complete command-line executions. These logs must be processed using the appropriate Splunk Technology Add-ons that are specific to the EDR product. The logs must also be mapped to the `Processes` node of the `Endpoint` data model. Use the Splunk Common Information Model (CIM) to normalize the field names and speed up the data modeling process.
 known_false_positives: Various business process or userland applications and behavior.
 references:
@@ -28,7 +58,7 @@ drilldown_searches:
       earliest_offset: 7d
       latest_offset: "0"
 finding:
-    title: A suspicious process $process_name$ was launched from $file_name$ on $dest$.
+    title: A suspicious file [$container_file_name$] was launched from container file [$file_name$] by process [$process_name$] on [$dest$].
     entity:
         field: user
         type: user
@@ -38,9 +68,13 @@ intermediate_findings:
         - field: dest
           type: system
           score: 50
-          message: A suspicious process $process_name$ was launched from $file_name$ on $dest$.
+          message: A suspicious file [$container_file_name$] was launched from container file [$file_name$] by process [$process_name$] on [$dest$].
 threat_objects:
+    - field: process_name
+      type: process_name
     - field: file_name
+      type: file_name
+    - field: container_file_name
       type: file_name
 analytic_story:
     - APT37 Rustonotto and FadeStealer


### PR DESCRIPTION
This PR fixes a field-mapping issue in the suspicious process executed from container file detection.

The detection previously extracted the file launched from inside the archive into process_name, which could overwrite or conflict with the CIM process_name field. Since process_name should represent the actual process image, such as wscript.exe, this update renames the extracted archive member field to container_file_name.

This keeps CIM process fields accurate while still capturing the suspicious file executed from the compressed container.

Updated behavior:
```
process_name = actual executing process
file_name = compressed container file
container_file_name = file launched from inside the container
```

Slack - https://splunk.slack.com/archives/C9RE1GUSZ/p1783544914063179