### PR TITLE
bump to contentctl-ng 1.1.1 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-contentctl-ng==1.0.2
+contentctl-ng==1.1.1


### PR DESCRIPTION
### Details

Bump to contentctl-ng 1.1.1 in requirements.txt for ESCU 6.5.0 release.
