### PR TITLE
Fix AWS ECR Container Scanning Findings detections returning zero results

### DIFF
--- a/detections/cloud/aws_ecr_container_scanning_findings_high.yml
+++ b/detections/cloud/aws_ecr_container_scanning_findings_high.yml
@@ -1,8 +1,8 @@
 name: AWS ECR Container Scanning Findings High
 id: 30a0e9f8-f1dd-4f9d-8fc2-c622461d781c
-version: 13
+version: 14
 creation_date: '2021-08-18'
-modification_date: '2026-05-13'
+modification_date: '2026-07-27'
 author: Patrick Bareiss, Splunk
 status: production
 type: TTP
@@ -16,7 +16,8 @@ search: |-
       | spath input=findings
       | search severity=HIGH
       | rename name as finding_name, description as finding_description, requestParameters.imageId.imageDigest as imageDigest, requestParameters.repositoryName as repository
-      | rename user_name as user
+      | rename userIdentity.arn as user, userAgent as user_agent, sourceIPAddress as src, awsRegion as vendor_region, userIdentity.accountId as vendor_account, eventName as signature, responseElements.registryId as dest
+      | eval vendor_product="Amazon Web Services"
       | stats count min(_time) as firstTime max(_time) as lastTime
         BY signature dest user
            user_agent src vendor_account

--- a/detections/cloud/aws_ecr_container_scanning_findings_low_informational_unknown.yml
+++ b/detections/cloud/aws_ecr_container_scanning_findings_low_informational_unknown.yml
@@ -1,8 +1,8 @@
 name: AWS ECR Container Scanning Findings Low Informational Unknown
 id: cbc95e44-7c22-443f-88fd-0424478f5589
-version: 13
+version: 14
 creation_date: '2021-08-18'
-modification_date: '2026-05-13'
+modification_date: '2026-07-27'
 author: Patrick Bareiss, Eric McGinnis Splunk
 status: production
 type: Anomaly
@@ -16,7 +16,8 @@ search: |-
       | spath input=findings
       | search severity IN ("LOW", "INFORMATIONAL", "UNKNOWN")
       | rename name as finding_name, description as finding_description, requestParameters.imageId.imageDigest as imageDigest, requestParameters.repositoryName as repository
-      | rename user_name as user
+      | rename userIdentity.arn as user, userAgent as user_agent, sourceIPAddress as src, awsRegion as vendor_region, userIdentity.accountId as vendor_account, eventName as signature, responseElements.registryId as dest
+      | eval vendor_product="Amazon Web Services"
       | stats count min(_time) as firstTime max(_time) as lastTime
         BY signature dest user
            user_agent src vendor_account

--- a/detections/cloud/aws_ecr_container_scanning_findings_medium.yml
+++ b/detections/cloud/aws_ecr_container_scanning_findings_medium.yml
@@ -1,8 +1,8 @@
 name: AWS ECR Container Scanning Findings Medium
 id: 0b80e2c8-c746-4ddb-89eb-9efd892220cf
-version: 13
+version: 14
 creation_date: '2021-08-18'
-modification_date: '2026-05-13'
+modification_date: '2026-07-27'
 author: Patrick Bareiss, Splunk
 status: production
 type: Anomaly
@@ -16,7 +16,8 @@ search: |-
       | spath input=findings
       | search severity=MEDIUM
       | rename name as finding_name, description as finding_description, requestParameters.imageId.imageDigest as imageDigest, requestParameters.repositoryName as repository
-      | rename user_name as user
+      | rename userIdentity.arn as user, userAgent as user_agent, sourceIPAddress as src, awsRegion as vendor_region, userIdentity.accountId as vendor_account, eventName as signature, responseElements.registryId as dest
+      | eval vendor_product="Amazon Web Services"
       | stats count min(_time) as firstTime max(_time) as lastTime
         BY signature dest user
            user_agent src vendor_account


### PR DESCRIPTION
Fixes #4169

## Problem

All three AWS ECR Container Scanning Findings detections (low/informational/unknown, medium, high) always return zero results, even against their own attack data. The final `stats` command groups by `signature`, `dest`, `user`, `user_agent`, `src`, `vendor_account`, `vendor_region`, and `vendor_product`, but nothing in the search pipeline creates these fields. They only exist if the AWS TA's CIM field aliasing is applied. Since `stats BY` drops any row where a groupby field is undefined, every row is silently dropped.

Root cause analysis and the fix were provided by @ratharaksa in #4169. The issue reports the low/informational/unknown detection; the medium and high variants have the identical rename/stats pattern and the same bug, so this PR fixes all three.

## Fix

Rename the raw CloudTrail fields explicitly instead of relying on unavailable field aliases:

- `userIdentity.arn` as `user`
- `userAgent` as `user_agent`
- `sourceIPAddress` as `src`
- `awsRegion` as `vendor_region`
- `userIdentity.accountId` as `vendor_account`
- `eventName` as `signature`
- `responseElements.registryId` as `dest`
- `eval vendor_product="Amazon Web Services"`

Bumped `version` to 14 and updated `modification_date` in all three detections.

## Verification

Verified every raw field referenced above exists in the detections' attack data (`aws_ecr_scanning_findings_events.json`). Against that data the fixed searches return 85 result rows (low/informational/unknown), 14 (medium), and 2 (high), with no rows dropped for undefined groupby fields. The issue author independently verified the same fix on a live Splunk instance.