### PR TITLE
Detection Against Content Copied From Browsers Executed through Run

### DIFF
--- a/data_sources/sysmon_eventid_24.yml
+++ b/data_sources/sysmon_eventid_24.yml
@@ -68,28 +68,17 @@ fields:
     - tag
     - tag::eventtype
 output_fields:
-    - action
     - dest
     - dvc
-    - dvc_nt_host
     - event_id
-    - eventtype
-    - linecount
-    - os
     - process_exec
     - process_guid
     - process_hash
     - process_id
     - process_name
     - process_path
-    - punct
     - severity
-    - severity_id
-    - signature
-    - signature_id
     - splunk_server
-    - src_host
     - user
-    - user_id
     - vendor_product
-example_log: <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>24</EventID><Version>5</Version><Level>4</Level><Task>24</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2026-09-07T14:37:29.0002181Z'/><EventRecordID>274447</EventRecordID><Correlation/><Execution ProcessID='3400' ThreadID='4440'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>EC2AMAZ-FKEOM7G</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>-</Data><Data Name='UtcTime'>2026-09-07 14:37:28.999</Data><Data Name='ProcessGuid'>{1b43529b-bf4f-6a9e-e4eb-020000006600}</Data><Data Name='ProcessId'>8988</Data><Data Name='Image'>C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe</Data><Data Name='Session'>2</Data><Data Name='ClientInfo'>user: EC2AMAZ-FKEOM7G\Administrator hostname: OERDOGAN-M-7N5Y</Data><Data Name='Hashes'>MD5=F2CD63BD7E2B5F9B738F589AF3BB1F8F,SHA256=397EE4CA855D96072D57E89ABFCA9F83634DAEA133E5302CB0766E87FDC3FEFC,IMPHASH=00000000000000000000000000000000</Data><Data Name='Archived'>false - failed with error 1337</Data><Data Name='User'>EC2AMAZ-FKEOM7G\Administrator</Data></EventData></Event>
+example_log: <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>24</EventID><Version>5</Version><Level>4</Level><Task>24</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2026-09-07T14:37:29.0002181Z'/><EventRecordID>274447</EventRecordID><Correlation/><Execution ProcessID='3400' ThreadID='4440'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>EC2AMAZ-FKEOM7G</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>-</Data><Data Name='UtcTime'>2026-09-07 14:37:28.999</Data><Data Name='ProcessGuid'>{1b43529b-bf4f-6a9e-e4eb-020000006600}</Data><Data Name='ProcessId'>8988</Data><Data Name='Image'>C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe</Data><Data Name='Session'>2</Data><Data Name='ClientInfo'>user EC2AMAZ-FKEOM7G\Administrator hostname OERDOGAN-M-7N5Y</Data><Data Name='Hashes'>MD5=F2CD63BD7E2B5F9B738F589AF3BB1F8F,SHA256=397EE4CA855D96072D57E89ABFCA9F83634DAEA133E5302CB0766E87FDC3FEFC,IMPHASH=00000000000000000000000000000000</Data><Data Name='Archived'>false - failed with error 1337</Data><Data Name='User'>EC2AMAZ-FKEOM7G\Administrator</Data></EventData></Event>

--- a/data_sources/sysmon_eventid_24.yml
+++ b/data_sources/sysmon_eventid_24.yml
@@ -1,0 +1,95 @@
+name: Sysmon EventID 24
+id: ae023710-3dbb-4de3-a1b2-5477a8ab74f9
+version: 1
+creation_date: '2024-09-07'
+modification_date: '2024-09-07'
+author: Onur Mustafa Erdogan, Splunk
+description: Logs whenever new content is copied into the clipboard, including details about the associated process, hash of the content, and the time of copying.
+mitre_components:
+    - Process Metadata
+    - Process Access
+    - Application Log Content
+    - OS API Execution
+source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+sourcetype: XmlWinEventLog
+separator: EventID
+separator_value: '24'
+configuration: https://github.com/SwiftOnSecurity/sysmon-config
+supported_TA:
+    - name: Splunk Add-on for Sysmon
+      url: https://splunkbase.splunk.com/app/5709
+      version: 5.0.1
+fields:
+    - _time
+    - Archived
+    - Channel
+    - ClientInfo
+    - Computer
+    - EventChannel
+    - EventCode
+    - EventData_Xml
+    - EventDescription
+    - EventID
+    - EventRecordID
+    - Guid
+    - Hashes
+    - IMPHASH
+    - Image
+    - Keywords
+    - Level
+    - MD5
+    - Name
+    - Opcode
+    - ProcessGuid
+    - ProcessID
+    - ProcessId
+    - RecordID
+    - RecordNumber
+    - RuleName
+    - SHA256
+    - SecurityID
+    - Session
+    - SrcHost
+    - SystemTime
+    - System_Props_Xml
+    - Task
+    - ThreadID
+    - TimeCreated
+    - User
+    - UserID
+    - UtcTime
+    - Version
+    - host
+    - id
+    - index
+    - source
+    - sourcetype
+    - splunk_server
+    - tag
+    - tag::eventtype
+output_fields:
+    - action
+    - dest
+    - dvc
+    - dvc_nt_host
+    - event_id
+    - eventtype
+    - linecount
+    - os
+    - process_exec
+    - process_guid
+    - process_hash
+    - process_id
+    - process_name
+    - process_path
+    - punct
+    - severity
+    - severity_id
+    - signature
+    - signature_id
+    - splunk_server
+    - src_host
+    - user
+    - user_id
+    - vendor_product
+example_log: <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>24</EventID><Version>5</Version><Level>4</Level><Task>24</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2026-09-07T14:37:29.0002181Z'/><EventRecordID>274447</EventRecordID><Correlation/><Execution ProcessID='3400' ThreadID='4440'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>EC2AMAZ-FKEOM7G</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>-</Data><Data Name='UtcTime'>2026-09-07 14:37:28.999</Data><Data Name='ProcessGuid'>{1b43529b-bf4f-6a9e-e4eb-020000006600}</Data><Data Name='ProcessId'>8988</Data><Data Name='Image'>C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe</Data><Data Name='Session'>2</Data><Data Name='ClientInfo'>user: EC2AMAZ-FKEOM7G\Administrator hostname: OERDOGAN-M-7N5Y</Data><Data Name='Hashes'>MD5=F2CD63BD7E2B5F9B738F589AF3BB1F8F,SHA256=397EE4CA855D96072D57E89ABFCA9F83634DAEA133E5302CB0766E87FDC3FEFC,IMPHASH=00000000000000000000000000000000</Data><Data Name='Archived'>false - failed with error 1337</Data><Data Name='User'>EC2AMAZ-FKEOM7G\Administrator</Data></EventData></Event>

--- a/detections/endpoint/windows_content_copied_from_browser_was_executed.yml
+++ b/detections/endpoint/windows_content_copied_from_browser_was_executed.yml
@@ -15,7 +15,7 @@ data_source:
 search: |-
     `sysmon`
     EventID IN (13, 24)
-    ( 
+    (
         registry_key_name=*RunMRU*
         OR
         process_name IN (

--- a/detections/endpoint/windows_content_copied_from_browser_was_executed.yml
+++ b/detections/endpoint/windows_content_copied_from_browser_was_executed.yml
@@ -13,7 +13,7 @@ description: |-
 data_source:
     - Sysmon EventID 13 AND Sysmon EventID 24
 search: |-
-    `sysmon` 
+    `sysmon`
     (
       (EventID=13 registry_key_name=*RunMRU*) OR
       (EventID=24 process_name IN (
@@ -46,7 +46,7 @@ how_to_implement: |-
     and clipboard change (Event ID 24) events. Ensure that registry modification events are collected for the RunMRU registry key
     and clipboard change events are collected from common browser processes. Ingest the data through the appropriate Splunk technology
     add-on and normalize field names using the Splunk Common Information Model (CIM).
-known_false_positives: No false positives were known for this detection.
+known_false_positives: No false positives have been identified at this time.
 references:
     - https://socradar.io/blog/doublecup-clickfix-loader-devicemanager-rats/
     - https://www.huntress.com/blog/clickfix-matanbuchus-astarionrat-analysis
@@ -59,21 +59,17 @@ drilldown_searches:
       search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
       earliest_offset: 7d
       latest_offset: "0"
-intermediate_findings:
-    entities:
-        - field: dest
-          type: system
-          score: 40
-          message: Content $process$ was copied from $process_name$ and was executed through the Run dialog box on $dest$
-        - field: user
-          type: user
-          score: 40
-          message: Content $process$ was copied from $process_name$ and was executed through the Run dialog box by $user$
+finding:
+    title: The content [$process$] was copied from [$process_name$] to the clipboard and was executed through the Run dialog box on [$dest$]
+    entity:
+        field: dest
+        type: system
+        score: 50
 threat_objects:
     - field: process
       type: process
     - field: hash_command
-      type: hash
+      type: process_hash
 analytic_story:
     - Fake CAPTCHA Campaigns
 asset_type: Endpoint
@@ -90,7 +86,7 @@ security_domain: endpoint
 tests:
     - name: True Positive Test
       attack_data:
-        - data: https://media.githubusercontent.com/media/splunk/attack_data/refs/heads/master/datasets/attack_techniques/T1202/windows_browser_copy_paste/windows_browser_copy_paste.log
+        - data: https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1202/windows_browser_copy_paste/windows_browser_copy_paste.log
           source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
           sourcetype: XmlWinEventLog
       test_type: unit

--- a/detections/endpoint/windows_content_copied_from_browser_was_executed.yml
+++ b/detections/endpoint/windows_content_copied_from_browser_was_executed.yml
@@ -1,0 +1,96 @@
+name: Windows Content Copied from Browser was Executed
+id: 5d1fdbcb-5ed9-4190-85c8-7f9026450a0b
+version: 1
+creation_date: '2026-09-07'
+modification_date: '2026-09-07'
+author: Onur Mustafa Erdogan, Splunk
+status: production
+type: TTP
+description: |-
+    The following analytic correlates modifications to the Windows RunMRU registry key with clipboard content
+    changes initiated by browsers. It aims to detect ClickFix scenarios in which commands copied
+    from a browser are subsequently executed on the Windows system through the Run dialog box.
+data_source:
+    - Sysmon EventID 13 AND Sysmon EventID 24
+search: |-
+    `sysmon` 
+    (
+      (EventID=13 registry_key_name=*RunMRU*) OR
+      (EventID=24 process_name IN (
+        "360se.exe", "arc.exe", "atlas.exe", "avastbrowser.exe", "avgbrowser.exe", "blpbrowser.exe", "brave.exe", "braveupdate.exe",
+        "chrome.exe", "chromium.exe", "coccoc.exe", "dragon.exe", "duckduckgo.exe", "epic.exe", "firefox.exe", "ghost.exe",
+        "iexplore.exe", "iridium.exe", "iron.exe", "maxthon.exe", "microsoftedge.exe", "microsoftedgeupdate.exe", "msedge.exe",
+        "msedgewebview2.exe", "opera.exe", "opera_autoupdate.exe", "perplexity.exe", "rave.exe", "safari.exe", "shift.exe",
+        "sidekick.exe", "thorium.exe", "torch.exe", "vivaldi.exe", "wavebrowser.exe", "whale.exe", "zen.exe"
+        )
+      )
+    )
+    | eval trimmed_command = rtrim(registry_value_data, "\1")
+    | eval utf16le_command = urldecode(replace(trimmed_command, "(.)", "\1%00"))
+    | eval sha256_process=upper(sha256(utf16le_command))
+    | eval hash_command=coalesce(SHA256,sha256_process)
+    | stats min(_time) as firstTime max(_time) as lastTime values(process_name) as process_name
+    values(trimmed_command) as process values(EventID) as EventID dc(EventID) as dc_EventID count
+    by hash_command dest user
+    | search dc_EventID>1
+    | eval process_name = mvfilter(process_name IN ("360se.exe", "arc.exe", "atlas.exe", "avastbrowser.exe", "avgbrowser.exe", "blpbrowser.exe", "brave.exe", "braveupdate.exe",
+        "chrome.exe", "chromium.exe", "coccoc.exe", "dragon.exe", "duckduckgo.exe", "epic.exe", "firefox.exe", "ghost.exe",
+        "iexplore.exe", "iridium.exe", "iron.exe", "maxthon.exe", "microsoftedge.exe", "microsoftedgeupdate.exe", "msedge.exe",
+        "msedgewebview2.exe", "opera.exe", "opera_autoupdate.exe", "perplexity.exe", "rave.exe", "safari.exe", "shift.exe",
+        "sidekick.exe", "thorium.exe", "torch.exe", "vivaldi.exe", "wavebrowser.exe", "whale.exe", "zen.exe"))
+    | `security_content_ctime(firstTime)`
+    | `security_content_ctime(lastTime)`
+    | `windows_content_copied_from_browser_was_executed_filter`'
+how_to_implement: |-
+    This detection requires Sysmon event logs. Configure your environment to ingest Sysmon registry modification (Event ID 13)
+    and clipboard change (Event ID 24) events. Ensure that registry modification events are collected for the RunMRU registry key
+    and clipboard change events are collected from common browser processes. Ingest the data through the appropriate Splunk technology
+    add-on and normalize field names using the Splunk Common Information Model (CIM).
+known_false_positives: No false positives were known for this detection.
+references:
+    - https://socradar.io/blog/doublecup-clickfix-loader-devicemanager-rats/
+    - https://www.huntress.com/blog/clickfix-matanbuchus-astarionrat-analysis
+drilldown_searches:
+    - name: View the detection results for - "$dest$"
+      search: '%original_detection_search% | search  dest = "$dest$"'
+      earliest_offset: $info_min_time$
+      latest_offset: $info_max_time$
+    - name: View risk events for the last 7 days for - "$dest$"
+      search: '| from datamodel Risk.All_Risk | search normalized_risk_object IN ("$dest$") | stats count min(_time) as firstTime max(_time) as lastTime values(search_name) as "Search Name" values(risk_message) as "Risk Message" values(analyticstories) as "Analytic Stories" values(annotations._all) as "Annotations" values(annotations.mitre_attack.mitre_tactic) as "ATT&CK Tactics" by normalized_risk_object | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`'
+      earliest_offset: 7d
+      latest_offset: "0"
+intermediate_findings:
+    entities:
+        - field: dest
+          type: system
+          score: 40
+          message: Content $process$ was copied from $process_name$ and was executed through the Run dialog box on $dest$
+        - field: user
+          type: user
+          score: 40
+          message: Content $process$ was copied from $process_name$ and was executed through the Run dialog box by $user$
+threat_objects:
+    - field: process
+      type: process
+    - field: hash_command
+      type: hash
+analytic_story:
+    - Fake CAPTCHA Campaigns
+asset_type: Endpoint
+mitre_attack_id:
+    - T1202
+    - T1059.001
+    - T1059.003
+product:
+    - Splunk Enterprise
+    - Splunk Enterprise Security
+    - Splunk Cloud
+category: endpoint
+security_domain: endpoint
+tests:
+    - name: True Positive Test
+      attack_data:
+        - data: https://media.githubusercontent.com/media/splunk/attack_data/refs/heads/master/datasets/attack_techniques/T1202/windows_browser_copy_paste/windows_browser_copy_paste.log
+          source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+          sourcetype: XmlWinEventLog
+      test_type: unit

--- a/detections/endpoint/windows_content_copied_from_browser_was_executed.yml
+++ b/detections/endpoint/windows_content_copied_from_browser_was_executed.yml
@@ -14,9 +14,28 @@ data_source:
     - Sysmon EventID 13 AND Sysmon EventID 24
 search: |-
     `sysmon`
-    (
-      (EventID=13 registry_key_name=*RunMRU*) OR
-      (EventID=24 process_name IN (
+    EventID IN (13, 24)
+    ( 
+        registry_key_name=*RunMRU*
+        OR
+        process_name IN (
+        "360se.exe", "arc.exe", "atlas.exe", "avastbrowser.exe", "avgbrowser.exe", "blpbrowser.exe", "brave.exe", "braveupdate.exe",
+        "chrome.exe", "chromium.exe", "coccoc.exe", "dragon.exe", "duckduckgo.exe", "epic.exe", "firefox.exe", "ghost.exe",
+        "iexplore.exe", "iridium.exe", "iron.exe", "maxthon.exe", "microsoftedge.exe", "microsoftedgeupdate.exe", "msedge.exe",
+        "msedgewebview2.exe", "opera.exe", "opera_autoupdate.exe", "perplexity.exe", "rave.exe", "safari.exe", "shift.exe",
+        "sidekick.exe", "thorium.exe", "torch.exe", "vivaldi.exe", "wavebrowser.exe", "whale.exe", "zen.exe"
+        )
+    )
+    | eval trimmed_command = rtrim(registry_value_data, "\1")
+    | eval utf16le_command = urldecode(replace(trimmed_command, "(.)", "\1%00"))
+    | eval sha256_process=upper(sha256(utf16le_command))
+    | eval hash_command=coalesce(SHA256,sha256_process)
+    | stats min(_time) as firstTime max(_time) as lastTime values(process_name) as process_name
+        values(trimmed_command) as process values(EventID) as EventID dc(EventID) as dc_EventID count
+        by hash_command dest user
+    | search dc_EventID>1
+    | eval process_name = mvfilter(
+        process_name IN (
         "360se.exe", "arc.exe", "atlas.exe", "avastbrowser.exe", "avgbrowser.exe", "blpbrowser.exe", "brave.exe", "braveupdate.exe",
         "chrome.exe", "chromium.exe", "coccoc.exe", "dragon.exe", "duckduckgo.exe", "epic.exe", "firefox.exe", "ghost.exe",
         "iexplore.exe", "iridium.exe", "iron.exe", "maxthon.exe", "microsoftedge.exe", "microsoftedgeupdate.exe", "msedge.exe",
@@ -24,23 +43,9 @@ search: |-
         "sidekick.exe", "thorium.exe", "torch.exe", "vivaldi.exe", "wavebrowser.exe", "whale.exe", "zen.exe"
         )
       )
-    )
-    | eval trimmed_command = rtrim(registry_value_data, "\1")
-    | eval utf16le_command = urldecode(replace(trimmed_command, "(.)", "\1%00"))
-    | eval sha256_process=upper(sha256(utf16le_command))
-    | eval hash_command=coalesce(SHA256,sha256_process)
-    | stats min(_time) as firstTime max(_time) as lastTime values(process_name) as process_name
-    values(trimmed_command) as process values(EventID) as EventID dc(EventID) as dc_EventID count
-    by hash_command dest user
-    | search dc_EventID>1
-    | eval process_name = mvfilter(process_name IN ("360se.exe", "arc.exe", "atlas.exe", "avastbrowser.exe", "avgbrowser.exe", "blpbrowser.exe", "brave.exe", "braveupdate.exe",
-        "chrome.exe", "chromium.exe", "coccoc.exe", "dragon.exe", "duckduckgo.exe", "epic.exe", "firefox.exe", "ghost.exe",
-        "iexplore.exe", "iridium.exe", "iron.exe", "maxthon.exe", "microsoftedge.exe", "microsoftedgeupdate.exe", "msedge.exe",
-        "msedgewebview2.exe", "opera.exe", "opera_autoupdate.exe", "perplexity.exe", "rave.exe", "safari.exe", "shift.exe",
-        "sidekick.exe", "thorium.exe", "torch.exe", "vivaldi.exe", "wavebrowser.exe", "whale.exe", "zen.exe"))
     | `security_content_ctime(firstTime)`
     | `security_content_ctime(lastTime)`
-    | `windows_content_copied_from_browser_was_executed_filter`'
+    | `windows_content_copied_from_browser_was_executed_filter`
 how_to_implement: |-
     This detection requires Sysmon event logs. Configure your environment to ingest Sysmon registry modification (Event ID 13)
     and clipboard change (Event ID 24) events. Ensure that registry modification events are collected for the RunMRU registry key


### PR DESCRIPTION
### Details

This detection correlates RunMRU registry modification and clipboard change from browsers. Correlation is done through the hash of the content that was copied to clipboard.

These activities combined, gives a solid base for detecting ClickFix attacks. Adversaries either asks users to manually copy or use Javascript to modify the clipboard by themselves. It first triggers the clipboard change event by the browser process. Once victim executes the copied content through Run dialog box, it triggers the modification of the RunMRU registry key.

Sysmon calculates the content hash based on UTF-16 LE encoding. Therefore RunMRU value is trimmed of its suffix and converted to UTF-16 LE, before its hash was calculated. I've also added missing Sysmon EID 24 to the repository.
