### PR TITLE
Fix original_file_name field typo in whoami and arp discovery detections

### DIFF
--- a/detections/endpoint/network_connection_discovery_with_arp.yml
+++ b/detections/endpoint/network_connection_discovery_with_arp.yml
@@ -1,8 +1,8 @@
 name: Network Connection Discovery With Arp
 id: ae008c0f-83bd-4ed4-9350-98d4328e15d2
-version: 10
+version: 11
 creation_date: '2021-08-24'
-modification_date: '2026-05-13'
+modification_date: '2026-08-30'
 author: Mauricio Velazco, Splunk
 status: production
 type: Hunting
@@ -22,7 +22,7 @@ search: |-
     (
         Processes.process_name="arp.exe"
         OR
-        Processes.process_original_file_name="arp.exe"
+        Processes.original_file_name="arp.exe"
     )
     Processes.process IN (
         "* -a*",

--- a/detections/endpoint/system_user_discovery_with_whoami.yml
+++ b/detections/endpoint/system_user_discovery_with_whoami.yml
@@ -1,8 +1,8 @@
 name: System User Discovery With Whoami
 id: 894fc43e-6f50-47d5-a68b-ee9ee23e18f4
-version: 11
+version: 12
 creation_date: '2021-08-24'
-modification_date: '2026-05-13'
+modification_date: '2026-08-30'
 author: Mauricio Velazco, Splunk
 status: production
 type: Hunting
@@ -16,7 +16,7 @@ search: |-
       WHERE (
             Processes.process_name="whoami.exe"
             OR
-            Processes.process_original_file_name="whoami.exe"
+            Processes.original_file_name="whoami.exe"
         )
       BY Processes.action Processes.dest Processes.original_file_name
          Processes.parent_process Processes.parent_process_exec Processes.parent_process_guid


### PR DESCRIPTION
### Details

Both searches OR two conditions to catch a renamed LOLBin: `process_name`, or the PE's original file name field (survives a rename). The second condition references `Processes.process_original_file_name`. That field does not exist in the CIM Endpoint.Processes model. The correct field is `Processes.original_file_name`, already used correctly a few lines down in each detection's own BY clause.

A field with no indexed values contributes nothing to a tstats OR. Both detections quietly collapse to a plain `process_name="whoami.exe"` or `process_name="arp.exe"` check. Rename the binary and both miss it. Catching that exact case is the whole point of checking original_file_name.

Fixed files:
- `detections/endpoint/system_user_discovery_with_whoami.yml`
- `detections/endpoint/network_connection_discovery_with_arp.yml`

Checked against the CIM 5.3 Endpoint docs, `original_file_name` is the only valid field. Bumped version and modification_date on both.

Ran `contentctl-ng build` locally against develop with these files changed. All 2157 detections parsed clean, corrected SPL renders right in savedsearches.conf. No Splunk instance here to replay the attack_data tests, so the True Positive test is unconfirmed end to end. Happy to add anything else the checklist needs, thanks.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature - N/A, no detection added or renamed
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed - ran `contentctl-ng build` locally instead, see note above
- [x] Validated SPL logic.
- [ ] Validated tags, description, and how to implement. - N/A, unchanged
- [ ] Verified references match analytic. - N/A, unchanged
- [ ] Confirm updates to lookups are handled properly. - N/A, no lookups touched
